### PR TITLE
Removendo arquivos da visualização do VSCode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@
 arquivos/zTestes/
 
 # Configuração do VSCode
-*.vscode/
+# *.vscode/
 
 # Arquivos da Interface Gráfica
 arquivos/gui

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,9 @@
+{
+    "files.exclude": {
+        "maria_cacau/{assets,core,design_system,features}/**/__init__.py": true,
+        "**/__pycache__": true,
+        "**/.DS_Store": true,
+        "**/venv": true,
+        "**.egg-info": true
+    }
+}


### PR DESCRIPTION
## Overview
Alguns arquivos ficam poluindo o VS Code, como por exemplo o `__init__.py` em todas as pastas. Ent ele e outros arquivos foram excluídos da visualização apenas.