### PR TITLE
Ajustando imports

### DIFF
--- a/maria_cacau/__main__.py
+++ b/maria_cacau/__main__.py
@@ -2,11 +2,12 @@
 
 # -*- coding: utf-8 -*-
 
-from maria_cacau.features.home.home_view import Gui_main
-
 import sys
-from PyQt6.QtWidgets import QApplication
+
 from PyQt6.QtCore import Qt
+from PyQt6.QtWidgets import QApplication
+
+from maria_cacau.features.home.home_view import Gui_main
 
 
 def main():

--- a/maria_cacau/core/analisePlan.py
+++ b/maria_cacau/core/analisePlan.py
@@ -8,12 +8,13 @@
 # que serão usadas, mas não pe feita nenhuma anáise. Além disso é feito os tratamento de
 # erros, sendo cada erro identificado com um código.
 
+from pandas import read_excel
 ## Bibliotecas necessárias:
 from pandas.core.frame import DataFrame
-from pandas import read_excel
 
-from maria_cacau.design_system.gui_popup import Gui_popup
 from maria_cacau.core import errors
+from maria_cacau.design_system.gui_popup import Gui_popup
+
 
 class Analise:
     def __init__(self) -> None:

--- a/maria_cacau/core/analisePlan.py
+++ b/maria_cacau/core/analisePlan.py
@@ -9,7 +9,6 @@
 # erros, sendo cada erro identificado com um código.
 
 from pandas import read_excel
-## Bibliotecas necessárias:
 from pandas.core.frame import DataFrame
 
 from maria_cacau.core import errors

--- a/maria_cacau/design_system/aux_frames.py
+++ b/maria_cacau/design_system/aux_frames.py
@@ -8,10 +8,10 @@
 # usadas várias vezes dentro dá área de "Notas SAGE" e "Melhor Envio"
 
 
+from PyQt6.QtWidgets import QFrame, QHBoxLayout
+
 ## Bibliotecas necessárias:
 from maria_cacau.design_system.aux_widgets import AuxWidgets
-
-from PyQt6.QtWidgets import QFrame, QHBoxLayout
 
 
 class AuxFrame(QFrame, AuxWidgets):

--- a/maria_cacau/design_system/aux_widgets.py
+++ b/maria_cacau/design_system/aux_widgets.py
@@ -10,11 +10,12 @@
 #    Por ser usados mais de uma vez passa a ser mais otimizado dessa forma.
 
 
+from PyQt6.QtCore import Qt
+from PyQt6.QtGui import QFont
 ## Bibliotecas necessárias:
 # GUI:
-from PyQt6.QtWidgets import QLabel, QPushButton, QGroupBox, QLineEdit, QTextBrowser, QGraphicsView, QWidget, QComboBox
-from PyQt6.QtGui import QFont
-from PyQt6.QtCore import Qt
+from PyQt6.QtWidgets import (QComboBox, QGraphicsView, QGroupBox, QLabel,
+                             QLineEdit, QPushButton, QTextBrowser, QWidget)
 
 
 class AuxWidgets:

--- a/maria_cacau/design_system/aux_widgets.py
+++ b/maria_cacau/design_system/aux_widgets.py
@@ -12,10 +12,8 @@
 
 from PyQt6.QtCore import Qt
 from PyQt6.QtGui import QFont
-## Bibliotecas necessárias:
-# GUI:
 from PyQt6.QtWidgets import (QComboBox, QGraphicsView, QGroupBox, QLabel,
-                             QLineEdit, QPushButton, QTextBrowser, QWidget)
+                             QLineEdit, QPushButton, QTextBrowser)
 
 
 class AuxWidgets:

--- a/maria_cacau/design_system/gui_popup.py
+++ b/maria_cacau/design_system/gui_popup.py
@@ -11,7 +11,6 @@
 from PyQt6.QtGui import QFont, QIcon
 from PyQt6.QtWidgets import QMessageBox
 
-## Bibliotecas necessárias:
 from maria_cacau.core.errors import AppError
 
 

--- a/maria_cacau/design_system/gui_popup.py
+++ b/maria_cacau/design_system/gui_popup.py
@@ -8,11 +8,11 @@
 # não é salva. Aqui é gerado e feito toda a configuração dela.
 
 
+from PyQt6.QtGui import QFont, QIcon
+from PyQt6.QtWidgets import QMessageBox
+
 ## Bibliotecas necessárias:
 from maria_cacau.core.errors import AppError
-
-from PyQt6.QtWidgets import QMessageBox
-from PyQt6.QtGui import QIcon, QFont
 
 
 class Gui_popup(QMessageBox):

--- a/maria_cacau/features/home/home_view.py
+++ b/maria_cacau/features/home/home_view.py
@@ -5,18 +5,25 @@
 ## Classe responsável pela criação da janela principal
 
 
-## Bibliotecas necessárias:
-from maria_cacau.features.home.sub_features.products_resume.products_resume_view import Gui_Produtos
-from maria_cacau.features.home.sub_features.orders_pendent.orders_pendent_view import Gui_Entregas
-from maria_cacau.features.home.sub_features.nota_fiscal.nota_fiscal_view import Gui_Dados
-from maria_cacau.features.home.sub_features.cpf_validation.cpf_validation_view import Gui_ValiCpf
-from maria_cacau.features.home.sub_features.freight_query.freight_query_view import Gui_ConsFrete
-from maria_cacau.core.analisePlan import Analise
-from maria_cacau.assets import strings
-
-from PyQt6.QtWidgets import QMainWindow, QWidget, QMenuBar, QMenu, QFileDialog, QApplication, QHBoxLayout, QVBoxLayout
-from PyQt6.QtGui import QIcon, QAction, QPixmap, QPainter
 from PyQt6.QtCore import Qt
+from PyQt6.QtGui import QAction, QIcon, QPainter, QPixmap
+from PyQt6.QtWidgets import (QApplication, QFileDialog, QHBoxLayout,
+                             QMainWindow, QMenu, QMenuBar, QVBoxLayout,
+                             QWidget)
+
+from maria_cacau.assets import strings
+from maria_cacau.core.analisePlan import Analise
+from maria_cacau.features.home.sub_features.cpf_validation.cpf_validation_view import \
+    Gui_ValiCpf
+from maria_cacau.features.home.sub_features.freight_query.freight_query_view import \
+    Gui_ConsFrete
+from maria_cacau.features.home.sub_features.nota_fiscal.nota_fiscal_view import \
+    Gui_Dados
+from maria_cacau.features.home.sub_features.orders_pendent.orders_pendent_view import \
+    Gui_Entregas
+## Bibliotecas necessárias:
+from maria_cacau.features.home.sub_features.products_resume.products_resume_view import \
+    Gui_Produtos
 
 
 class _BackgroundWidget(QWidget):

--- a/maria_cacau/features/home/home_view.py
+++ b/maria_cacau/features/home/home_view.py
@@ -4,8 +4,6 @@
 
 ## Classe responsável pela criação da janela principal
 
-
-from PyQt6.QtCore import Qt
 from PyQt6.QtGui import QAction, QIcon, QPainter, QPixmap
 from PyQt6.QtWidgets import (QApplication, QFileDialog, QHBoxLayout,
                              QMainWindow, QMenu, QMenuBar, QVBoxLayout,
@@ -21,7 +19,6 @@ from maria_cacau.features.home.sub_features.nota_fiscal.nota_fiscal_view import 
     Gui_Dados
 from maria_cacau.features.home.sub_features.orders_pendent.orders_pendent_view import \
     Gui_Entregas
-## Bibliotecas necessárias:
 from maria_cacau.features.home.sub_features.products_resume.products_resume_view import \
     Gui_Produtos
 

--- a/maria_cacau/features/home/sub_features/cpf_validation/cpf_validation_view.py
+++ b/maria_cacau/features/home/sub_features/cpf_validation/cpf_validation_view.py
@@ -8,12 +8,12 @@
 # também o calculo para a vaidação do CPF.
 
 
+from PyQt6.QtCore import Qt
+from PyQt6.QtWidgets import QWidget
+
+from maria_cacau.assets import strings
 ## Bibliotecas necessárias:
 from maria_cacau.design_system.aux_widgets import AuxWidgets
-from maria_cacau.assets import strings
-
-from PyQt6.QtWidgets import QWidget
-from PyQt6.QtCore import Qt
 
 
 class Gui_ValiCpf(AuxWidgets):
@@ -33,7 +33,7 @@ class Gui_ValiCpf(AuxWidgets):
 
     ## Método: cria e configura a janela
     def gui_Ui(self) -> None:
-        from PyQt6.QtWidgets import QVBoxLayout, QHBoxLayout
+        from PyQt6.QtWidgets import QHBoxLayout, QVBoxLayout
         layout = QVBoxLayout(self.root)
 
         inputLayout = QHBoxLayout()

--- a/maria_cacau/features/home/sub_features/cpf_validation/cpf_validation_view.py
+++ b/maria_cacau/features/home/sub_features/cpf_validation/cpf_validation_view.py
@@ -7,12 +7,9 @@
 #    Aqui é onde é feito a construção da Interface Gráfica da área e
 # também o calculo para a vaidação do CPF.
 
-
 from PyQt6.QtCore import Qt
-from PyQt6.QtWidgets import QWidget
 
 from maria_cacau.assets import strings
-## Bibliotecas necessárias:
 from maria_cacau.design_system.aux_widgets import AuxWidgets
 
 

--- a/maria_cacau/features/home/sub_features/freight_query/freight_query_view.py
+++ b/maria_cacau/features/home/sub_features/freight_query/freight_query_view.py
@@ -10,7 +10,6 @@
 
 from PyQt6.QtWidgets import QHBoxLayout, QVBoxLayout
 
-## Bibliotecas necessárias:
 from maria_cacau.design_system.aux_widgets import AuxWidgets
 
 

--- a/maria_cacau/features/home/sub_features/freight_query/freight_query_view.py
+++ b/maria_cacau/features/home/sub_features/freight_query/freight_query_view.py
@@ -8,10 +8,10 @@
 # a parte lógica.
 
 
+from PyQt6.QtWidgets import QHBoxLayout, QVBoxLayout
+
 ## Bibliotecas necessárias:
 from maria_cacau.design_system.aux_widgets import AuxWidgets
-
-from PyQt6.QtWidgets import QVBoxLayout, QHBoxLayout
 
 
 class Gui_ConsFrete(AuxWidgets):

--- a/maria_cacau/features/home/sub_features/nota_fiscal/nota_fiscal_view.py
+++ b/maria_cacau/features/home/sub_features/nota_fiscal/nota_fiscal_view.py
@@ -8,14 +8,13 @@
 # a análise e filtragem feita dentro da planilha.
 
 
+from pandas.core.frame import DataFrame
+from PyQt6.QtCore import Qt
+from PyQt6.QtWidgets import QHBoxLayout, QTabWidget, QVBoxLayout, QWidget
+
+from maria_cacau.design_system.aux_frames import AuxFrame
 ## Bibliotecas necessárias:
 from maria_cacau.design_system.aux_widgets import AuxWidgets
-from maria_cacau.design_system.aux_frames import AuxFrame
-
-from pandas.core.frame import DataFrame
-
-from PyQt6.QtWidgets import QWidget, QTabWidget, QVBoxLayout, QHBoxLayout
-from PyQt6.QtCore import Qt
 
 
 class Gui_Dados(AuxWidgets):

--- a/maria_cacau/features/home/sub_features/nota_fiscal/nota_fiscal_view.py
+++ b/maria_cacau/features/home/sub_features/nota_fiscal/nota_fiscal_view.py
@@ -13,7 +13,6 @@ from PyQt6.QtCore import Qt
 from PyQt6.QtWidgets import QHBoxLayout, QTabWidget, QVBoxLayout, QWidget
 
 from maria_cacau.design_system.aux_frames import AuxFrame
-## Bibliotecas necessárias:
 from maria_cacau.design_system.aux_widgets import AuxWidgets
 
 

--- a/maria_cacau/features/home/sub_features/orders_pendent/orders_pendent_view.py
+++ b/maria_cacau/features/home/sub_features/orders_pendent/orders_pendent_view.py
@@ -7,14 +7,12 @@
 #    Essa classe é responsável pela interface gráfica + toda
 # a parte lógica.
 
-
 from pandas.core.frame import DataFrame
 from pandas.core.series import Series
 from PyQt6.QtWidgets import QHBoxLayout, QVBoxLayout
 
 from maria_cacau.assets import strings
 from maria_cacau.core import errors
-## Bibliotecas necessárias:
 from maria_cacau.design_system.aux_widgets import AuxWidgets
 from maria_cacau.design_system.gui_popup import Gui_popup
 

--- a/maria_cacau/features/home/sub_features/orders_pendent/orders_pendent_view.py
+++ b/maria_cacau/features/home/sub_features/orders_pendent/orders_pendent_view.py
@@ -8,16 +8,15 @@
 # a parte lógica.
 
 
+from pandas.core.frame import DataFrame
+from pandas.core.series import Series
+from PyQt6.QtWidgets import QHBoxLayout, QVBoxLayout
+
+from maria_cacau.assets import strings
+from maria_cacau.core import errors
 ## Bibliotecas necessárias:
 from maria_cacau.design_system.aux_widgets import AuxWidgets
 from maria_cacau.design_system.gui_popup import Gui_popup
-from maria_cacau.assets import strings
-from maria_cacau.core import errors
-
-from PyQt6.QtWidgets import QVBoxLayout, QHBoxLayout
-
-from pandas.core.frame import DataFrame
-from pandas.core.series import Series
 
 
 class Gui_Entregas(AuxWidgets):

--- a/maria_cacau/features/home/sub_features/products_resume/products_resume_view.py
+++ b/maria_cacau/features/home/sub_features/products_resume/products_resume_view.py
@@ -7,11 +7,11 @@
 
 ## Bibliotecas necessárias:
 from pandas.core.frame import DataFrame
-from maria_cacau.design_system.aux_widgets import AuxWidgets
-from maria_cacau.assets import strings
-
-from PyQt6.QtWidgets import QVBoxLayout, QHBoxLayout
 from PyQt6.QtGui import QFont
+from PyQt6.QtWidgets import QHBoxLayout, QVBoxLayout
+
+from maria_cacau.assets import strings
+from maria_cacau.design_system.aux_widgets import AuxWidgets
 
 
 class Gui_Produtos(AuxWidgets):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ maria-cacau = "maria_cacau.__main__:main"
 
 [project.optional-dependencies]
 build = ["nuitka"]
+dev   = ["isort"]
 
 [tool.setuptools.packages.find]
 where = ["."]


### PR DESCRIPTION
## Overview
De acordo com a [PEP 8](https://www.datacamp.com/tutorial/pep8-tutorial-python-code#:~:text=the%20given%20encoding.-,Imports,-Importing%20libraries%20and), o padrão de import em Python eh:

1. Biblioteca padrão
import json
from typing import Final

2. Terceiros (libs instaladas)
import gspread
import keyring
from google.oauth2.service_account import Credentials
from pandas import DataFrame

3. Locais (do próprio projeto)
from maria_cacau.x import y


## Novo framework
Foi adicionado o framework [isort](https://pycqa.github.io/isort/), que com o comando `isort maria_cacau/` automaticamente ajusta os imports dos arquivos.