### PR TITLE
Cacheando em memória as respostas do back

### DIFF
--- a/.ai/architecture.md
+++ b/.ai/architecture.md
@@ -297,8 +297,11 @@ clear_override()
 
 O padrão adotado em todas as features migradas é `ThreadPoolExecutor(max_workers=1)` no `ViewModel`. Operações com I/O (chamadas ao backend) rodam em background; o resultado volta para a main thread via `pyqtSignal`. Operações de cache local (leitura de JSON) são síncronas — sem thread.
 
-### "Limpar cache" no menu Arquivo
-Refere-se ao cache **em memória** dos repositories/services (dados carregados da planilha), não à pasta `~/.mariacacau/`. A action está presente no menu mas desabilitada — será implementada quando os repositories tiverem cache em memória explícito.
+### Cache em memória nos repositories
+
+`OrdersRepository` (delivery) e `SummaryRepository` (summary) armazenam os resultados das chamadas ao backend em dicts internos, com a chave sendo os parâmetros da request (`date` ou `(start, end)`). Na segunda consulta com os mesmos parâmetros, o dado é devolvido do cache sem bater na planilha.
+
+O cache é limpo pelo usuário via **Arquivo → Limpar cache**: a view emite `cache_clear_triggered`, o controller chama `bus.cache_cleared.emit()`, e cada repository — que subscreveu esse signal no `__init__` — limpa o seu dict interno. O evento `CACHE_CLEAR` é logado na observabilidade. Cache hits também geram log via `FeatureEvents.CACHE_HIT` de cada feature.
 
 ## Status bar (`GuiStatusBar`)
 Barra fixa na base da janela com três estados de cor:
@@ -329,7 +332,7 @@ Módulo `maria_cacau/core/observability.py` — singleton `observability` com en
 | `SHEET_SELECT` | `name=`, `sheet_id=` | Planilha existente selecionada |
 | `BTN_COPY` | `feature=` | Botão Copiar clicado (entregas ou produtos) |
 | `PREWARM_DONE` | `duration_s=` | Pré-aquecimento OAuth + TLS concluído |
-| `CACHE_CLEAR` | — | Cache da planilha limpo pelo usuário |
+| `CACHE_CLEAR` | — | Cache em memória limpo pelo usuário (Arquivo → Limpar cache) |
 | `ERROR` | `msg=`, `where=` (opcional), `duration_s=` (opcional) | Qualquer exceção capturada |
 
 Saída: `~/.mariacacau/logs.log` (append-only, formato `YYYY-MM-DD HH:MM:SS  LEVEL  mensagem`).

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,12 +1,12 @@
 # Graph Report - Maria-Cacau-Contagem  (2026-05-19)
 
 ## Corpus Check
-- 159 files · ~609,798 words
+- 159 files · ~609,927 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 928 nodes · 1900 edges · 69 communities detected
-- Extraction: 55% EXTRACTED · 45% INFERRED · 0% AMBIGUOUS · INFERRED: 858 edges (avg confidence: 0.61)
+- 933 nodes · 1915 edges · 68 communities detected
+- Extraction: 55% EXTRACTED · 45% INFERRED · 0% AMBIGUOUS · INFERRED: 869 edges (avg confidence: 0.61)
 - Token cost: 0 input · 0 output
 
 ## Community Hubs (Navigation)
@@ -28,11 +28,11 @@
 - [[_COMMUNITY_Community 15|Community 15]]
 - [[_COMMUNITY_Community 16|Community 16]]
 - [[_COMMUNITY_Community 17|Community 17]]
-- [[_COMMUNITY_Community 18|Community 18]]
+- [[_COMMUNITY_Community 35|Community 35]]
 - [[_COMMUNITY_Community 36|Community 36]]
-- [[_COMMUNITY_Community 37|Community 37]]
+- [[_COMMUNITY_Community 38|Community 38]]
 - [[_COMMUNITY_Community 39|Community 39]]
-- [[_COMMUNITY_Community 40|Community 40]]
+- [[_COMMUNITY_Community 43|Community 43]]
 - [[_COMMUNITY_Community 44|Community 44]]
 - [[_COMMUNITY_Community 45|Community 45]]
 - [[_COMMUNITY_Community 46|Community 46]]
@@ -78,7 +78,6 @@
 - [[_COMMUNITY_Community 86|Community 86]]
 - [[_COMMUNITY_Community 87|Community 87]]
 - [[_COMMUNITY_Community 88|Community 88]]
-- [[_COMMUNITY_Community 89|Community 89]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `SecurityStorage` - 41 edges
@@ -90,157 +89,157 @@
 7. `DeliveryView` - 21 edges
 8. `DataSourceError` - 21 edges
 9. `SummaryView` - 20 edges
-10. `ChartType` - 19 edges
+10. `connect()` - 20 edges
 
 ## Surprising Connections (you probably didn't know these)
-- `StorageHandler` --uses--> `Backend de cache em arquivo JSON no diretório do usuário.`  [INFERRED]
-  maria_cacau/core/storage/handler.py → core/storage/cache.py
+- `Frame composto reutilizável com label, entrada de texto e botão de cópia.` --uses--> `AuxWidgets`  [INFERRED]
+  design_system/aux_frames.py → maria_cacau/design_system/aux_widgets.py
 - `AuxWidgets` --uses--> `Área de validação de CPF: interface gráfica e lógica de verificação.`  [INFERRED]
   maria_cacau/design_system/aux_widgets.py → features/home/sub_features/cpf_validation/cpf_validation_view.py
 - `Entry point da aplicação. Execute com: python -m maria_cacau` --uses--> `BackendServer`  [INFERRED]
   __main__.py → maria_cacau/backend/_server.py
-- `AppEvent` --uses--> `Janela principal da aplicação e orquestração das sub-features.`  [INFERRED]
-  maria_cacau/core/observability.py → features/home/home_view.py
 - `AppEvent` --uses--> `Autenticação e acesso ao Google Sheets.`  [INFERRED]
+  maria_cacau/core/observability.py → core/sheets/service.py
+- `AppEvent` --uses--> `Tenta autenticar usando credenciais salvas. Retorna False se não houver.`  [INFERRED]
   maria_cacau/core/observability.py → core/sheets/service.py
 
 ## Communities
 
 ### Community 0 - "Community 0"
 Cohesion: 0.04
-Nodes (44): connect(), AuxWidgets, ChartType, ChartWidget, Widget de gráfico reutilizável (barras ou pizza) usando seaborn + matplotlib., Retorna (w, h) para o canvas.         h = altura do viewport (sem desperdício/ov, _short_label(), AuxFrame (+36 more)
+Nodes (59): GoogleSheetsDataSource, Implementação de DataSourceProtocol para Google Sheets via gspread., Implementação de DataSourceProtocol para Google Sheets via gspread., _fix_prod4(), normalize(), Normaliza headers inconsistentes da planilha para os valores canônicos dos enums, Renomeia a coluna que segue prod3 para prod4, independente do header atual., Traduz headers reais da planilha para os nomes canônicos definidos nos enums. (+51 more)
 
 ### Community 1 - "Community 1"
-Cohesion: 0.04
-Nodes (59): GoogleSheetsDataSource, Implementação de DataSourceProtocol para Google Sheets via gspread., Implementação de DataSourceProtocol para Google Sheets via gspread., _fix_prod4(), normalize(), Normaliza headers inconsistentes da planilha para os valores canônicos dos enums, Renomeia a coluna que segue prod3 para prod4, independente do header atual., Traduz headers reais da planilha para os nomes canônicos definidos nos enums. (+51 more)
+Cohesion: 0.05
+Nodes (35): ChartType, ChartWidget, Widget de gráfico reutilizável (barras ou pizza) usando seaborn + matplotlib., Retorna (w, h) para o canvas.         h = altura do viewport (sem desperdício/ov, _short_label(), AuxWidgets, Factory de widgets PyQt6 reutilizáveis em toda a interface., GuiPopup (+27 more)
 
 ### Community 2 - "Community 2"
 Cohesion: 0.06
-Nodes (46): AppCoordinator, BackendServer, main(), Entry point da aplicação. Execute com: python -m maria_cacau, API, entity(), Comunicação alto nivel para chamadas de api, O tipo precisa aceitar **kwargs (dataclass ou similar). (+38 more)
+Nodes (39): API, DeliveriesAPI, OrdersSummaryAPI, path(), PaymentsPendentAPI, Definição dos endpoints do backend consumidos pela feature Delivery., DeliveriesMapper, ErrorMapper (+31 more)
 
 ### Community 3 - "Community 3"
-Cohesion: 0.08
-Nodes (34): API, ConnectAuthAPI, DeliveriesAPI, DisconnectAuthAPI, OrdersSummaryAPI, path(), PaymentsPendentAPI, Definição dos endpoints do backend consumidos pela feature Delivery. (+26 more)
+Cohesion: 0.04
+Nodes (43): ABC, AppEvent, Área de validação de CPF: interface gráfica e lógica de verificação., Janela principal da aplicação e orquestração das sub-features., # TODO: MIGRAR, # TODO: MIGRAR, # TODO: MIGRAR, QStatusBar (+35 more)
 
 ### Community 4 - "Community 4"
-Cohesion: 0.06
-Nodes (25): _EventBus, AppSession, CpfValidationResult, DaySummary, ProductsSummary, ProductsViewData, Models utilizados no módulo, CpfValidationSignals (+17 more)
+Cohesion: 0.05
+Nodes (16): AppCoordinator, MenuHandler, MainWindow, connect(), BackendServer, Erro genérico para exceções não tratadas., unexpected_error(), main() (+8 more)
 
 ### Community 5 - "Community 5"
-Cohesion: 0.08
-Nodes (12): DeliveryModel, DeliveryViewData, DeliveryUseCase, Busca deliveries e payments em paralelo e retorna o modelo consolidado., DeliveryController, Inicia a consulta: trava a view, dispara o ViewModel e registra o timestamp para, Recebe o resultado do ViewModel, atualiza a view e loga a duração da consulta., SummaryController (+4 more)
+Cohesion: 0.05
+Nodes (16): AuxWidgets, AuxFrame, Frame composto reutilizável com label, entrada de texto e botão de cópia., _date_field(), DateRangePicker, POC — date picker moderno com QDateEdit + QSS., NotaFiscalController, NotaFiscalView (+8 more)
 
 ### Community 6 - "Community 6"
-Cohesion: 0.06
-Nodes (36): ABC, AppEvent, _Observability, Observabilidade centralizada do app., Área de validação de CPF: interface gráfica e lógica de verificação., Autenticação e acesso ao Google Sheets., Retorna True se uma planilha foi vinculada., Define qual planilha vai ser lida pelo ID ou URL do Google Sheets. (+28 more)
+Cohesion: 0.07
+Nodes (42): API, entity(), Comunicação alto nivel para chamadas de api, O tipo precisa aceitar **kwargs (dataclass ou similar)., O tipo precisa aceitar **kwargs (dataclass ou similar)., O tipo precisa aceitar **kwargs (dataclass ou similar)., HTTPClientContract, LocalClient (+34 more)
 
 ### Community 7 - "Community 7"
-Cohesion: 0.07
-Nodes (7): SheetsUseCase, SheetsController, SheetsViewModel, QDialog, QMenu, SheetCreateView, SheetsMenuView
+Cohesion: 0.08
+Nodes (17): ConnectAuthAPI, DisconnectAuthAPI, RemoveSheetAPI, SelectSheetAPI, AuthRepository, _extract_sheet_id(), Lê o JSON do caminho, persiste em storage seguro e envia ao backend., Lê credenciais salvas e autentica o backend. Retorna False se não houver. (+9 more)
 
 ### Community 8 - "Community 8"
+Cohesion: 0.07
+Nodes (17): _Observability, Observabilidade centralizada do app., PopupIcon, PopupModel, Janela de popup para exibição de erros e informações ao usuário., FeatureEvents, Eventos relacionados às entregas pendentes., AuthSignals (+9 more)
+
+### Community 9 - "Community 9"
 Cohesion: 0.05
 Nodes (21): Rotas de autenticação, AuthService, Service de autenticação — gerencia o estado de conexão do DataSource., DataSourceProtocol, Autentica com o JSON bruto da service account e guarda o client em memória., Define a planilha ativa e dispara prewarm em background., Retorna pedidos da data informada (DD/MM/YYYY)., Retorna pedidos no intervalo de datas informado (DD/MM/YYYY). (+13 more)
 
-### Community 9 - "Community 9"
+### Community 10 - "Community 10"
 Cohesion: 0.08
 Nodes (29): DeliveryTypeCount, Models de domínio da feature de entregas., DeliveriesRepository, Repositório de entregas — busca e prepara dados da planilha para o DeliveriesSer, Retorna todos os pedidos de uma data como DataFrame bruto., Acessa o data source e entrega um DataFrame para o DeliveriesService.      Não f, get_deliveries(), Rota de entregas — GET /orders/deliveries. (+21 more)
 
-### Community 10 - "Community 10"
-Cohesion: 0.08
-Nodes (14): PopupIcon, PopupModel, Janela de popup para exibição de erros e informações ao usuário., FeatureEvents, Eventos relacionados às entregas pendentes., AuthSignals, AuthUseCase, Lê o arquivo JSON, salva em storage seguro e autentica o backend. (+6 more)
-
 ### Community 11 - "Community 11"
-Cohesion: 0.1
-Nodes (24): handle_backend_error(), handle_data_source_error(), handle_unexpected_error(), AppError, certificado_limpo(), certificado_ok(), http_error(), planilha_conectada() (+16 more)
+Cohesion: 0.09
+Nodes (14): _EventBus, AppSession, CpfValidationResult, Models utilizados no módulo, CpfValidationSignals, DeliverySignals, SheetsSignals, SummarySignals (+6 more)
 
 ### Community 12 - "Community 12"
 Cohesion: 0.11
-Nodes (13): RemoveSheetAPI, SelectSheetAPI, _extract_sheet_id(), # TODO: substituir por AuthUseCase.has_credentials() — ver features/auth, Retorna o sheet_id da última planilha salva em cache, sem HTTP., SheetsRepository, SheetModel, Janela principal da aplicação e orquestração das sub-features. (+5 more)
+Nodes (22): handle_backend_error(), handle_data_source_error(), handle_unexpected_error(), AppError, certificado_limpo(), certificado_ok(), http_error(), planilha_conectada() (+14 more)
 
 ### Community 13 - "Community 13"
 Cohesion: 0.27
 Nodes (24): _customer(), _customization(), _delivery(), _financial(), OrderMapper, _payments(), _products(), Mapeamento de uma linha do DataFrame para o model Order. (+16 more)
 
 ### Community 14 - "Community 14"
-Cohesion: 0.13
-Nodes (6): MenuHandler, MainWindow, QMainWindow, QStatusBar, GuiStatusBar, Barra de status da aplicação: planilha conectada, credenciais e estado de carreg
-
-### Community 15 - "Community 15"
 Cohesion: 0.15
 Nodes (14): _cast_numeric(), OrdersSummaryRepository, Repositório de pedidos — busca por período para o OrdersService., Retorna todos os pedidos de um período como DataFrame., Retorna todos os pedidos de um período com colunas numéricas convertidas para fl, _to_dataframe(), get_orders(), Rota de pedidos — GET /orders. (+6 more)
 
-### Community 16 - "Community 16"
-Cohesion: 0.29
-Nodes (3): HomeController, HomeFeaturesModel, HomeView
-
-### Community 17 - "Community 17"
+### Community 15 - "Community 15"
 Cohesion: 0.4
 Nodes (3): normalize_decimal(), Utilitários de formatação numérica., Converte número no formato brasileiro para o formato inglês.      Remove o separ
 
-### Community 18 - "Community 18"
+### Community 16 - "Community 16"
+Cohesion: 0.5
+Nodes (3): asset(), Metadados centralizados do pacote maria-cacau., Resolve um path relativo à pasta assets, funciona em dev e no .exe compilado.
+
+### Community 17 - "Community 17"
 Cohesion: 1.0
 Nodes (1): r"""Indica se a resposta foi bem sucedida (status code 2xx).
 
-### Community 36 - "Community 36"
+### Community 35 - "Community 35"
 Cohesion: 1.0
 Nodes (1): Converte list[dict] em DataFrame com cast numérico de todas as colunas de valor.
 
-### Community 37 - "Community 37"
+### Community 36 - "Community 36"
 Cohesion: 1.0
 Nodes (1): Faz cast numérico de uma coluna se ela existir no DataFrame.
+
+### Community 38 - "Community 38"
+Cohesion: 1.0
+Nodes (1): Converte list[dict] em DataFrame com cast numérico de todas as colunas de valor.
 
 ### Community 39 - "Community 39"
 Cohesion: 1.0
-Nodes (1): Converte list[dict] em DataFrame com cast numérico de todas as colunas de valor.
-
-### Community 40 - "Community 40"
-Cohesion: 1.0
 Nodes (1): Faz cast numérico de uma coluna se ela existir no DataFrame.
 
-### Community 44 - "Community 44"
+### Community 43 - "Community 43"
 Cohesion: 1.0
 Nodes (1): Lê o arquivo JSON, salva em storage seguro e autentica o backend.
 
-### Community 45 - "Community 45"
+### Community 44 - "Community 44"
 Cohesion: 1.0
 Nodes (1): Autentica usando credenciais já salvas. Retorna False se não houver.
 
-### Community 46 - "Community 46"
+### Community 45 - "Community 45"
 Cohesion: 1.0
 Nodes (1): Remove credenciais do storage e desautentica o backend.
 
-### Community 47 - "Community 47"
+### Community 46 - "Community 46"
 Cohesion: 1.0
 Nodes (1): Colunas usadas da planilha
 
-### Community 48 - "Community 48"
+### Community 47 - "Community 47"
 Cohesion: 1.0
 Nodes (1): Orquestra a autenticação e o acesso às abas da planilha.
 
-### Community 49 - "Community 49"
+### Community 48 - "Community 48"
 Cohesion: 1.0
 Nodes (1): Autentica e aponta para a planilha. Não lê dados ainda.
 
-### Community 50 - "Community 50"
+### Community 49 - "Community 49"
 Cohesion: 1.0
 Nodes (1): Lê e processa as 20 datas mais recentes da aba Cadastro (chamado uma vez, no Ati
 
-### Community 51 - "Community 51"
+### Community 50 - "Community 50"
 Cohesion: 1.0
 Nodes (1): Lê entregas de uma data específica direto da planilha (sem cache global).
 
-### Community 52 - "Community 52"
+### Community 51 - "Community 51"
 Cohesion: 1.0
 Nodes (1): Descarta os dados em memória, forçando nova leitura na próxima consulta.
 
-### Community 53 - "Community 53"
+### Community 52 - "Community 52"
 Cohesion: 1.0
 Nodes (1): Serializa o resultado do OrdersService para dict JSON-ready.
 
-### Community 54 - "Community 54"
+### Community 53 - "Community 53"
 Cohesion: 1.0
 Nodes (1): Aplica regra de negócio sobre os pedidos de um período e retorna o resumo.
+
+### Community 54 - "Community 54"
+Cohesion: 1.0
+Nodes (1): Acessa o data source e entrega um DataFrame para o OrdersService.
 
 ### Community 55 - "Community 55"
 Cohesion: 1.0
@@ -248,255 +247,251 @@ Nodes (1): Acessa o data source e entrega um DataFrame para o OrdersService.
 
 ### Community 56 - "Community 56"
 Cohesion: 1.0
-Nodes (1): Acessa o data source e entrega um DataFrame para o OrdersService.
+Nodes (1): Estrutura de uma mensagem de erro/info para exibição no PopUp.
 
 ### Community 57 - "Community 57"
 Cohesion: 1.0
-Nodes (1): Estrutura de uma mensagem de erro/info para exibição no PopUp.
+Nodes (1): Confirmação de certificado configurado com sucesso.
 
 ### Community 58 - "Community 58"
 Cohesion: 1.0
-Nodes (1): Confirmação de certificado configurado com sucesso.
+Nodes (1): Confirmação de credenciais removidas com sucesso.
 
 ### Community 59 - "Community 59"
 Cohesion: 1.0
-Nodes (1): Confirmação de credenciais removidas com sucesso.
+Nodes (1): Confirmação de planilha selecionada com sucesso.
 
 ### Community 60 - "Community 60"
 Cohesion: 1.0
-Nodes (1): Confirmação de planilha selecionada com sucesso.
+Nodes (1): Confirmação de leitura bem-sucedida da planilha.
 
 ### Community 61 - "Community 61"
 Cohesion: 1.0
-Nodes (1): Confirmação de leitura bem-sucedida da planilha.
+Nodes (1): Lógica de negócio para obter as deliveries e pagamentos pendentes.
 
 ### Community 62 - "Community 62"
 Cohesion: 1.0
-Nodes (1): Lógica de negócio para obter as deliveries e pagamentos pendentes.
+Nodes (1): Sinais compartilhadaos dentro do módulo
 
 ### Community 63 - "Community 63"
 Cohesion: 1.0
-Nodes (1): Sinais compartilhadaos dentro do módulo
+Nodes (1): Área de entregas pendentes: controller da view.
 
 ### Community 64 - "Community 64"
 Cohesion: 1.0
-Nodes (1): Área de entregas pendentes: controller da view.
+Nodes (1): Models utilizados no módulo
 
 ### Community 65 - "Community 65"
 Cohesion: 1.0
-Nodes (1): Models utilizados no módulo
+Nodes (1): Eventos relacionados às entregas pendentes.
 
 ### Community 66 - "Community 66"
 Cohesion: 1.0
-Nodes (1): Eventos relacionados às entregas pendentes.
+Nodes (1): Regra de negócios das entregas
 
 ### Community 67 - "Community 67"
 Cohesion: 1.0
-Nodes (1): Regra de negócios das entregas
+Nodes (1): Conexão com serviço da planilha/base de dados
 
 ### Community 68 - "Community 68"
 Cohesion: 1.0
-Nodes (1): Conexão com serviço da planilha/base de dados
+Nodes (1): Normaliza uma data para DD/MM/YYYY aceitando os formatos DD/MM/YY e DD/MM/YYYY.
 
 ### Community 69 - "Community 69"
 Cohesion: 1.0
-Nodes (1): Normaliza uma data para DD/MM/YYYY aceitando os formatos DD/MM/YY e DD/MM/YYYY.
+Nodes (1): Converte linhas da planilha em lista de dicts usando o cabeçalho como chaves (lo
 
 ### Community 70 - "Community 70"
 Cohesion: 1.0
-Nodes (1): Converte linhas da planilha em lista de dicts usando o cabeçalho como chaves (lo
+Nodes (1): Agrupa números de linha consecutivos em ranges A1 notation e divide em batches d
 
 ### Community 71 - "Community 71"
 Cohesion: 1.0
-Nodes (1): Agrupa números de linha consecutivos em ranges A1 notation e divide em batches d
+Nodes (1): Retorna o conjunto de todas as datas (DD/MM/YYYY) entre start e end, inclusive.
 
 ### Community 72 - "Community 72"
 Cohesion: 1.0
-Nodes (1): Retorna o conjunto de todas as datas (DD/MM/YYYY) entre start e end, inclusive.
+Nodes (1): Acessa o data source e entrega um DataFrame tipado para o PaymentsService.
 
 ### Community 73 - "Community 73"
 Cohesion: 1.0
-Nodes (1): Acessa o data source e entrega um DataFrame tipado para o PaymentsService.
+Nodes (1): Retorna todos os pedidos de uma data com colunas numéricas convertidas para floa
 
 ### Community 74 - "Community 74"
 Cohesion: 1.0
-Nodes (1): Retorna todos os pedidos de uma data com colunas numéricas convertidas para floa
+Nodes (1): Converte list[dict] em DataFrame com cast numérico de todas as colunas de valor.
 
 ### Community 75 - "Community 75"
 Cohesion: 1.0
-Nodes (1): Converte list[dict] em DataFrame com cast numérico de todas as colunas de valor.
+Nodes (1): Faz cast numérico de uma coluna se ela existir no DataFrame.
 
 ### Community 76 - "Community 76"
 Cohesion: 1.0
-Nodes (1): Faz cast numérico de uma coluna se ela existir no DataFrame.
+Nodes (1): Códigos de erro da aplicação com estrutura AppError.
 
 ### Community 77 - "Community 77"
 Cohesion: 1.0
-Nodes (1): Códigos de erro da aplicação com estrutura AppError.
+Nodes (1): Estrutura de uma mensagem de erro/info para exibição no PopUp.
 
 ### Community 78 - "Community 78"
 Cohesion: 1.0
-Nodes (1): Estrutura de uma mensagem de erro/info para exibição no PopUp.
+Nodes (1): Confirmação de certificado configurado com sucesso.
 
 ### Community 79 - "Community 79"
 Cohesion: 1.0
-Nodes (1): Confirmação de certificado configurado com sucesso.
+Nodes (1): Confirmação de credenciais removidas com sucesso.
 
 ### Community 80 - "Community 80"
 Cohesion: 1.0
-Nodes (1): Confirmação de credenciais removidas com sucesso.
+Nodes (1): Confirmação de planilha selecionada com sucesso.
 
 ### Community 81 - "Community 81"
 Cohesion: 1.0
-Nodes (1): Confirmação de planilha selecionada com sucesso.
+Nodes (1): Confirmação de leitura bem-sucedida da planilha.
 
 ### Community 82 - "Community 82"
 Cohesion: 1.0
-Nodes (1): Confirmação de leitura bem-sucedida da planilha.
+Nodes (1): Retorna (w, h) para o canvas.         h = altura do viewport (sem desperdício/ov
 
 ### Community 83 - "Community 83"
 Cohesion: 1.0
-Nodes (1): Retorna (w, h) para o canvas.         h = altura do viewport (sem desperdício/ov
+Nodes (1): Autentica e aponta para a planilha. Não lê dados ainda.
 
 ### Community 84 - "Community 84"
 Cohesion: 1.0
-Nodes (1): Autentica e aponta para a planilha. Não lê dados ainda.
+Nodes (1): Lê e processa as 20 datas mais recentes da aba Cadastro (chamado uma vez, no Ati
 
 ### Community 85 - "Community 85"
 Cohesion: 1.0
-Nodes (1): Lê e processa as 20 datas mais recentes da aba Cadastro (chamado uma vez, no Ati
+Nodes (1): Lê entregas de uma data específica direto da planilha (sem cache global).
 
 ### Community 86 - "Community 86"
 Cohesion: 1.0
-Nodes (1): Lê entregas de uma data específica direto da planilha (sem cache global).
+Nodes (1): Descarta os dados em memória, forçando nova leitura na próxima consulta.
 
 ### Community 87 - "Community 87"
 Cohesion: 1.0
-Nodes (1): Descarta os dados em memória, forçando nova leitura na próxima consulta.
-
-### Community 88 - "Community 88"
-Cohesion: 1.0
 Nodes (1): r"""Decodifica o body para um objeto.
 
-### Community 89 - "Community 89"
+### Community 88 - "Community 88"
 Cohesion: 1.0
 Nodes (1): r"""Indica se a resposta foi bem sucedida (status code 2xx).
 
 ## Knowledge Gaps
 - **106 isolated node(s):** `Metadados centralizados do pacote maria-cacau.`, `Resolve um path relativo à pasta assets, funciona em dev e no .exe compilado.`, `Widget de gráfico reutilizável (barras ou pizza) usando seaborn + matplotlib.`, `Retorna (w, h) para o canvas.         h = altura do viewport (sem desperdício/ov`, `Observabilidade centralizada do app.` (+101 more)
   These have ≤1 connection - possible missing edges or undocumented components.
-- **Thin community `Community 18`** (1 nodes): `r"""Indica se a resposta foi bem sucedida (status code 2xx).`
+- **Thin community `Community 17`** (1 nodes): `r"""Indica se a resposta foi bem sucedida (status code 2xx).`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 36`** (1 nodes): `Converte list[dict] em DataFrame com cast numérico de todas as colunas de valor.`
+- **Thin community `Community 35`** (1 nodes): `Converte list[dict] em DataFrame com cast numérico de todas as colunas de valor.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 37`** (1 nodes): `Faz cast numérico de uma coluna se ela existir no DataFrame.`
+- **Thin community `Community 36`** (1 nodes): `Faz cast numérico de uma coluna se ela existir no DataFrame.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 39`** (1 nodes): `Converte list[dict] em DataFrame com cast numérico de todas as colunas de valor.`
+- **Thin community `Community 38`** (1 nodes): `Converte list[dict] em DataFrame com cast numérico de todas as colunas de valor.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 40`** (1 nodes): `Faz cast numérico de uma coluna se ela existir no DataFrame.`
+- **Thin community `Community 39`** (1 nodes): `Faz cast numérico de uma coluna se ela existir no DataFrame.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 44`** (1 nodes): `Lê o arquivo JSON, salva em storage seguro e autentica o backend.`
+- **Thin community `Community 43`** (1 nodes): `Lê o arquivo JSON, salva em storage seguro e autentica o backend.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 45`** (1 nodes): `Autentica usando credenciais já salvas. Retorna False se não houver.`
+- **Thin community `Community 44`** (1 nodes): `Autentica usando credenciais já salvas. Retorna False se não houver.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 46`** (1 nodes): `Remove credenciais do storage e desautentica o backend.`
+- **Thin community `Community 45`** (1 nodes): `Remove credenciais do storage e desautentica o backend.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 47`** (1 nodes): `Colunas usadas da planilha`
+- **Thin community `Community 46`** (1 nodes): `Colunas usadas da planilha`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 48`** (1 nodes): `Orquestra a autenticação e o acesso às abas da planilha.`
+- **Thin community `Community 47`** (1 nodes): `Orquestra a autenticação e o acesso às abas da planilha.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 49`** (1 nodes): `Autentica e aponta para a planilha. Não lê dados ainda.`
+- **Thin community `Community 48`** (1 nodes): `Autentica e aponta para a planilha. Não lê dados ainda.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 50`** (1 nodes): `Lê e processa as 20 datas mais recentes da aba Cadastro (chamado uma vez, no Ati`
+- **Thin community `Community 49`** (1 nodes): `Lê e processa as 20 datas mais recentes da aba Cadastro (chamado uma vez, no Ati`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 51`** (1 nodes): `Lê entregas de uma data específica direto da planilha (sem cache global).`
+- **Thin community `Community 50`** (1 nodes): `Lê entregas de uma data específica direto da planilha (sem cache global).`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 52`** (1 nodes): `Descarta os dados em memória, forçando nova leitura na próxima consulta.`
+- **Thin community `Community 51`** (1 nodes): `Descarta os dados em memória, forçando nova leitura na próxima consulta.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 53`** (1 nodes): `Serializa o resultado do OrdersService para dict JSON-ready.`
+- **Thin community `Community 52`** (1 nodes): `Serializa o resultado do OrdersService para dict JSON-ready.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 54`** (1 nodes): `Aplica regra de negócio sobre os pedidos de um período e retorna o resumo.`
+- **Thin community `Community 53`** (1 nodes): `Aplica regra de negócio sobre os pedidos de um período e retorna o resumo.`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 54`** (1 nodes): `Acessa o data source e entrega um DataFrame para o OrdersService.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 55`** (1 nodes): `Acessa o data source e entrega um DataFrame para o OrdersService.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 56`** (1 nodes): `Acessa o data source e entrega um DataFrame para o OrdersService.`
+- **Thin community `Community 56`** (1 nodes): `Estrutura de uma mensagem de erro/info para exibição no PopUp.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 57`** (1 nodes): `Estrutura de uma mensagem de erro/info para exibição no PopUp.`
+- **Thin community `Community 57`** (1 nodes): `Confirmação de certificado configurado com sucesso.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 58`** (1 nodes): `Confirmação de certificado configurado com sucesso.`
+- **Thin community `Community 58`** (1 nodes): `Confirmação de credenciais removidas com sucesso.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 59`** (1 nodes): `Confirmação de credenciais removidas com sucesso.`
+- **Thin community `Community 59`** (1 nodes): `Confirmação de planilha selecionada com sucesso.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 60`** (1 nodes): `Confirmação de planilha selecionada com sucesso.`
+- **Thin community `Community 60`** (1 nodes): `Confirmação de leitura bem-sucedida da planilha.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 61`** (1 nodes): `Confirmação de leitura bem-sucedida da planilha.`
+- **Thin community `Community 61`** (1 nodes): `Lógica de negócio para obter as deliveries e pagamentos pendentes.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 62`** (1 nodes): `Lógica de negócio para obter as deliveries e pagamentos pendentes.`
+- **Thin community `Community 62`** (1 nodes): `Sinais compartilhadaos dentro do módulo`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 63`** (1 nodes): `Sinais compartilhadaos dentro do módulo`
+- **Thin community `Community 63`** (1 nodes): `Área de entregas pendentes: controller da view.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 64`** (1 nodes): `Área de entregas pendentes: controller da view.`
+- **Thin community `Community 64`** (1 nodes): `Models utilizados no módulo`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 65`** (1 nodes): `Models utilizados no módulo`
+- **Thin community `Community 65`** (1 nodes): `Eventos relacionados às entregas pendentes.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 66`** (1 nodes): `Eventos relacionados às entregas pendentes.`
+- **Thin community `Community 66`** (1 nodes): `Regra de negócios das entregas`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 67`** (1 nodes): `Regra de negócios das entregas`
+- **Thin community `Community 67`** (1 nodes): `Conexão com serviço da planilha/base de dados`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 68`** (1 nodes): `Conexão com serviço da planilha/base de dados`
+- **Thin community `Community 68`** (1 nodes): `Normaliza uma data para DD/MM/YYYY aceitando os formatos DD/MM/YY e DD/MM/YYYY.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 69`** (1 nodes): `Normaliza uma data para DD/MM/YYYY aceitando os formatos DD/MM/YY e DD/MM/YYYY.`
+- **Thin community `Community 69`** (1 nodes): `Converte linhas da planilha em lista de dicts usando o cabeçalho como chaves (lo`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 70`** (1 nodes): `Converte linhas da planilha em lista de dicts usando o cabeçalho como chaves (lo`
+- **Thin community `Community 70`** (1 nodes): `Agrupa números de linha consecutivos em ranges A1 notation e divide em batches d`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 71`** (1 nodes): `Agrupa números de linha consecutivos em ranges A1 notation e divide em batches d`
+- **Thin community `Community 71`** (1 nodes): `Retorna o conjunto de todas as datas (DD/MM/YYYY) entre start e end, inclusive.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 72`** (1 nodes): `Retorna o conjunto de todas as datas (DD/MM/YYYY) entre start e end, inclusive.`
+- **Thin community `Community 72`** (1 nodes): `Acessa o data source e entrega um DataFrame tipado para o PaymentsService.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 73`** (1 nodes): `Acessa o data source e entrega um DataFrame tipado para o PaymentsService.`
+- **Thin community `Community 73`** (1 nodes): `Retorna todos os pedidos de uma data com colunas numéricas convertidas para floa`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 74`** (1 nodes): `Retorna todos os pedidos de uma data com colunas numéricas convertidas para floa`
+- **Thin community `Community 74`** (1 nodes): `Converte list[dict] em DataFrame com cast numérico de todas as colunas de valor.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 75`** (1 nodes): `Converte list[dict] em DataFrame com cast numérico de todas as colunas de valor.`
+- **Thin community `Community 75`** (1 nodes): `Faz cast numérico de uma coluna se ela existir no DataFrame.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 76`** (1 nodes): `Faz cast numérico de uma coluna se ela existir no DataFrame.`
+- **Thin community `Community 76`** (1 nodes): `Códigos de erro da aplicação com estrutura AppError.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 77`** (1 nodes): `Códigos de erro da aplicação com estrutura AppError.`
+- **Thin community `Community 77`** (1 nodes): `Estrutura de uma mensagem de erro/info para exibição no PopUp.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 78`** (1 nodes): `Estrutura de uma mensagem de erro/info para exibição no PopUp.`
+- **Thin community `Community 78`** (1 nodes): `Confirmação de certificado configurado com sucesso.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 79`** (1 nodes): `Confirmação de certificado configurado com sucesso.`
+- **Thin community `Community 79`** (1 nodes): `Confirmação de credenciais removidas com sucesso.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 80`** (1 nodes): `Confirmação de credenciais removidas com sucesso.`
+- **Thin community `Community 80`** (1 nodes): `Confirmação de planilha selecionada com sucesso.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 81`** (1 nodes): `Confirmação de planilha selecionada com sucesso.`
+- **Thin community `Community 81`** (1 nodes): `Confirmação de leitura bem-sucedida da planilha.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 82`** (1 nodes): `Confirmação de leitura bem-sucedida da planilha.`
+- **Thin community `Community 82`** (1 nodes): `Retorna (w, h) para o canvas.         h = altura do viewport (sem desperdício/ov`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 83`** (1 nodes): `Retorna (w, h) para o canvas.         h = altura do viewport (sem desperdício/ov`
+- **Thin community `Community 83`** (1 nodes): `Autentica e aponta para a planilha. Não lê dados ainda.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 84`** (1 nodes): `Autentica e aponta para a planilha. Não lê dados ainda.`
+- **Thin community `Community 84`** (1 nodes): `Lê e processa as 20 datas mais recentes da aba Cadastro (chamado uma vez, no Ati`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 85`** (1 nodes): `Lê e processa as 20 datas mais recentes da aba Cadastro (chamado uma vez, no Ati`
+- **Thin community `Community 85`** (1 nodes): `Lê entregas de uma data específica direto da planilha (sem cache global).`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 86`** (1 nodes): `Lê entregas de uma data específica direto da planilha (sem cache global).`
+- **Thin community `Community 86`** (1 nodes): `Descarta os dados em memória, forçando nova leitura na próxima consulta.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 87`** (1 nodes): `Descarta os dados em memória, forçando nova leitura na próxima consulta.`
+- **Thin community `Community 87`** (1 nodes): `r"""Decodifica o body para um objeto.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 88`** (1 nodes): `r"""Decodifica o body para um objeto.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 89`** (1 nodes): `r"""Indica se a resposta foi bem sucedida (status code 2xx).`
+- **Thin community `Community 88`** (1 nodes): `r"""Indica se a resposta foi bem sucedida (status code 2xx).`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions
 _Questions this graph is uniquely positioned to answer:_
 
-- **Why does `GuiPopup` connect `Community 0` to `Community 4`, `Community 5`, `Community 7`, `Community 10`, `Community 12`?**
-  _High betweenness centrality (0.095) - this node is a cross-community bridge._
-- **Why does `AppEvent` connect `Community 6` to `Community 10`, `Community 2`, `Community 12`?**
-  _High betweenness centrality (0.076) - this node is a cross-community bridge._
-- **Why does `BackendServer` connect `Community 2` to `Community 1`, `Community 11`?**
-  _High betweenness centrality (0.076) - this node is a cross-community bridge._
+- **Why does `FeatureEvents` connect `Community 8` to `Community 1`, `Community 2`, `Community 11`, `Community 4`?**
+  _High betweenness centrality (0.092) - this node is a cross-community bridge._
+- **Why does `GuiPopup` connect `Community 1` to `Community 8`, `Community 2`, `Community 3`, `Community 4`?**
+  _High betweenness centrality (0.089) - this node is a cross-community bridge._
+- **Why does `BackendServer` connect `Community 4` to `Community 0`, `Community 12`, `Community 6`?**
+  _High betweenness centrality (0.073) - this node is a cross-community bridge._
 - **Are the 34 inferred relationships involving `SecurityStorage` (e.g. with `StorageHandler` and `AuthRepository`) actually correct?**
   _`SecurityStorage` has 34 INFERRED edges - model-reasoned connections that need verification._
 - **Are the 25 inferred relationships involving `AuxWidgets` (e.g. with `AuxFrame` and `Frame composto reutilizável com label, entrada de texto e botão de cópia.`) actually correct?**

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -9,7 +9,7 @@
       "source_file": "maria_cacau/__init__.py",
       "source_location": "L1",
       "id": "maria_cacau_init_py",
-      "community": 0,
+      "community": 16,
       "norm_label": "__init__.py"
     },
     {
@@ -18,7 +18,7 @@
       "source_file": "maria_cacau/__init__.py",
       "source_location": "L17",
       "id": "maria_cacau_init_asset",
-      "community": 0,
+      "community": 16,
       "norm_label": "asset()"
     },
     {
@@ -26,7 +26,7 @@
       "file_type": "rationale",
       "source_file": "__init__.py",
       "source_location": "L1",
-      "community": 0,
+      "community": 16,
       "norm_label": "metadados centralizados do pacote maria-cacau.",
       "id": "maria_cacau_init_rationale_1"
     },
@@ -35,7 +35,7 @@
       "file_type": "rationale",
       "source_file": "__init__.py",
       "source_location": "L18",
-      "community": 0,
+      "community": 16,
       "norm_label": "resolve um path relativo a pasta assets, funciona em dev e no .exe compilado.",
       "id": "maria_cacau_init_rationale_18"
     },
@@ -45,7 +45,7 @@
       "source_file": "maria_cacau/__main__.py",
       "source_location": "L1",
       "id": "maria_cacau_main_py",
-      "community": 2,
+      "community": 4,
       "norm_label": "__main__.py"
     },
     {
@@ -54,7 +54,7 @@
       "source_file": "maria_cacau/__main__.py",
       "source_location": "L10",
       "id": "maria_cacau_main_main",
-      "community": 2,
+      "community": 4,
       "norm_label": "main()"
     },
     {
@@ -62,7 +62,7 @@
       "file_type": "rationale",
       "source_file": "__main__.py",
       "source_location": "L1",
-      "community": 2,
+      "community": 4,
       "norm_label": "entry point da aplicacao. execute com: python -m maria_cacau",
       "id": "maria_cacau_main_rationale_1"
     },
@@ -72,7 +72,7 @@
       "source_file": "maria_cacau/core/charts.py",
       "source_location": "L1",
       "id": "maria_cacau_core_charts_py",
-      "community": 0,
+      "community": 1,
       "norm_label": "charts.py"
     },
     {
@@ -81,7 +81,7 @@
       "source_file": "maria_cacau/core/charts.py",
       "source_location": "L17",
       "id": "core_charts_charttype",
-      "community": 0,
+      "community": 1,
       "norm_label": "charttype"
     },
     {
@@ -90,7 +90,7 @@
       "source_file": "",
       "source_location": "",
       "id": "enum",
-      "community": 10,
+      "community": 8,
       "norm_label": "enum"
     },
     {
@@ -99,7 +99,7 @@
       "source_file": "maria_cacau/core/charts.py",
       "source_location": "L22",
       "id": "core_charts_short_label",
-      "community": 0,
+      "community": 1,
       "norm_label": "_short_label()"
     },
     {
@@ -108,7 +108,7 @@
       "source_file": "maria_cacau/core/charts.py",
       "source_location": "L30",
       "id": "core_charts_chartwidget",
-      "community": 0,
+      "community": 1,
       "norm_label": "chartwidget"
     },
     {
@@ -117,7 +117,7 @@
       "source_file": "",
       "source_location": "",
       "id": "qwidget",
-      "community": 0,
+      "community": 5,
       "norm_label": "qwidget"
     },
     {
@@ -126,7 +126,7 @@
       "source_file": "maria_cacau/core/charts.py",
       "source_location": "L31",
       "id": "core_charts_chartwidget_init",
-      "community": 0,
+      "community": 1,
       "norm_label": ".__init__()"
     },
     {
@@ -135,7 +135,7 @@
       "source_file": "maria_cacau/core/charts.py",
       "source_location": "L68",
       "id": "core_charts_chartwidget_update_data",
-      "community": 0,
+      "community": 1,
       "norm_label": ".update_data()"
     },
     {
@@ -144,7 +144,7 @@
       "source_file": "maria_cacau/core/charts.py",
       "source_location": "L73",
       "id": "core_charts_chartwidget_set_type",
-      "community": 0,
+      "community": 1,
       "norm_label": ".set_type()"
     },
     {
@@ -153,7 +153,7 @@
       "source_file": "maria_cacau/core/charts.py",
       "source_location": "L78",
       "id": "core_charts_chartwidget_copy_to_clipboard",
-      "community": 0,
+      "community": 1,
       "norm_label": ".copy_to_clipboard()"
     },
     {
@@ -162,7 +162,7 @@
       "source_file": "maria_cacau/core/charts.py",
       "source_location": "L88",
       "id": "core_charts_chartwidget_save_to_file",
-      "community": 0,
+      "community": 1,
       "norm_label": ".save_to_file()"
     },
     {
@@ -171,7 +171,7 @@
       "source_file": "maria_cacau/core/charts.py",
       "source_location": "L98",
       "id": "core_charts_chartwidget_canvas_dims",
-      "community": 0,
+      "community": 1,
       "norm_label": "._canvas_dims()"
     },
     {
@@ -180,7 +180,7 @@
       "source_file": "maria_cacau/core/charts.py",
       "source_location": "L110",
       "id": "core_charts_chartwidget_render",
-      "community": 0,
+      "community": 1,
       "norm_label": "._render()"
     },
     {
@@ -189,7 +189,7 @@
       "source_file": "maria_cacau/core/charts.py",
       "source_location": "L116",
       "id": "core_charts_chartwidget_render_bar",
-      "community": 0,
+      "community": 1,
       "norm_label": "._render_bar()"
     },
     {
@@ -198,7 +198,7 @@
       "source_file": "maria_cacau/core/charts.py",
       "source_location": "L154",
       "id": "core_charts_chartwidget_render_pie",
-      "community": 0,
+      "community": 1,
       "norm_label": "._render_pie()"
     },
     {
@@ -207,7 +207,7 @@
       "source_file": "maria_cacau/core/charts.py",
       "source_location": "L198",
       "id": "core_charts_chartwidget_empty",
-      "community": 0,
+      "community": 1,
       "norm_label": "._empty()"
     },
     {
@@ -215,7 +215,7 @@
       "file_type": "rationale",
       "source_file": "core/charts.py",
       "source_location": "L1",
-      "community": 0,
+      "community": 1,
       "norm_label": "widget de grafico reutilizavel (barras ou pizza) usando seaborn + matplotlib.",
       "id": "core_charts_rationale_1"
     },
@@ -224,7 +224,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/core/charts.py",
       "source_location": "L99",
-      "community": 0,
+      "community": 1,
       "norm_label": "retorna (w, h) para o canvas.         h = altura do viewport (sem desperdicio/ov",
       "id": "core_charts_rationale_99"
     },
@@ -234,7 +234,7 @@
       "source_file": "maria_cacau/core/session.py",
       "source_location": "L1",
       "id": "maria_cacau_core_session_py",
-      "community": 4,
+      "community": 11,
       "norm_label": "session.py"
     },
     {
@@ -243,7 +243,7 @@
       "source_file": "maria_cacau/core/session.py",
       "source_location": "L1",
       "id": "core_session_appsession",
-      "community": 4,
+      "community": 11,
       "norm_label": "appsession"
     },
     {
@@ -252,7 +252,7 @@
       "source_file": "maria_cacau/core/session.py",
       "source_location": "L2",
       "id": "core_session_appsession_init",
-      "community": 4,
+      "community": 11,
       "norm_label": ".__init__()"
     },
     {
@@ -261,7 +261,7 @@
       "source_file": "maria_cacau/core/__init__.py",
       "source_location": "L1",
       "id": "maria_cacau_core_init_py",
-      "community": 4,
+      "community": 11,
       "norm_label": "__init__.py"
     },
     {
@@ -270,7 +270,7 @@
       "source_file": "maria_cacau/core/observability.py",
       "source_location": "L1",
       "id": "maria_cacau_core_observability_py",
-      "community": 6,
+      "community": 8,
       "norm_label": "observability.py"
     },
     {
@@ -279,7 +279,7 @@
       "source_file": "maria_cacau/core/observability.py",
       "source_location": "L13",
       "id": "core_observability_appevent",
-      "community": 6,
+      "community": 3,
       "norm_label": "appevent"
     },
     {
@@ -288,7 +288,7 @@
       "source_file": "maria_cacau/core/observability.py",
       "source_location": "L28",
       "id": "core_observability_observability",
-      "community": 6,
+      "community": 8,
       "norm_label": "_observability"
     },
     {
@@ -297,7 +297,7 @@
       "source_file": "maria_cacau/core/observability.py",
       "source_location": "L29",
       "id": "core_observability_observability_init",
-      "community": 6,
+      "community": 8,
       "norm_label": ".__init__()"
     },
     {
@@ -306,7 +306,7 @@
       "source_file": "maria_cacau/core/observability.py",
       "source_location": "L38",
       "id": "core_observability_observability_log",
-      "community": 5,
+      "community": 1,
       "norm_label": ".log()"
     },
     {
@@ -314,7 +314,7 @@
       "file_type": "rationale",
       "source_file": "core/observability.py",
       "source_location": "L1",
-      "community": 6,
+      "community": 8,
       "norm_label": "observabilidade centralizada do app.",
       "id": "core_observability_rationale_1"
     },
@@ -324,7 +324,7 @@
       "source_file": "maria_cacau/core/bus.py",
       "source_location": "L1",
       "id": "maria_cacau_core_bus_py",
-      "community": 4,
+      "community": 11,
       "norm_label": "bus.py"
     },
     {
@@ -333,7 +333,7 @@
       "source_file": "maria_cacau/core/bus.py",
       "source_location": "L4",
       "id": "core_bus_eventbus",
-      "community": 4,
+      "community": 11,
       "norm_label": "_eventbus"
     },
     {
@@ -342,7 +342,7 @@
       "source_file": "",
       "source_location": "",
       "id": "qobject",
-      "community": 4,
+      "community": 11,
       "norm_label": "qobject"
     },
     {
@@ -351,7 +351,7 @@
       "source_file": "maria_cacau/core/network/_errors.py",
       "source_location": "L1",
       "id": "maria_cacau_core_network_errors_py",
-      "community": 2,
+      "community": 6,
       "norm_label": "_errors.py"
     },
     {
@@ -360,7 +360,7 @@
       "source_file": "maria_cacau/core/network/_errors.py",
       "source_location": "L9",
       "id": "network_errors_networkerror",
-      "community": 2,
+      "community": 6,
       "norm_label": "networkerror"
     },
     {
@@ -369,7 +369,7 @@
       "source_file": "",
       "source_location": "",
       "id": "exception",
-      "community": 11,
+      "community": 12,
       "norm_label": "exception"
     },
     {
@@ -378,7 +378,7 @@
       "source_file": "maria_cacau/core/network/_errors.py",
       "source_location": "L14",
       "id": "network_errors_networknotconfigurederror",
-      "community": 2,
+      "community": 6,
       "norm_label": "networknotconfigurederror"
     },
     {
@@ -387,7 +387,7 @@
       "source_file": "maria_cacau/core/network/_errors.py",
       "source_location": "L16",
       "id": "network_errors_networknotconfigurederror_init",
-      "community": 2,
+      "community": 6,
       "norm_label": ".__init__()"
     },
     {
@@ -396,7 +396,7 @@
       "source_file": "maria_cacau/core/network/_errors.py",
       "source_location": "L19",
       "id": "network_errors_httprequesterror",
-      "community": 2,
+      "community": 6,
       "norm_label": "httprequesterror"
     },
     {
@@ -405,7 +405,7 @@
       "source_file": "maria_cacau/core/network/_errors.py",
       "source_location": "L21",
       "id": "network_errors_httprequesterror_init",
-      "community": 2,
+      "community": 6,
       "norm_label": ".__init__()"
     },
     {
@@ -414,7 +414,7 @@
       "source_file": "maria_cacau/core/network/_errors.py",
       "source_location": "L25",
       "id": "network_errors_httpresponseerror",
-      "community": 2,
+      "community": 6,
       "norm_label": "httpresponseerror"
     },
     {
@@ -423,7 +423,7 @@
       "source_file": "maria_cacau/core/network/_errors.py",
       "source_location": "L27",
       "id": "network_errors_httpresponseerror_init",
-      "community": 2,
+      "community": 6,
       "norm_label": ".__init__()"
     },
     {
@@ -432,7 +432,7 @@
       "source_file": "maria_cacau/core/network/_errors.py",
       "source_location": "L34",
       "id": "network_errors_errormessages",
-      "community": 2,
+      "community": 6,
       "norm_label": "errormessages"
     },
     {
@@ -441,7 +441,7 @@
       "source_file": "",
       "source_location": "",
       "id": "strenum",
-      "community": 1,
+      "community": 0,
       "norm_label": "strenum"
     },
     {
@@ -449,7 +449,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/core/network/_errors.py",
       "source_location": "L1",
-      "community": 2,
+      "community": 6,
       "norm_label": "erros mapeados usados no modulo",
       "id": "network_errors_rationale_1"
     },
@@ -458,7 +458,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/core/network/_errors.py",
       "source_location": "L10",
-      "community": 2,
+      "community": 6,
       "norm_label": "r\"\"\"erro base da camada de network.",
       "id": "network_errors_rationale_10"
     },
@@ -467,7 +467,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/core/network/_errors.py",
       "source_location": "L15",
-      "community": 2,
+      "community": 6,
       "norm_label": "configure() nao foi chamado antes de usar a lib.",
       "id": "network_errors_rationale_15"
     },
@@ -476,7 +476,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/core/network/_errors.py",
       "source_location": "L20",
-      "community": 2,
+      "community": 6,
       "norm_label": "erro antes de receber resposta (conectividade, timeout, url invalida).",
       "id": "network_errors_rationale_20"
     },
@@ -485,7 +485,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/core/network/_errors.py",
       "source_location": "L26",
-      "community": 2,
+      "community": 6,
       "norm_label": "resposta recebida com status de erro (4xx, 5xx).",
       "id": "network_errors_rationale_26"
     },
@@ -495,7 +495,7 @@
       "source_file": "maria_cacau/core/network/_method.py",
       "source_location": "L1",
       "id": "maria_cacau_core_network_method_py",
-      "community": 2,
+      "community": 6,
       "norm_label": "_method.py"
     },
     {
@@ -504,7 +504,7 @@
       "source_file": "maria_cacau/core/network/_method.py",
       "source_location": "L6",
       "id": "network_method_httpmethod",
-      "community": 2,
+      "community": 6,
       "norm_label": "httpmethod"
     },
     {
@@ -512,7 +512,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/core/network/_method.py",
       "source_location": "L1",
-      "community": 2,
+      "community": 6,
       "norm_label": "http metodos disponiveis para uso",
       "id": "network_method_rationale_1"
     },
@@ -522,7 +522,7 @@
       "source_file": "maria_cacau/core/network/_response.py",
       "source_location": "L1",
       "id": "maria_cacau_core_network_response_py",
-      "community": 2,
+      "community": 6,
       "norm_label": "_response.py"
     },
     {
@@ -531,7 +531,7 @@
       "source_file": "maria_cacau/core/network/_response.py",
       "source_location": "L6",
       "id": "network_response_httpresponse",
-      "community": 2,
+      "community": 6,
       "norm_label": "httpresponse"
     },
     {
@@ -540,7 +540,7 @@
       "source_file": "maria_cacau/core/network/_response.py",
       "source_location": "L11",
       "id": "network_response_httpresponse_json",
-      "community": 2,
+      "community": 6,
       "norm_label": ".json()"
     },
     {
@@ -549,7 +549,7 @@
       "source_file": "maria_cacau/core/network/_response.py",
       "source_location": "L16",
       "id": "network_response_is_success",
-      "community": 2,
+      "community": 6,
       "norm_label": "is_success()"
     },
     {
@@ -557,7 +557,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/core/network/_response.py",
       "source_location": "L12",
-      "community": 2,
+      "community": 6,
       "norm_label": "r\"\"\"decodifica o body para um objeto.",
       "id": "network_response_rationale_12"
     },
@@ -566,7 +566,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/core/network/_response.py",
       "source_location": "L17",
-      "community": 18,
+      "community": 17,
       "norm_label": "r\"\"\"indica se a resposta foi bem sucedida (status code 2xx).",
       "id": "network_response_rationale_17"
     },
@@ -576,7 +576,7 @@
       "source_file": "maria_cacau/core/network/__init__.py",
       "source_location": "L1",
       "id": "maria_cacau_core_network_init_py",
-      "community": 2,
+      "community": 6,
       "norm_label": "__init__.py"
     },
     {
@@ -585,7 +585,7 @@
       "source_file": "maria_cacau/core/network/_request.py",
       "source_location": "L1",
       "id": "maria_cacau_core_network_request_py",
-      "community": 2,
+      "community": 6,
       "norm_label": "_request.py"
     },
     {
@@ -594,7 +594,7 @@
       "source_file": "maria_cacau/core/network/_request.py",
       "source_location": "L9",
       "id": "network_request_httprequest",
-      "community": 2,
+      "community": 6,
       "norm_label": "httprequest"
     },
     {
@@ -602,7 +602,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/core/network/_request.py",
       "source_location": "L1",
-      "community": 2,
+      "community": 6,
       "norm_label": "dados e parametros de uma request",
       "id": "network_request_rationale_1"
     },
@@ -612,7 +612,7 @@
       "source_file": "maria_cacau/core/network/api.py",
       "source_location": "L1",
       "id": "maria_cacau_core_network_api_py",
-      "community": 2,
+      "community": 6,
       "norm_label": "api.py"
     },
     {
@@ -621,7 +621,7 @@
       "source_file": "maria_cacau/core/network/api.py",
       "source_location": "L14",
       "id": "network_api_api",
-      "community": 2,
+      "community": 6,
       "norm_label": "api"
     },
     {
@@ -630,7 +630,7 @@
       "source_file": "",
       "source_location": "",
       "id": "abc",
-      "community": 6,
+      "community": 3,
       "norm_label": "abc"
     },
     {
@@ -639,7 +639,7 @@
       "source_file": "maria_cacau/core/network/api.py",
       "source_location": "L15",
       "id": "network_api_api_init",
-      "community": 2,
+      "community": 6,
       "norm_label": ".__init__()"
     },
     {
@@ -648,7 +648,7 @@
       "source_file": "maria_cacau/core/network/api.py",
       "source_location": "L21",
       "id": "network_api_path",
-      "community": 2,
+      "community": 6,
       "norm_label": "path()"
     },
     {
@@ -657,7 +657,7 @@
       "source_file": "maria_cacau/core/network/api.py",
       "source_location": "L25",
       "id": "network_api_call",
-      "community": 3,
+      "community": 7,
       "norm_label": "call()"
     },
     {
@@ -666,7 +666,7 @@
       "source_file": "maria_cacau/core/network/api.py",
       "source_location": "L33",
       "id": "network_api_entity",
-      "community": 2,
+      "community": 6,
       "norm_label": "entity()"
     },
     {
@@ -674,7 +674,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/core/network/api.py",
       "source_location": "L1",
-      "community": 2,
+      "community": 6,
       "norm_label": "comunicacao alto nivel para chamadas de api",
       "id": "network_api_rationale_1"
     },
@@ -683,7 +683,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/core/network/api.py",
       "source_location": "L34",
-      "community": 2,
+      "community": 6,
       "norm_label": "o tipo precisa aceitar **kwargs (dataclass ou similar).",
       "id": "network_api_rationale_34"
     },
@@ -693,7 +693,7 @@
       "source_file": "maria_cacau/core/network/_client.py",
       "source_location": "L1",
       "id": "maria_cacau_core_network_client_py",
-      "community": 2,
+      "community": 6,
       "norm_label": "_client.py"
     },
     {
@@ -702,7 +702,7 @@
       "source_file": "maria_cacau/core/network/_client.py",
       "source_location": "L11",
       "id": "network_client_httpclientcontract",
-      "community": 2,
+      "community": 6,
       "norm_label": "httpclientcontract"
     },
     {
@@ -711,7 +711,7 @@
       "source_file": "",
       "source_location": "",
       "id": "protocol",
-      "community": 8,
+      "community": 9,
       "norm_label": "protocol"
     },
     {
@@ -720,7 +720,7 @@
       "source_file": "maria_cacau/core/network/_client.py",
       "source_location": "L13",
       "id": "network_client_httpclientcontract_execute",
-      "community": 2,
+      "community": 6,
       "norm_label": ".execute()"
     },
     {
@@ -729,7 +729,7 @@
       "source_file": "maria_cacau/core/network/_client.py",
       "source_location": "L18",
       "id": "network_client_localclient",
-      "community": 2,
+      "community": 6,
       "norm_label": "localclient"
     },
     {
@@ -738,7 +738,7 @@
       "source_file": "maria_cacau/core/network/_client.py",
       "source_location": "L23",
       "id": "network_client_localclient_init",
-      "community": 2,
+      "community": 6,
       "norm_label": ".__init__()"
     },
     {
@@ -747,7 +747,7 @@
       "source_file": "maria_cacau/core/network/_client.py",
       "source_location": "L26",
       "id": "network_client_localclient_execute",
-      "community": 2,
+      "community": 6,
       "norm_label": ".execute()"
     },
     {
@@ -755,7 +755,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/core/network/_client.py",
       "source_location": "L1",
-      "community": 2,
+      "community": 6,
       "norm_label": "realiza as request de fato",
       "id": "network_client_rationale_1"
     },
@@ -764,7 +764,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/core/network/_client.py",
       "source_location": "L12",
-      "community": 2,
+      "community": 6,
       "norm_label": "contrato que qualquer client precisa cumprir.",
       "id": "network_client_rationale_12"
     },
@@ -773,7 +773,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/core/network/_client.py",
       "source_location": "L19",
-      "community": 2,
+      "community": 6,
       "norm_label": "roteia requests para o backend local (in-process).     nenhuma rede envolvida \u2014",
       "id": "network_client_rationale_19"
     },
@@ -783,7 +783,7 @@
       "source_file": "maria_cacau/core/network/_config.py",
       "source_location": "L1",
       "id": "maria_cacau_core_network_config_py",
-      "community": 2,
+      "community": 6,
       "norm_label": "_config.py"
     },
     {
@@ -792,7 +792,7 @@
       "source_file": "maria_cacau/core/network/_config.py",
       "source_location": "L15",
       "id": "network_config_configure",
-      "community": 2,
+      "community": 6,
       "norm_label": "configure()"
     },
     {
@@ -801,7 +801,7 @@
       "source_file": "maria_cacau/core/network/_config.py",
       "source_location": "L20",
       "id": "network_config_override",
-      "community": 2,
+      "community": 6,
       "norm_label": "override()"
     },
     {
@@ -810,7 +810,7 @@
       "source_file": "maria_cacau/core/network/_config.py",
       "source_location": "L25",
       "id": "network_config_clear_override",
-      "community": 2,
+      "community": 6,
       "norm_label": "clear_override()"
     },
     {
@@ -819,7 +819,7 @@
       "source_file": "maria_cacau/core/network/_config.py",
       "source_location": "L30",
       "id": "network_config_get_client",
-      "community": 2,
+      "community": 6,
       "norm_label": "get_client()"
     },
     {
@@ -827,7 +827,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/core/network/_config.py",
       "source_location": "L1",
-      "community": 2,
+      "community": 6,
       "norm_label": "configuracoes globais para uso do modulo",
       "id": "network_config_rationale_1"
     },
@@ -836,7 +836,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/core/network/_config.py",
       "source_location": "L16",
-      "community": 2,
+      "community": 6,
       "norm_label": "configura o client ativo.",
       "id": "network_config_rationale_16"
     },
@@ -845,7 +845,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/core/network/_config.py",
       "source_location": "L21",
-      "community": 2,
+      "community": 6,
       "norm_label": "substitui o client \u2014 util para testes ou wiremock.",
       "id": "network_config_rationale_21"
     },
@@ -854,7 +854,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/core/network/_config.py",
       "source_location": "L26",
-      "community": 2,
+      "community": 6,
       "norm_label": "remove o override. volta ao client padrao.",
       "id": "network_config_rationale_26"
     },
@@ -863,7 +863,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/core/network/_config.py",
       "source_location": "L31",
-      "community": 2,
+      "community": 6,
       "norm_label": "retorna o client ativo (override se existir, padrao caso contrario).",
       "id": "network_config_rationale_31"
     },
@@ -873,7 +873,7 @@
       "source_file": "maria_cacau/core/storage/handler.py",
       "source_location": "L1",
       "id": "maria_cacau_core_storage_handler_py",
-      "community": 6,
+      "community": 3,
       "norm_label": "handler.py"
     },
     {
@@ -882,7 +882,7 @@
       "source_file": "maria_cacau/core/storage/handler.py",
       "source_location": "L9",
       "id": "storage_handler_storagehandler",
-      "community": 6,
+      "community": 3,
       "norm_label": "storagehandler"
     },
     {
@@ -891,7 +891,7 @@
       "source_file": "maria_cacau/core/storage/handler.py",
       "source_location": "L11",
       "id": "storage_handler_save",
-      "community": 6,
+      "community": 3,
       "norm_label": "save()"
     },
     {
@@ -900,7 +900,7 @@
       "source_file": "maria_cacau/core/storage/handler.py",
       "source_location": "L14",
       "id": "storage_handler_retrieve",
-      "community": 6,
+      "community": 3,
       "norm_label": "retrieve()"
     },
     {
@@ -909,7 +909,7 @@
       "source_file": "maria_cacau/core/storage/handler.py",
       "source_location": "L17",
       "id": "storage_handler_delete",
-      "community": 6,
+      "community": 3,
       "norm_label": "delete()"
     },
     {
@@ -918,7 +918,7 @@
       "source_file": "maria_cacau/core/storage/handler.py",
       "source_location": "L20",
       "id": "storage_handler_clean_all",
-      "community": 6,
+      "community": 3,
       "norm_label": "clean_all()"
     },
     {
@@ -926,7 +926,7 @@
       "file_type": "rationale",
       "source_file": "core/storage/handler.py",
       "source_location": "L1",
-      "community": 6,
+      "community": 3,
       "norm_label": "contrato base para todos os backends de armazenamento.",
       "id": "storage_handler_rationale_1"
     },
@@ -936,7 +936,7 @@
       "source_file": "maria_cacau/core/storage/security.py",
       "source_location": "L1",
       "id": "maria_cacau_core_storage_security_py",
-      "community": 6,
+      "community": 3,
       "norm_label": "security.py"
     },
     {
@@ -945,7 +945,7 @@
       "source_file": "maria_cacau/core/storage/security.py",
       "source_location": "L10",
       "id": "storage_security_securitystorage",
-      "community": 6,
+      "community": 3,
       "norm_label": "securitystorage"
     },
     {
@@ -954,7 +954,7 @@
       "source_file": "maria_cacau/core/storage/security.py",
       "source_location": "L11",
       "id": "storage_security_securitystorage_init",
-      "community": 6,
+      "community": 3,
       "norm_label": ".__init__()"
     },
     {
@@ -963,7 +963,7 @@
       "source_file": "maria_cacau/core/storage/security.py",
       "source_location": "L15",
       "id": "storage_security_securitystorage_save",
-      "community": 6,
+      "community": 3,
       "norm_label": ".save()"
     },
     {
@@ -972,7 +972,7 @@
       "source_file": "maria_cacau/core/storage/security.py",
       "source_location": "L23",
       "id": "storage_security_securitystorage_retrieve",
-      "community": 6,
+      "community": 3,
       "norm_label": ".retrieve()"
     },
     {
@@ -981,7 +981,7 @@
       "source_file": "maria_cacau/core/storage/security.py",
       "source_location": "L29",
       "id": "storage_security_securitystorage_delete",
-      "community": 6,
+      "community": 3,
       "norm_label": ".delete()"
     },
     {
@@ -990,7 +990,7 @@
       "source_file": "maria_cacau/core/storage/security.py",
       "source_location": "L36",
       "id": "storage_security_securitystorage_clean_all",
-      "community": 6,
+      "community": 3,
       "norm_label": ".clean_all()"
     },
     {
@@ -999,7 +999,7 @@
       "source_file": "maria_cacau/core/storage/security.py",
       "source_location": "L40",
       "id": "storage_security_securitystorage_path",
-      "community": 6,
+      "community": 3,
       "norm_label": "._path()"
     },
     {
@@ -1007,7 +1007,7 @@
       "file_type": "rationale",
       "source_file": "core/storage/security.py",
       "source_location": "L1",
-      "community": 6,
+      "community": 3,
       "norm_label": "backend de armazenamento seguro via arquivo protegido no diretorio do usuario.",
       "id": "storage_security_rationale_1"
     },
@@ -1017,7 +1017,7 @@
       "source_file": "maria_cacau/core/storage/cache.py",
       "source_location": "L1",
       "id": "maria_cacau_core_storage_cache_py",
-      "community": 12,
+      "community": 3,
       "norm_label": "cache.py"
     },
     {
@@ -1026,7 +1026,7 @@
       "source_file": "maria_cacau/core/storage/cache.py",
       "source_location": "L10",
       "id": "storage_cache_cachestorage",
-      "community": 12,
+      "community": 3,
       "norm_label": "cachestorage"
     },
     {
@@ -1035,7 +1035,7 @@
       "source_file": "maria_cacau/core/storage/cache.py",
       "source_location": "L11",
       "id": "storage_cache_cachestorage_init",
-      "community": 12,
+      "community": 3,
       "norm_label": ".__init__()"
     },
     {
@@ -1044,7 +1044,7 @@
       "source_file": "maria_cacau/core/storage/cache.py",
       "source_location": "L15",
       "id": "storage_cache_cachestorage_save",
-      "community": 12,
+      "community": 3,
       "norm_label": ".save()"
     },
     {
@@ -1053,7 +1053,7 @@
       "source_file": "maria_cacau/core/storage/cache.py",
       "source_location": "L21",
       "id": "storage_cache_cachestorage_retrieve",
-      "community": 12,
+      "community": 3,
       "norm_label": ".retrieve()"
     },
     {
@@ -1062,7 +1062,7 @@
       "source_file": "maria_cacau/core/storage/cache.py",
       "source_location": "L30",
       "id": "storage_cache_cachestorage_delete",
-      "community": 12,
+      "community": 3,
       "norm_label": ".delete()"
     },
     {
@@ -1071,7 +1071,7 @@
       "source_file": "maria_cacau/core/storage/cache.py",
       "source_location": "L37",
       "id": "storage_cache_cachestorage_clean_all",
-      "community": 12,
+      "community": 3,
       "norm_label": ".clean_all()"
     },
     {
@@ -1080,7 +1080,7 @@
       "source_file": "maria_cacau/core/storage/cache.py",
       "source_location": "L41",
       "id": "storage_cache_cachestorage_path",
-      "community": 12,
+      "community": 3,
       "norm_label": "._path()"
     },
     {
@@ -1088,7 +1088,7 @@
       "file_type": "rationale",
       "source_file": "core/storage/cache.py",
       "source_location": "L1",
-      "community": 12,
+      "community": 3,
       "norm_label": "backend de cache em arquivo json no diretorio do usuario.",
       "id": "storage_cache_rationale_1"
     },
@@ -1098,7 +1098,7 @@
       "source_file": "maria_cacau/core/storage/__init__.py",
       "source_location": "L1",
       "id": "maria_cacau_core_storage_init_py",
-      "community": 19,
+      "community": 18,
       "norm_label": "__init__.py"
     },
     {
@@ -1107,7 +1107,7 @@
       "source_file": "maria_cacau/core/error/models.py",
       "source_location": "L1",
       "id": "maria_cacau_core_error_models_py",
-      "community": 11,
+      "community": 12,
       "norm_label": "models.py"
     },
     {
@@ -1116,7 +1116,7 @@
       "source_file": "maria_cacau/core/error/models.py",
       "source_location": "L7",
       "id": "error_models_errormodel",
-      "community": 11,
+      "community": 12,
       "norm_label": "errormodel"
     },
     {
@@ -1125,7 +1125,7 @@
       "source_file": "maria_cacau/core/error/models.py",
       "source_location": "L12",
       "id": "error_models_errormodel_post_init",
-      "community": 0,
+      "community": 5,
       "norm_label": ".__post_init__()"
     },
     {
@@ -1134,7 +1134,7 @@
       "source_file": "maria_cacau/core/error/models.py",
       "source_location": "L16",
       "id": "error_models_from_error",
-      "community": 11,
+      "community": 12,
       "norm_label": "from_error()"
     },
     {
@@ -1143,7 +1143,7 @@
       "source_file": "maria_cacau/core/error/models.py",
       "source_location": "L23",
       "id": "error_models_errormodel_to_popup",
-      "community": 5,
+      "community": 1,
       "norm_label": ".to_popup()"
     },
     {
@@ -1152,7 +1152,7 @@
       "source_file": "maria_cacau/core/error/__init__.py",
       "source_location": "L1",
       "id": "maria_cacau_core_error_init_py",
-      "community": 11,
+      "community": 12,
       "norm_label": "__init__.py"
     },
     {
@@ -1161,7 +1161,7 @@
       "source_file": "maria_cacau/core/error/errors.py",
       "source_location": "L1",
       "id": "maria_cacau_core_error_errors_py",
-      "community": 11,
+      "community": 12,
       "norm_label": "errors.py"
     },
     {
@@ -1170,7 +1170,7 @@
       "source_file": "maria_cacau/core/error/errors.py",
       "source_location": "L8",
       "id": "error_errors_apperror",
-      "community": 11,
+      "community": 12,
       "norm_label": "apperror"
     },
     {
@@ -1179,7 +1179,7 @@
       "source_file": "",
       "source_location": "",
       "id": "namedtuple",
-      "community": 11,
+      "community": 12,
       "norm_label": "namedtuple"
     },
     {
@@ -1188,7 +1188,7 @@
       "source_file": "maria_cacau/core/error/errors.py",
       "source_location": "L104",
       "id": "error_errors_certificado_ok",
-      "community": 11,
+      "community": 12,
       "norm_label": "certificado_ok()"
     },
     {
@@ -1197,7 +1197,7 @@
       "source_file": "maria_cacau/core/error/errors.py",
       "source_location": "L113",
       "id": "error_errors_certificado_limpo",
-      "community": 11,
+      "community": 12,
       "norm_label": "certificado_limpo()"
     },
     {
@@ -1206,7 +1206,7 @@
       "source_file": "maria_cacau/core/error/errors.py",
       "source_location": "L122",
       "id": "error_errors_planilha_conectada",
-      "community": 11,
+      "community": 12,
       "norm_label": "planilha_conectada()"
     },
     {
@@ -1215,7 +1215,7 @@
       "source_file": "maria_cacau/core/error/errors.py",
       "source_location": "L131",
       "id": "error_errors_unexpected_error",
-      "community": 11,
+      "community": 4,
       "norm_label": "unexpected_error()"
     },
     {
@@ -1224,7 +1224,7 @@
       "source_file": "maria_cacau/core/error/errors.py",
       "source_location": "L140",
       "id": "error_errors_http_error",
-      "community": 11,
+      "community": 12,
       "norm_label": "http_error()"
     },
     {
@@ -1233,7 +1233,7 @@
       "source_file": "maria_cacau/core/error/errors.py",
       "source_location": "L149",
       "id": "error_errors_planilha_ok",
-      "community": 11,
+      "community": 12,
       "norm_label": "planilha_ok()"
     },
     {
@@ -1241,7 +1241,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/core/error/errors.py",
       "source_location": "L1",
-      "community": 11,
+      "community": 12,
       "norm_label": "codigos de erro da aplicacao com estrutura apperror.",
       "id": "error_errors_rationale_1"
     },
@@ -1250,7 +1250,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/core/error/errors.py",
       "source_location": "L9",
-      "community": 11,
+      "community": 12,
       "norm_label": "estrutura de uma mensagem de erro/info para exibicao no popup.",
       "id": "error_errors_rationale_9"
     },
@@ -1259,7 +1259,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/core/error/errors.py",
       "source_location": "L105",
-      "community": 11,
+      "community": 12,
       "norm_label": "confirmacao de certificado configurado com sucesso.",
       "id": "error_errors_rationale_105"
     },
@@ -1268,7 +1268,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/core/error/errors.py",
       "source_location": "L114",
-      "community": 11,
+      "community": 12,
       "norm_label": "confirmacao de credenciais removidas com sucesso.",
       "id": "error_errors_rationale_114"
     },
@@ -1277,7 +1277,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/core/error/errors.py",
       "source_location": "L123",
-      "community": 11,
+      "community": 12,
       "norm_label": "confirmacao de planilha selecionada com sucesso.",
       "id": "error_errors_rationale_123"
     },
@@ -1286,7 +1286,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/core/error/errors.py",
       "source_location": "L132",
-      "community": 11,
+      "community": 4,
       "norm_label": "erro generico para excecoes nao tratadas.",
       "id": "error_errors_rationale_132"
     },
@@ -1295,7 +1295,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/core/error/errors.py",
       "source_location": "L141",
-      "community": 11,
+      "community": 12,
       "norm_label": "erro http sem body json \u2014 resposta de erro nao estruturada do servidor.",
       "id": "error_errors_rationale_141"
     },
@@ -1304,7 +1304,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/core/error/errors.py",
       "source_location": "L150",
-      "community": 11,
+      "community": 12,
       "norm_label": "confirmacao de leitura bem-sucedida da planilha.",
       "id": "error_errors_rationale_150"
     },
@@ -1314,7 +1314,7 @@
       "source_file": "maria_cacau/app/coordinator.py",
       "source_location": "L1",
       "id": "maria_cacau_app_coordinator_py",
-      "community": 2,
+      "community": 4,
       "norm_label": "coordinator.py"
     },
     {
@@ -1323,7 +1323,7 @@
       "source_file": "maria_cacau/app/coordinator.py",
       "source_location": "L16",
       "id": "app_coordinator_appcoordinator",
-      "community": 2,
+      "community": 4,
       "norm_label": "appcoordinator"
     },
     {
@@ -1332,7 +1332,7 @@
       "source_file": "maria_cacau/app/coordinator.py",
       "source_location": "L17",
       "id": "app_coordinator_appcoordinator_init",
-      "community": 2,
+      "community": 4,
       "norm_label": ".__init__()"
     },
     {
@@ -1341,7 +1341,7 @@
       "source_file": "maria_cacau/app/coordinator.py",
       "source_location": "L23",
       "id": "app_coordinator_appcoordinator_launch",
-      "community": 2,
+      "community": 4,
       "norm_label": ".launch()"
     },
     {
@@ -1350,7 +1350,7 @@
       "source_file": "maria_cacau/app/coordinator.py",
       "source_location": "L29",
       "id": "app_coordinator_appcoordinator_configure_app",
-      "community": 2,
+      "community": 4,
       "norm_label": "._configure_app()"
     },
     {
@@ -1359,7 +1359,7 @@
       "source_file": "maria_cacau/app/coordinator.py",
       "source_location": "L34",
       "id": "app_coordinator_appcoordinator_on_launch",
-      "community": 2,
+      "community": 4,
       "norm_label": "._on_launch()"
     },
     {
@@ -1368,7 +1368,7 @@
       "source_file": "maria_cacau/app/coordinator.py",
       "source_location": "L37",
       "id": "app_coordinator_appcoordinator_initialize",
-      "community": 3,
+      "community": 7,
       "norm_label": "._initialize()"
     },
     {
@@ -1377,7 +1377,7 @@
       "source_file": "maria_cacau/app/coordinator.py",
       "source_location": "L44",
       "id": "app_coordinator_appcoordinator_on_quit",
-      "community": 2,
+      "community": 4,
       "norm_label": "._on_quit()"
     },
     {
@@ -1386,7 +1386,7 @@
       "source_file": "maria_cacau/app/handler.py",
       "source_location": "L1",
       "id": "maria_cacau_app_handler_py",
-      "community": 14,
+      "community": 4,
       "norm_label": "handler.py"
     },
     {
@@ -1395,7 +1395,7 @@
       "source_file": "maria_cacau/app/handler.py",
       "source_location": "L10",
       "id": "app_handler_menuhandler",
-      "community": 14,
+      "community": 4,
       "norm_label": "menuhandler"
     },
     {
@@ -1404,7 +1404,7 @@
       "source_file": "maria_cacau/app/handler.py",
       "source_location": "L11",
       "id": "app_handler_menuhandler_init",
-      "community": 14,
+      "community": 4,
       "norm_label": ".__init__()"
     },
     {
@@ -1413,7 +1413,7 @@
       "source_file": "maria_cacau/app/handler.py",
       "source_location": "L15",
       "id": "app_handler_menuhandler_setup_menus",
-      "community": 14,
+      "community": 4,
       "norm_label": ".setup_menus()"
     },
     {
@@ -1422,7 +1422,7 @@
       "source_file": "maria_cacau/app/handler.py",
       "source_location": "L20",
       "id": "app_handler_menuhandler_create_help_menu",
-      "community": 14,
+      "community": 4,
       "norm_label": "._create_help_menu()"
     },
     {
@@ -1431,7 +1431,7 @@
       "source_file": "maria_cacau/app/window.py",
       "source_location": "L1",
       "id": "maria_cacau_app_window_py",
-      "community": 14,
+      "community": 4,
       "norm_label": "window.py"
     },
     {
@@ -1440,7 +1440,7 @@
       "source_file": "maria_cacau/app/window.py",
       "source_location": "L12",
       "id": "app_window_mainwindow",
-      "community": 14,
+      "community": 4,
       "norm_label": "mainwindow"
     },
     {
@@ -1449,7 +1449,7 @@
       "source_file": "",
       "source_location": "",
       "id": "qmainwindow",
-      "community": 14,
+      "community": 4,
       "norm_label": "qmainwindow"
     },
     {
@@ -1458,7 +1458,7 @@
       "source_file": "maria_cacau/app/window.py",
       "source_location": "L13",
       "id": "app_window_mainwindow_init",
-      "community": 14,
+      "community": 4,
       "norm_label": ".__init__()"
     },
     {
@@ -1467,7 +1467,7 @@
       "source_file": "maria_cacau/app/window.py",
       "source_location": "L21",
       "id": "app_window_mainwindow_setup_window",
-      "community": 14,
+      "community": 4,
       "norm_label": "._setup_window()"
     },
     {
@@ -1476,7 +1476,7 @@
       "source_file": "maria_cacau/app/window.py",
       "source_location": "L31",
       "id": "app_window_mainwindow_setup_menus",
-      "community": 14,
+      "community": 4,
       "norm_label": "._setup_menus()"
     },
     {
@@ -1485,7 +1485,7 @@
       "source_file": "maria_cacau/app/__init__.py",
       "source_location": "L1",
       "id": "maria_cacau_app_init_py",
-      "community": 2,
+      "community": 4,
       "norm_label": "__init__.py"
     },
     {
@@ -1494,7 +1494,7 @@
       "source_file": "maria_cacau/design_system/gui_popup.py",
       "source_location": "L1",
       "id": "maria_cacau_design_system_gui_popup_py",
-      "community": 10,
+      "community": 8,
       "norm_label": "gui_popup.py"
     },
     {
@@ -1503,7 +1503,7 @@
       "source_file": "maria_cacau/design_system/gui_popup.py",
       "source_location": "L12",
       "id": "design_system_gui_popup_popupicon",
-      "community": 10,
+      "community": 8,
       "norm_label": "popupicon"
     },
     {
@@ -1512,7 +1512,7 @@
       "source_file": "maria_cacau/design_system/gui_popup.py",
       "source_location": "L19",
       "id": "design_system_gui_popup_popupmodel",
-      "community": 10,
+      "community": 8,
       "norm_label": "popupmodel"
     },
     {
@@ -1521,7 +1521,7 @@
       "source_file": "maria_cacau/design_system/gui_popup.py",
       "source_location": "L26",
       "id": "design_system_gui_popup_guipopup",
-      "community": 0,
+      "community": 1,
       "norm_label": "guipopup"
     },
     {
@@ -1530,7 +1530,7 @@
       "source_file": "",
       "source_location": "",
       "id": "qmessagebox",
-      "community": 0,
+      "community": 1,
       "norm_label": "qmessagebox"
     },
     {
@@ -1539,7 +1539,7 @@
       "source_file": "maria_cacau/design_system/gui_popup.py",
       "source_location": "L28",
       "id": "design_system_gui_popup_guipopup_init",
-      "community": 0,
+      "community": 1,
       "norm_label": ".__init__()"
     },
     {
@@ -1548,7 +1548,7 @@
       "source_file": "maria_cacau/design_system/gui_popup.py",
       "source_location": "L33",
       "id": "design_system_gui_popup_guipopup_setup_ui",
-      "community": 0,
+      "community": 1,
       "norm_label": ".setup_ui()"
     },
     {
@@ -1557,7 +1557,7 @@
       "source_file": "maria_cacau/design_system/gui_popup.py",
       "source_location": "L44",
       "id": "design_system_gui_popup_guipopup_show",
-      "community": 5,
+      "community": 1,
       "norm_label": ".show()"
     },
     {
@@ -1565,7 +1565,7 @@
       "file_type": "rationale",
       "source_file": "design_system/gui_popup.py",
       "source_location": "L1",
-      "community": 10,
+      "community": 8,
       "norm_label": "janela de popup para exibicao de erros e informacoes ao usuario.",
       "id": "design_system_gui_popup_rationale_1"
     },
@@ -1575,7 +1575,7 @@
       "source_file": "maria_cacau/design_system/__init__.py",
       "source_location": "L1",
       "id": "maria_cacau_design_system_init_py",
-      "community": 20,
+      "community": 19,
       "norm_label": "__init__.py"
     },
     {
@@ -1584,7 +1584,7 @@
       "source_file": "maria_cacau/design_system/aux_frames.py",
       "source_location": "L1",
       "id": "maria_cacau_design_system_aux_frames_py",
-      "community": 0,
+      "community": 5,
       "norm_label": "aux_frames.py"
     },
     {
@@ -1593,7 +1593,7 @@
       "source_file": "maria_cacau/design_system/aux_frames.py",
       "source_location": "L8",
       "id": "design_system_aux_frames_auxframe",
-      "community": 0,
+      "community": 5,
       "norm_label": "auxframe"
     },
     {
@@ -1602,7 +1602,7 @@
       "source_file": "",
       "source_location": "",
       "id": "qframe",
-      "community": 0,
+      "community": 5,
       "norm_label": "qframe"
     },
     {
@@ -1611,7 +1611,7 @@
       "source_file": "",
       "source_location": "",
       "id": "auxwidgets",
-      "community": 0,
+      "community": 5,
       "norm_label": "auxwidgets"
     },
     {
@@ -1620,7 +1620,7 @@
       "source_file": "maria_cacau/design_system/aux_frames.py",
       "source_location": "L10",
       "id": "design_system_aux_frames_auxframe_init",
-      "community": 0,
+      "community": 5,
       "norm_label": ".__init__()"
     },
     {
@@ -1629,7 +1629,7 @@
       "source_file": "maria_cacau/design_system/aux_frames.py",
       "source_location": "L15",
       "id": "design_system_aux_frames_auxframe_setup_ui",
-      "community": 0,
+      "community": 5,
       "norm_label": ".setup_ui()"
     },
     {
@@ -1638,7 +1638,7 @@
       "source_file": "maria_cacau/design_system/aux_frames.py",
       "source_location": "L28",
       "id": "design_system_aux_frames_auxframe_bt_action",
-      "community": 0,
+      "community": 5,
       "norm_label": ".bt_action()"
     },
     {
@@ -1647,7 +1647,7 @@
       "source_file": "maria_cacau/design_system/aux_frames.py",
       "source_location": "L33",
       "id": "design_system_aux_frames_auxframe_get_text",
-      "community": 0,
+      "community": 5,
       "norm_label": ".get_text()"
     },
     {
@@ -1656,7 +1656,7 @@
       "source_file": "maria_cacau/design_system/aux_frames.py",
       "source_location": "L36",
       "id": "design_system_aux_frames_auxframe_set_text",
-      "community": 0,
+      "community": 5,
       "norm_label": ".set_text()"
     },
     {
@@ -1664,7 +1664,7 @@
       "file_type": "rationale",
       "source_file": "design_system/aux_frames.py",
       "source_location": "L1",
-      "community": 0,
+      "community": 5,
       "norm_label": "frame composto reutilizavel com label, entrada de texto e botao de copia.",
       "id": "design_system_aux_frames_rationale_1"
     },
@@ -1674,7 +1674,7 @@
       "source_file": "maria_cacau/design_system/aux_widgets.py",
       "source_location": "L1",
       "id": "maria_cacau_design_system_aux_widgets_py",
-      "community": 0,
+      "community": 1,
       "norm_label": "aux_widgets.py"
     },
     {
@@ -1683,7 +1683,7 @@
       "source_file": "maria_cacau/design_system/aux_widgets.py",
       "source_location": "L9",
       "id": "design_system_aux_widgets_auxwidgets",
-      "community": 0,
+      "community": 1,
       "norm_label": "auxwidgets"
     },
     {
@@ -1692,7 +1692,7 @@
       "source_file": "maria_cacau/design_system/aux_widgets.py",
       "source_location": "L11",
       "id": "design_system_aux_widgets_auxwidgets_init",
-      "community": 0,
+      "community": 1,
       "norm_label": ".__init__()"
     },
     {
@@ -1701,7 +1701,7 @@
       "source_file": "maria_cacau/design_system/aux_widgets.py",
       "source_location": "L15",
       "id": "design_system_aux_widgets_auxwidgets_lbl",
-      "community": 0,
+      "community": 5,
       "norm_label": ".lbl()"
     },
     {
@@ -1710,7 +1710,7 @@
       "source_file": "maria_cacau/design_system/aux_widgets.py",
       "source_location": "L23",
       "id": "design_system_aux_widgets_auxwidgets_bts",
-      "community": 0,
+      "community": 1,
       "norm_label": ".bts()"
     },
     {
@@ -1719,7 +1719,7 @@
       "source_file": "maria_cacau/design_system/aux_widgets.py",
       "source_location": "L29",
       "id": "design_system_aux_widgets_auxwidgets_button_img",
-      "community": 0,
+      "community": 5,
       "norm_label": ".button_img()"
     },
     {
@@ -1728,7 +1728,7 @@
       "source_file": "maria_cacau/design_system/aux_widgets.py",
       "source_location": "L37",
       "id": "design_system_aux_widgets_auxwidgets_line_edit",
-      "community": 0,
+      "community": 5,
       "norm_label": ".line_edit()"
     },
     {
@@ -1737,7 +1737,7 @@
       "source_file": "maria_cacau/design_system/aux_widgets.py",
       "source_location": "L45",
       "id": "design_system_aux_widgets_auxwidgets_text_view",
-      "community": 0,
+      "community": 1,
       "norm_label": ".text_view()"
     },
     {
@@ -1746,7 +1746,7 @@
       "source_file": "maria_cacau/design_system/aux_widgets.py",
       "source_location": "L51",
       "id": "design_system_aux_widgets_auxwidgets_graph_view",
-      "community": 0,
+      "community": 1,
       "norm_label": ".graph_view()"
     },
     {
@@ -1755,7 +1755,7 @@
       "source_file": "maria_cacau/design_system/aux_widgets.py",
       "source_location": "L57",
       "id": "design_system_aux_widgets_auxwidgets_group_box",
-      "community": 0,
+      "community": 5,
       "norm_label": ".group_box()"
     },
     {
@@ -1764,7 +1764,7 @@
       "source_file": "maria_cacau/design_system/aux_widgets.py",
       "source_location": "L76",
       "id": "design_system_aux_widgets_auxwidgets_combo_box",
-      "community": 0,
+      "community": 1,
       "norm_label": ".combo_box()"
     },
     {
@@ -1773,7 +1773,7 @@
       "source_file": "maria_cacau/design_system/aux_widgets.py",
       "source_location": "L84",
       "id": "design_system_aux_widgets_auxwidgets_fix_date",
-      "community": 0,
+      "community": 1,
       "norm_label": ".fix_date()"
     },
     {
@@ -1782,7 +1782,7 @@
       "source_file": "maria_cacau/design_system/aux_widgets.py",
       "source_location": "L87",
       "id": "design_system_aux_widgets_auxwidgets_on_copy",
-      "community": 0,
+      "community": 1,
       "norm_label": ".on_copy()"
     },
     {
@@ -1790,7 +1790,7 @@
       "file_type": "rationale",
       "source_file": "design_system/aux_widgets.py",
       "source_location": "L1",
-      "community": 0,
+      "community": 1,
       "norm_label": "factory de widgets pyqt6 reutilizaveis em toda a interface.",
       "id": "design_system_aux_widgets_rationale_1"
     },
@@ -1800,7 +1800,7 @@
       "source_file": "maria_cacau/features/__init__.py",
       "source_location": "L1",
       "id": "maria_cacau_features_init_py",
-      "community": 21,
+      "community": 20,
       "norm_label": "__init__.py"
     },
     {
@@ -1809,7 +1809,7 @@
       "source_file": "maria_cacau/features/home/__init__.py",
       "source_location": "L1",
       "id": "maria_cacau_features_home_init_py",
-      "community": 22,
+      "community": 21,
       "norm_label": "__init__.py"
     },
     {
@@ -1818,7 +1818,7 @@
       "source_file": "maria_cacau/features/home/source/controller.py",
       "source_location": "L1",
       "id": "maria_cacau_features_home_source_controller_py",
-      "community": 16,
+      "community": 5,
       "norm_label": "controller.py"
     },
     {
@@ -1827,7 +1827,7 @@
       "source_file": "maria_cacau/features/home/source/controller.py",
       "source_location": "L8",
       "id": "source_controller_homecontroller",
-      "community": 16,
+      "community": 5,
       "norm_label": "homecontroller"
     },
     {
@@ -1836,7 +1836,7 @@
       "source_file": "maria_cacau/features/home/source/controller.py",
       "source_location": "L9",
       "id": "source_controller_homecontroller_init",
-      "community": 16,
+      "community": 5,
       "norm_label": ".__init__()"
     },
     {
@@ -1845,7 +1845,7 @@
       "source_file": "maria_cacau/features/home/source/controller.py",
       "source_location": "L17",
       "id": "source_controller_homecontroller_setup_view",
-      "community": 16,
+      "community": 5,
       "norm_label": ".setup_view()"
     },
     {
@@ -1854,7 +1854,7 @@
       "source_file": "maria_cacau/features/home/source/models.py",
       "source_location": "L1",
       "id": "maria_cacau_features_home_source_models_py",
-      "community": 16,
+      "community": 5,
       "norm_label": "models.py"
     },
     {
@@ -1863,7 +1863,7 @@
       "source_file": "maria_cacau/features/home/source/models.py",
       "source_location": "L7",
       "id": "source_models_homefeaturesmodel",
-      "community": 16,
+      "community": 5,
       "norm_label": "homefeaturesmodel"
     },
     {
@@ -1872,7 +1872,7 @@
       "source_file": "maria_cacau/features/home/source/__init__.py",
       "source_location": "L1",
       "id": "maria_cacau_features_home_source_init_py",
-      "community": 16,
+      "community": 5,
       "norm_label": "__init__.py"
     },
     {
@@ -1881,7 +1881,7 @@
       "source_file": "maria_cacau/features/home/source/view.py",
       "source_location": "L1",
       "id": "maria_cacau_features_home_source_view_py",
-      "community": 16,
+      "community": 5,
       "norm_label": "view.py"
     },
     {
@@ -1890,7 +1890,7 @@
       "source_file": "maria_cacau/features/home/source/view.py",
       "source_location": "L7",
       "id": "source_view_homeview",
-      "community": 16,
+      "community": 5,
       "norm_label": "homeview"
     },
     {
@@ -1899,7 +1899,7 @@
       "source_file": "maria_cacau/features/home/source/view.py",
       "source_location": "L8",
       "id": "source_view_homeview_init",
-      "community": 16,
+      "community": 5,
       "norm_label": ".__init__()"
     },
     {
@@ -1908,7 +1908,7 @@
       "source_file": "maria_cacau/features/home/source/view.py",
       "source_location": "L12",
       "id": "source_view_homeview_paintevent",
-      "community": 16,
+      "community": 5,
       "norm_label": ".paintevent()"
     },
     {
@@ -1917,7 +1917,7 @@
       "source_file": "maria_cacau/features/home/source/view.py",
       "source_location": "L16",
       "id": "source_view_homeview_setup_layout",
-      "community": 16,
+      "community": 5,
       "norm_label": ".setup_layout()"
     },
     {
@@ -1926,7 +1926,7 @@
       "source_file": "maria_cacau/features/home/sub_features/__init__.py",
       "source_location": "L1",
       "id": "maria_cacau_features_home_sub_features_init_py",
-      "community": 23,
+      "community": 22,
       "norm_label": "__init__.py"
     },
     {
@@ -1935,7 +1935,7 @@
       "source_file": "maria_cacau/features/home/sub_features/cpf_validation/__init__.py",
       "source_location": "L1",
       "id": "maria_cacau_features_home_sub_features_cpf_validation_init_py",
-      "community": 24,
+      "community": 23,
       "norm_label": "__init__.py"
     },
     {
@@ -1944,7 +1944,7 @@
       "source_file": "maria_cacau/features/home/sub_features/cpf_validation/domain/use_case.py",
       "source_location": "L1",
       "id": "maria_cacau_features_home_sub_features_cpf_validation_domain_use_case_py",
-      "community": 4,
+      "community": 11,
       "norm_label": "use_case.py"
     },
     {
@@ -1953,7 +1953,7 @@
       "source_file": "maria_cacau/features/home/sub_features/cpf_validation/domain/use_case.py",
       "source_location": "L6",
       "id": "domain_use_case_is_valid_cpf",
-      "community": 4,
+      "community": 11,
       "norm_label": "_is_valid_cpf()"
     },
     {
@@ -1962,7 +1962,7 @@
       "source_file": "maria_cacau/features/home/sub_features/cpf_validation/domain/use_case.py",
       "source_location": "L29",
       "id": "domain_use_case_cpfvalidationusecase",
-      "community": 4,
+      "community": 11,
       "norm_label": "cpfvalidationusecase"
     },
     {
@@ -1971,7 +1971,7 @@
       "source_file": "maria_cacau/features/home/sub_features/cpf_validation/domain/use_case.py",
       "source_location": "L30",
       "id": "domain_use_case_cpfvalidationusecase_validate",
-      "community": 4,
+      "community": 11,
       "norm_label": ".validate()"
     },
     {
@@ -1979,7 +1979,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/features/home/sub_features/delivery/domain/use_case.py",
       "source_location": "L1",
-      "community": 3,
+      "community": 2,
       "norm_label": "caso de uso: busca e consolida entregas e pagamentos pendentes para uma data.",
       "id": "domain_use_case_rationale_1"
     },
@@ -1988,7 +1988,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/features/home/sub_features/cpf_validation/domain/use_case.py",
       "source_location": "L7",
-      "community": 4,
+      "community": 11,
       "norm_label": "valida um cpf pela regra dos dois digitos verificadores (algoritmo da receita fe",
       "id": "domain_use_case_rationale_7"
     },
@@ -1998,7 +1998,7 @@
       "source_file": "maria_cacau/features/home/sub_features/cpf_validation/domain/signals.py",
       "source_location": "L1",
       "id": "maria_cacau_features_home_sub_features_cpf_validation_domain_signals_py",
-      "community": 4,
+      "community": 11,
       "norm_label": "signals.py"
     },
     {
@@ -2007,7 +2007,7 @@
       "source_file": "maria_cacau/features/home/sub_features/cpf_validation/domain/signals.py",
       "source_location": "L8",
       "id": "domain_signals_cpfvalidationsignals",
-      "community": 4,
+      "community": 11,
       "norm_label": "cpfvalidationsignals"
     },
     {
@@ -2015,7 +2015,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/features/home/sub_features/delivery/domain/signals.py",
       "source_location": "L1",
-      "community": 4,
+      "community": 8,
       "norm_label": "sinais compartilhados dentro do modulo",
       "id": "domain_signals_rationale_1"
     },
@@ -2025,7 +2025,7 @@
       "source_file": "maria_cacau/features/home/sub_features/cpf_validation/domain/models.py",
       "source_location": "L1",
       "id": "maria_cacau_features_home_sub_features_cpf_validation_domain_models_py",
-      "community": 4,
+      "community": 11,
       "norm_label": "models.py"
     },
     {
@@ -2034,7 +2034,7 @@
       "source_file": "maria_cacau/features/home/sub_features/cpf_validation/domain/models.py",
       "source_location": "L7",
       "id": "domain_models_cpfvalidationresult",
-      "community": 4,
+      "community": 11,
       "norm_label": "cpfvalidationresult"
     },
     {
@@ -2042,7 +2042,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/features/home/sub_features/delivery/domain/models.py",
       "source_location": "L1",
-      "community": 4,
+      "community": 11,
       "norm_label": "models utilizados no modulo",
       "id": "domain_models_rationale_1"
     },
@@ -2052,7 +2052,7 @@
       "source_file": "maria_cacau/features/home/sub_features/cpf_validation/domain/events.py",
       "source_location": "L1",
       "id": "maria_cacau_features_home_sub_features_cpf_validation_domain_events_py",
-      "community": 10,
+      "community": 8,
       "norm_label": "events.py"
     },
     {
@@ -2061,7 +2061,7 @@
       "source_file": "maria_cacau/features/auth/domain/events.py",
       "source_location": "L6",
       "id": "domain_events_featureevents",
-      "community": 10,
+      "community": 8,
       "norm_label": "featureevents"
     },
     {
@@ -2069,7 +2069,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/features/home/sub_features/delivery/domain/events.py",
       "source_location": "L1",
-      "community": 10,
+      "community": 8,
       "norm_label": "eventos relacionados as entregas pendentes.",
       "id": "domain_events_rationale_1"
     },
@@ -2079,7 +2079,7 @@
       "source_file": "maria_cacau/features/home/sub_features/cpf_validation/domain/__init__.py",
       "source_location": "L1",
       "id": "maria_cacau_features_home_sub_features_cpf_validation_domain_init_py",
-      "community": 4,
+      "community": 11,
       "norm_label": "__init__.py"
     },
     {
@@ -2088,7 +2088,7 @@
       "source_file": "maria_cacau/features/home/sub_features/cpf_validation/presentation/controller.py",
       "source_location": "L1",
       "id": "maria_cacau_features_home_sub_features_cpf_validation_presentation_controller_py",
-      "community": 4,
+      "community": 11,
       "norm_label": "controller.py"
     },
     {
@@ -2097,7 +2097,7 @@
       "source_file": "maria_cacau/features/home/sub_features/cpf_validation/presentation/controller.py",
       "source_location": "L12",
       "id": "presentation_controller_cpfvalidationcontroller",
-      "community": 4,
+      "community": 11,
       "norm_label": "cpfvalidationcontroller"
     },
     {
@@ -2106,7 +2106,7 @@
       "source_file": "maria_cacau/features/home/sub_features/cpf_validation/presentation/controller.py",
       "source_location": "L13",
       "id": "presentation_controller_cpfvalidationcontroller_init",
-      "community": 4,
+      "community": 11,
       "norm_label": ".__init__()"
     },
     {
@@ -2115,7 +2115,7 @@
       "source_file": "maria_cacau/features/home/sub_features/cpf_validation/presentation/controller.py",
       "source_location": "L18",
       "id": "presentation_controller_cpfvalidationcontroller_setup_actions",
-      "community": 4,
+      "community": 11,
       "norm_label": "._setup_actions()"
     },
     {
@@ -2124,7 +2124,7 @@
       "source_file": "maria_cacau/features/home/sub_features/cpf_validation/presentation/controller.py",
       "source_location": "L22",
       "id": "presentation_controller_cpfvalidationcontroller_on_validate",
-      "community": 4,
+      "community": 11,
       "norm_label": ".on_validate()"
     },
     {
@@ -2133,7 +2133,7 @@
       "source_file": "maria_cacau/features/home/sub_features/cpf_validation/presentation/controller.py",
       "source_location": "L29",
       "id": "presentation_controller_cpfvalidationcontroller_handle_result",
-      "community": 4,
+      "community": 11,
       "norm_label": ".handle_result()"
     },
     {
@@ -2141,7 +2141,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/features/home/sub_features/delivery/presentation/controller.py",
       "source_location": "L1",
-      "community": 4,
+      "community": 2,
       "norm_label": "area de entregas pendentes: controller da view.",
       "id": "presentation_controller_rationale_1"
     },
@@ -2151,7 +2151,7 @@
       "source_file": "maria_cacau/features/home/sub_features/cpf_validation/presentation/__init__.py",
       "source_location": "L1",
       "id": "maria_cacau_features_home_sub_features_cpf_validation_presentation_init_py",
-      "community": 4,
+      "community": 11,
       "norm_label": "__init__.py"
     },
     {
@@ -2160,7 +2160,7 @@
       "source_file": "maria_cacau/features/home/sub_features/cpf_validation/presentation/viewmodel.py",
       "source_location": "L1",
       "id": "maria_cacau_features_home_sub_features_cpf_validation_presentation_viewmodel_py",
-      "community": 4,
+      "community": 11,
       "norm_label": "viewmodel.py"
     },
     {
@@ -2169,7 +2169,7 @@
       "source_file": "maria_cacau/features/home/sub_features/cpf_validation/presentation/viewmodel.py",
       "source_location": "L7",
       "id": "presentation_viewmodel_cpfvalidationviewmodel",
-      "community": 4,
+      "community": 11,
       "norm_label": "cpfvalidationviewmodel"
     },
     {
@@ -2178,7 +2178,7 @@
       "source_file": "maria_cacau/features/home/sub_features/cpf_validation/presentation/viewmodel.py",
       "source_location": "L8",
       "id": "presentation_viewmodel_cpfvalidationviewmodel_init",
-      "community": 4,
+      "community": 11,
       "norm_label": ".__init__()"
     },
     {
@@ -2187,7 +2187,7 @@
       "source_file": "maria_cacau/features/home/sub_features/cpf_validation/presentation/viewmodel.py",
       "source_location": "L11",
       "id": "presentation_viewmodel_cpfvalidationviewmodel_on_validate",
-      "community": 4,
+      "community": 11,
       "norm_label": ".on_validate()"
     },
     {
@@ -2195,7 +2195,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/features/home/sub_features/delivery/presentation/viewmodel.py",
       "source_location": "L1",
-      "community": 5,
+      "community": 2,
       "norm_label": "regra de negocios das entregas",
       "id": "presentation_viewmodel_rationale_1"
     },
@@ -2205,7 +2205,7 @@
       "source_file": "maria_cacau/features/home/sub_features/cpf_validation/presentation/view.py",
       "source_location": "L1",
       "id": "maria_cacau_features_home_sub_features_cpf_validation_presentation_view_py",
-      "community": 4,
+      "community": 1,
       "norm_label": "view.py"
     },
     {
@@ -2214,7 +2214,7 @@
       "source_file": "maria_cacau/features/home/sub_features/cpf_validation/presentation/view.py",
       "source_location": "L12",
       "id": "presentation_view_cpfvalidationview",
-      "community": 0,
+      "community": 5,
       "norm_label": "cpfvalidationview"
     },
     {
@@ -2223,7 +2223,7 @@
       "source_file": "maria_cacau/features/home/sub_features/cpf_validation/presentation/view.py",
       "source_location": "L18",
       "id": "presentation_view_cpfvalidationview_init",
-      "community": 0,
+      "community": 5,
       "norm_label": ".__init__()"
     },
     {
@@ -2232,7 +2232,7 @@
       "source_file": "maria_cacau/features/auth/presentation/view.py",
       "source_location": "L19",
       "id": "presentation_view_view_title",
-      "community": 4,
+      "community": 1,
       "norm_label": "view_title()"
     },
     {
@@ -2241,7 +2241,7 @@
       "source_file": "maria_cacau/features/home/sub_features/cpf_validation/presentation/view.py",
       "source_location": "L26",
       "id": "presentation_view_cpfvalidationview_setup_ui",
-      "community": 0,
+      "community": 5,
       "norm_label": "._setup_ui()"
     },
     {
@@ -2250,7 +2250,7 @@
       "source_file": "maria_cacau/features/home/sub_features/cpf_validation/presentation/view.py",
       "source_location": "L30",
       "id": "presentation_view_cpfvalidationview_setup_components",
-      "community": 0,
+      "community": 5,
       "norm_label": "._setup_components()"
     },
     {
@@ -2259,7 +2259,7 @@
       "source_file": "maria_cacau/features/home/sub_features/cpf_validation/presentation/view.py",
       "source_location": "L40",
       "id": "presentation_view_cpfvalidationview_setup_layout",
-      "community": 0,
+      "community": 5,
       "norm_label": "._setup_layout()"
     },
     {
@@ -2268,7 +2268,7 @@
       "source_file": "maria_cacau/features/home/sub_features/cpf_validation/presentation/view.py",
       "source_location": "L52",
       "id": "presentation_view_cpfvalidationview_get_cpf",
-      "community": 4,
+      "community": 11,
       "norm_label": ".get_cpf()"
     },
     {
@@ -2277,7 +2277,7 @@
       "source_file": "maria_cacau/features/home/sub_features/cpf_validation/presentation/view.py",
       "source_location": "L55",
       "id": "presentation_view_cpfvalidationview_update_result",
-      "community": 4,
+      "community": 11,
       "norm_label": ".update_result()"
     },
     {
@@ -2285,7 +2285,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/features/home/sub_features/delivery/presentation/view.py",
       "source_location": "L1",
-      "community": 4,
+      "community": 1,
       "norm_label": "area de entregas pendentes: resumo diario com inadimplencias.",
       "id": "presentation_view_rationale_1"
     },
@@ -2295,7 +2295,7 @@
       "source_file": "maria_cacau/features/home/sub_features/shipping_rate/controller.py",
       "source_location": "L1",
       "id": "maria_cacau_features_home_sub_features_shipping_rate_controller_py",
-      "community": 0,
+      "community": 5,
       "norm_label": "controller.py"
     },
     {
@@ -2304,7 +2304,7 @@
       "source_file": "maria_cacau/features/home/sub_features/shipping_rate/controller.py",
       "source_location": "L4",
       "id": "shipping_rate_controller_shippingratecontroller",
-      "community": 0,
+      "community": 5,
       "norm_label": "shippingratecontroller"
     },
     {
@@ -2313,7 +2313,7 @@
       "source_file": "maria_cacau/features/home/sub_features/shipping_rate/controller.py",
       "source_location": "L5",
       "id": "shipping_rate_controller_shippingratecontroller_init",
-      "community": 0,
+      "community": 5,
       "norm_label": ".__init__()"
     },
     {
@@ -2322,7 +2322,7 @@
       "source_file": "maria_cacau/features/home/sub_features/shipping_rate/__init__.py",
       "source_location": "L1",
       "id": "maria_cacau_features_home_sub_features_shipping_rate_init_py",
-      "community": 0,
+      "community": 5,
       "norm_label": "__init__.py"
     },
     {
@@ -2331,7 +2331,7 @@
       "source_file": "maria_cacau/features/home/sub_features/shipping_rate/view.py",
       "source_location": "L1",
       "id": "maria_cacau_features_home_sub_features_shipping_rate_view_py",
-      "community": 0,
+      "community": 5,
       "norm_label": "view.py"
     },
     {
@@ -2340,7 +2340,7 @@
       "source_file": "maria_cacau/features/home/sub_features/shipping_rate/view.py",
       "source_location": "L8",
       "id": "shipping_rate_view_shippingrateview",
-      "community": 0,
+      "community": 5,
       "norm_label": "shippingrateview"
     },
     {
@@ -2349,7 +2349,7 @@
       "source_file": "maria_cacau/features/home/sub_features/shipping_rate/view.py",
       "source_location": "L9",
       "id": "shipping_rate_view_shippingrateview_init",
-      "community": 0,
+      "community": 5,
       "norm_label": ".__init__()"
     },
     {
@@ -2358,7 +2358,7 @@
       "source_file": "maria_cacau/features/home/sub_features/shipping_rate/view.py",
       "source_location": "L14",
       "id": "shipping_rate_view_view_title",
-      "community": 0,
+      "community": 5,
       "norm_label": "view_title()"
     },
     {
@@ -2367,7 +2367,7 @@
       "source_file": "maria_cacau/features/home/sub_features/shipping_rate/view.py",
       "source_location": "L17",
       "id": "shipping_rate_view_shippingrateview_setup_ui",
-      "community": 0,
+      "community": 5,
       "norm_label": "._setup_ui()"
     },
     {
@@ -2376,7 +2376,7 @@
       "source_file": "maria_cacau/features/home/sub_features/shipping_rate/view.py",
       "source_location": "L21",
       "id": "shipping_rate_view_shippingrateview_setup_components",
-      "community": 0,
+      "community": 5,
       "norm_label": "._setup_components()"
     },
     {
@@ -2385,7 +2385,7 @@
       "source_file": "maria_cacau/features/home/sub_features/shipping_rate/view.py",
       "source_location": "L25",
       "id": "shipping_rate_view_shippingrateview_setup_layout",
-      "community": 0,
+      "community": 5,
       "norm_label": "._setup_layout()"
     },
     {
@@ -2394,7 +2394,7 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/__init__.py",
       "source_location": "L1",
       "id": "maria_cacau_features_home_sub_features_delivery_init_py",
-      "community": 25,
+      "community": 24,
       "norm_label": "__init__.py"
     },
     {
@@ -2403,7 +2403,7 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/data/mapper.py",
       "source_location": "L1",
       "id": "maria_cacau_features_home_sub_features_delivery_data_mapper_py",
-      "community": 3,
+      "community": 2,
       "norm_label": "mapper.py"
     },
     {
@@ -2412,7 +2412,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/data/mapper.py",
       "source_location": "L9",
       "id": "data_mapper_errormapper",
-      "community": 3,
+      "community": 2,
       "norm_label": "errormapper"
     },
     {
@@ -2421,7 +2421,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/data/mapper.py",
       "source_location": "L11",
       "id": "data_mapper_from_response",
-      "community": 3,
+      "community": 2,
       "norm_label": "from_response()"
     },
     {
@@ -2430,7 +2430,7 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/data/mapper.py",
       "source_location": "L24",
       "id": "data_mapper_deliveriesmapper",
-      "community": 3,
+      "community": 2,
       "norm_label": "deliveriesmapper"
     },
     {
@@ -2439,7 +2439,7 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/data/mapper.py",
       "source_location": "L36",
       "id": "data_mapper_paymentsmapper",
-      "community": 3,
+      "community": 2,
       "norm_label": "paymentsmapper"
     },
     {
@@ -2447,7 +2447,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/features/home/sub_features/delivery/data/mapper.py",
       "source_location": "L1",
-      "community": 3,
+      "community": 2,
       "norm_label": "mappers de httpresponse para domain models e de httpresponseerror para errormode",
       "id": "data_mapper_rationale_1"
     },
@@ -2456,7 +2456,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/features/home/sub_features/delivery/data/mapper.py",
       "source_location": "L12",
-      "community": 3,
+      "community": 2,
       "norm_label": "le o json do backend; cai em http_error generico se o corpo nao for json valido.",
       "id": "data_mapper_rationale_12"
     },
@@ -2466,7 +2466,7 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/data/__init__.py",
       "source_location": "L1",
       "id": "maria_cacau_features_home_sub_features_delivery_data_init_py",
-      "community": 3,
+      "community": 2,
       "norm_label": "__init__.py"
     },
     {
@@ -2475,7 +2475,7 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/data/apis.py",
       "source_location": "L1",
       "id": "maria_cacau_features_home_sub_features_delivery_data_apis_py",
-      "community": 3,
+      "community": 2,
       "norm_label": "apis.py"
     },
     {
@@ -2484,7 +2484,7 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/data/apis.py",
       "source_location": "L6",
       "id": "data_apis_deliveriesapi",
-      "community": 3,
+      "community": 2,
       "norm_label": "deliveriesapi"
     },
     {
@@ -2493,7 +2493,7 @@
       "source_file": "",
       "source_location": "",
       "id": "api",
-      "community": 3,
+      "community": 2,
       "norm_label": "api"
     },
     {
@@ -2502,7 +2502,7 @@
       "source_file": "maria_cacau/features/auth/data/apis.py",
       "source_location": "L13",
       "id": "data_apis_path",
-      "community": 3,
+      "community": 2,
       "norm_label": "path()"
     },
     {
@@ -2511,7 +2511,7 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/data/apis.py",
       "source_location": "L11",
       "id": "data_apis_deliveriesapi_for_date",
-      "community": 3,
+      "community": 2,
       "norm_label": ".for_date()"
     },
     {
@@ -2520,7 +2520,7 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/data/apis.py",
       "source_location": "L16",
       "id": "data_apis_paymentspendentapi",
-      "community": 3,
+      "community": 2,
       "norm_label": "paymentspendentapi"
     },
     {
@@ -2529,7 +2529,7 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/data/apis.py",
       "source_location": "L21",
       "id": "data_apis_paymentspendentapi_for_date",
-      "community": 3,
+      "community": 2,
       "norm_label": ".for_date()"
     },
     {
@@ -2537,7 +2537,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/features/home/sub_features/delivery/data/apis.py",
       "source_location": "L1",
-      "community": 3,
+      "community": 2,
       "norm_label": "definicao dos endpoints do backend consumidos pela feature delivery.",
       "id": "data_apis_rationale_1"
     },
@@ -2547,62 +2547,62 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/data/repository.py",
       "source_location": "L1",
       "id": "maria_cacau_features_home_sub_features_delivery_data_repository_py",
-      "community": 3,
+      "community": 2,
       "norm_label": "repository.py"
     },
     {
       "label": "OrdersRepository",
       "file_type": "code",
       "source_file": "maria_cacau/features/home/sub_features/delivery/data/repository.py",
-      "source_location": "L10",
+      "source_location": "L13",
       "id": "data_repository_ordersrepository",
-      "community": 3,
+      "community": 2,
       "norm_label": "ordersrepository"
+    },
+    {
+      "label": ".__init__()",
+      "file_type": "code",
+      "source_file": "maria_cacau/features/home/sub_features/delivery/data/repository.py",
+      "source_location": "L14",
+      "id": "data_repository_ordersrepository_init",
+      "community": 4,
+      "norm_label": ".__init__()"
     },
     {
       "label": ".get_deliveries()",
       "file_type": "code",
       "source_file": "maria_cacau/features/home/sub_features/delivery/data/repository.py",
-      "source_location": "L11",
+      "source_location": "L19",
       "id": "data_repository_ordersrepository_get_deliveries",
-      "community": 3,
+      "community": 2,
       "norm_label": ".get_deliveries()"
     },
     {
       "label": ".get_pendent_payments()",
       "file_type": "code",
       "source_file": "maria_cacau/features/home/sub_features/delivery/data/repository.py",
-      "source_location": "L19",
+      "source_location": "L31",
       "id": "data_repository_ordersrepository_get_pendent_payments",
-      "community": 3,
+      "community": 2,
       "norm_label": ".get_pendent_payments()"
+    },
+    {
+      "label": "._clear_cache()",
+      "file_type": "code",
+      "source_file": "maria_cacau/features/home/sub_features/delivery/data/repository.py",
+      "source_location": "L43",
+      "id": "data_repository_ordersrepository_clear_cache",
+      "community": 8,
+      "norm_label": "._clear_cache()"
     },
     {
       "label": "Repository da feature Delivery: chama as APIs e converte erros HTTP em ErrorMode",
       "file_type": "rationale",
       "source_file": "maria_cacau/features/home/sub_features/delivery/data/repository.py",
       "source_location": "L1",
-      "community": 3,
+      "community": 2,
       "norm_label": "repository da feature delivery: chama as apis e converte erros http em errormode",
       "id": "data_repository_rationale_1"
-    },
-    {
-      "label": "Busca entregas do dia; converte HTTPResponseError em ErrorModel antes de relan\u00e7a",
-      "file_type": "rationale",
-      "source_file": "maria_cacau/features/home/sub_features/delivery/data/repository.py",
-      "source_location": "L12",
-      "community": 3,
-      "norm_label": "busca entregas do dia; converte httpresponseerror em errormodel antes de relanca",
-      "id": "data_repository_rationale_12"
-    },
-    {
-      "label": "Busca pagamentos pendentes do dia; converte HTTPResponseError em ErrorModel ante",
-      "file_type": "rationale",
-      "source_file": "maria_cacau/features/home/sub_features/delivery/data/repository.py",
-      "source_location": "L20",
-      "community": 3,
-      "norm_label": "busca pagamentos pendentes do dia; converte httpresponseerror em errormodel ante",
-      "id": "data_repository_rationale_20"
     },
     {
       "label": "use_case.py",
@@ -2610,7 +2610,7 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/domain/use_case.py",
       "source_location": "L1",
       "id": "maria_cacau_features_home_sub_features_delivery_domain_use_case_py",
-      "community": 3,
+      "community": 2,
       "norm_label": "use_case.py"
     },
     {
@@ -2619,7 +2619,7 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/domain/use_case.py",
       "source_location": "L9",
       "id": "domain_use_case_deliveryusecase",
-      "community": 5,
+      "community": 2,
       "norm_label": "deliveryusecase"
     },
     {
@@ -2628,7 +2628,7 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/domain/use_case.py",
       "source_location": "L10",
       "id": "domain_use_case_deliveryusecase_init",
-      "community": 5,
+      "community": 2,
       "norm_label": ".__init__()"
     },
     {
@@ -2637,7 +2637,7 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/domain/use_case.py",
       "source_location": "L13",
       "id": "domain_use_case_deliveryusecase_get_orders",
-      "community": 5,
+      "community": 2,
       "norm_label": ".get_orders()"
     },
     {
@@ -2645,7 +2645,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/features/home/sub_features/delivery/domain/use_case.py",
       "source_location": "L14",
-      "community": 5,
+      "community": 2,
       "norm_label": "busca deliveries e payments em paralelo e retorna o modelo consolidado.",
       "id": "domain_use_case_rationale_14"
     },
@@ -2655,7 +2655,7 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/domain/signals.py",
       "source_location": "L1",
       "id": "maria_cacau_features_home_sub_features_delivery_domain_signals_py",
-      "community": 3,
+      "community": 2,
       "norm_label": "signals.py"
     },
     {
@@ -2664,7 +2664,7 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/domain/signals.py",
       "source_location": "L8",
       "id": "domain_signals_deliverysignals",
-      "community": 4,
+      "community": 11,
       "norm_label": "deliverysignals"
     },
     {
@@ -2673,7 +2673,7 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/domain/models.py",
       "source_location": "L1",
       "id": "maria_cacau_features_home_sub_features_delivery_domain_models_py",
-      "community": 3,
+      "community": 2,
       "norm_label": "models.py"
     },
     {
@@ -2682,7 +2682,7 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/domain/models.py",
       "source_location": "L7",
       "id": "domain_models_deliverycount",
-      "community": 3,
+      "community": 2,
       "norm_label": "deliverycount"
     },
     {
@@ -2691,7 +2691,7 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/domain/models.py",
       "source_location": "L13",
       "id": "domain_models_deliveriessummary",
-      "community": 3,
+      "community": 2,
       "norm_label": "deliveriessummary"
     },
     {
@@ -2700,7 +2700,7 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/domain/models.py",
       "source_location": "L20",
       "id": "domain_models_pendentorder",
-      "community": 3,
+      "community": 2,
       "norm_label": "pendentorder"
     },
     {
@@ -2709,7 +2709,7 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/domain/models.py",
       "source_location": "L29",
       "id": "domain_models_deliverymodel",
-      "community": 5,
+      "community": 2,
       "norm_label": "deliverymodel"
     },
     {
@@ -2718,7 +2718,7 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/domain/models.py",
       "source_location": "L35",
       "id": "domain_models_deliveryviewdata",
-      "community": 5,
+      "community": 1,
       "norm_label": "deliveryviewdata"
     },
     {
@@ -2727,7 +2727,7 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/domain/events.py",
       "source_location": "L1",
       "id": "maria_cacau_features_home_sub_features_delivery_domain_events_py",
-      "community": 10,
+      "community": 8,
       "norm_label": "events.py"
     },
     {
@@ -2736,7 +2736,7 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/domain/__init__.py",
       "source_location": "L1",
       "id": "maria_cacau_features_home_sub_features_delivery_domain_init_py",
-      "community": 3,
+      "community": 2,
       "norm_label": "__init__.py"
     },
     {
@@ -2745,7 +2745,7 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/presentation/controller.py",
       "source_location": "L1",
       "id": "maria_cacau_features_home_sub_features_delivery_presentation_controller_py",
-      "community": 3,
+      "community": 2,
       "norm_label": "controller.py"
     },
     {
@@ -2754,7 +2754,7 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/presentation/controller.py",
       "source_location": "L15",
       "id": "presentation_controller_deliverycontroller",
-      "community": 5,
+      "community": 1,
       "norm_label": "deliverycontroller"
     },
     {
@@ -2763,7 +2763,7 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/presentation/controller.py",
       "source_location": "L16",
       "id": "presentation_controller_deliverycontroller_init",
-      "community": 5,
+      "community": 1,
       "norm_label": ".__init__()"
     },
     {
@@ -2772,7 +2772,7 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/presentation/controller.py",
       "source_location": "L22",
       "id": "presentation_controller_deliverycontroller_setupactions",
-      "community": 5,
+      "community": 1,
       "norm_label": "._setupactions()"
     },
     {
@@ -2781,7 +2781,7 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/presentation/controller.py",
       "source_location": "L33",
       "id": "presentation_controller_deliverycontroller_on_generate_report",
-      "community": 5,
+      "community": 1,
       "norm_label": ".on_generate_report()"
     },
     {
@@ -2790,7 +2790,7 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/presentation/controller.py",
       "source_location": "L42",
       "id": "presentation_controller_deliverycontroller_on_copy_report",
-      "community": 5,
+      "community": 1,
       "norm_label": ".on_copy_report()"
     },
     {
@@ -2799,7 +2799,7 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/presentation/controller.py",
       "source_location": "L45",
       "id": "presentation_controller_deliverycontroller_on_copy_graph",
-      "community": 5,
+      "community": 1,
       "norm_label": ".on_copy_graph()"
     },
     {
@@ -2808,7 +2808,7 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/presentation/controller.py",
       "source_location": "L48",
       "id": "presentation_controller_deliverycontroller_on_download_graph",
-      "community": 5,
+      "community": 1,
       "norm_label": ".on_download_graph()"
     },
     {
@@ -2817,7 +2817,7 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/presentation/controller.py",
       "source_location": "L53",
       "id": "presentation_controller_deliverycontroller_handle_error",
-      "community": 5,
+      "community": 1,
       "norm_label": ".handle_error()"
     },
     {
@@ -2826,7 +2826,7 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/presentation/controller.py",
       "source_location": "L56",
       "id": "presentation_controller_deliverycontroller_handle_report_generated",
-      "community": 5,
+      "community": 1,
       "norm_label": ".handle_report_generated()"
     },
     {
@@ -2834,7 +2834,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/features/home/sub_features/delivery/presentation/controller.py",
       "source_location": "L34",
-      "community": 5,
+      "community": 1,
       "norm_label": "inicia a consulta: trava a view, dispara o viewmodel e registra o timestamp para",
       "id": "presentation_controller_rationale_34"
     },
@@ -2843,7 +2843,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/features/home/sub_features/delivery/presentation/controller.py",
       "source_location": "L57",
-      "community": 5,
+      "community": 1,
       "norm_label": "recebe o resultado do viewmodel, atualiza a view e loga a duracao da consulta.",
       "id": "presentation_controller_rationale_57"
     },
@@ -2853,7 +2853,7 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/presentation/__init__.py",
       "source_location": "L1",
       "id": "maria_cacau_features_home_sub_features_delivery_presentation_init_py",
-      "community": 3,
+      "community": 2,
       "norm_label": "__init__.py"
     },
     {
@@ -2862,7 +2862,7 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/presentation/viewmodel.py",
       "source_location": "L1",
       "id": "maria_cacau_features_home_sub_features_delivery_presentation_viewmodel_py",
-      "community": 3,
+      "community": 2,
       "norm_label": "viewmodel.py"
     },
     {
@@ -2871,7 +2871,7 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/presentation/viewmodel.py",
       "source_location": "L12",
       "id": "presentation_viewmodel_deliveryviewmodel",
-      "community": 5,
+      "community": 2,
       "norm_label": "deliveryviewmodel"
     },
     {
@@ -2880,7 +2880,7 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/presentation/viewmodel.py",
       "source_location": "L13",
       "id": "presentation_viewmodel_deliveryviewmodel_init",
-      "community": 5,
+      "community": 2,
       "norm_label": ".__init__()"
     },
     {
@@ -2889,7 +2889,7 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/presentation/viewmodel.py",
       "source_location": "L17",
       "id": "presentation_viewmodel_deliveryviewmodel_on_generate",
-      "community": 5,
+      "community": 2,
       "norm_label": ".on_generate()"
     },
     {
@@ -2898,7 +2898,7 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/presentation/viewmodel.py",
       "source_location": "L20",
       "id": "presentation_viewmodel_deliveryviewmodel_fetch",
-      "community": 5,
+      "community": 2,
       "norm_label": "._fetch()"
     },
     {
@@ -2907,7 +2907,7 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/presentation/viewmodel.py",
       "source_location": "L31",
       "id": "presentation_viewmodel_deliveryviewmodel_build_view_data",
-      "community": 5,
+      "community": 2,
       "norm_label": "._build_view_data()"
     },
     {
@@ -2916,7 +2916,7 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/presentation/viewmodel.py",
       "source_location": "L37",
       "id": "presentation_viewmodel_deliveryviewmodel_build_report",
-      "community": 5,
+      "community": 2,
       "norm_label": "._build_report()"
     },
     {
@@ -2924,7 +2924,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/features/home/sub_features/delivery/presentation/viewmodel.py",
       "source_location": "L21",
-      "community": 5,
+      "community": 2,
       "norm_label": "roda o usecase, monta o viewdata e emite sucesso ou erro \u2014 sempre via signal par",
       "id": "presentation_viewmodel_rationale_21"
     },
@@ -2934,7 +2934,7 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/presentation/view.py",
       "source_location": "L1",
       "id": "maria_cacau_features_home_sub_features_delivery_presentation_view_py",
-      "community": 4,
+      "community": 1,
       "norm_label": "view.py"
     },
     {
@@ -2943,7 +2943,7 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/presentation/view.py",
       "source_location": "L15",
       "id": "presentation_view_deliveryview",
-      "community": 5,
+      "community": 1,
       "norm_label": "deliveryview"
     },
     {
@@ -2952,7 +2952,7 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/presentation/view.py",
       "source_location": "L22",
       "id": "presentation_view_deliveryview_init",
-      "community": 5,
+      "community": 1,
       "norm_label": ".__init__()"
     },
     {
@@ -2961,7 +2961,7 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/presentation/view.py",
       "source_location": "L31",
       "id": "presentation_view_deliveryview_setup_ui",
-      "community": 5,
+      "community": 1,
       "norm_label": "._setup_ui()"
     },
     {
@@ -2970,7 +2970,7 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/presentation/view.py",
       "source_location": "L36",
       "id": "presentation_view_deliveryview_setup_layout",
-      "community": 5,
+      "community": 1,
       "norm_label": "._setup_layout()"
     },
     {
@@ -2979,7 +2979,7 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/presentation/view.py",
       "source_location": "L55",
       "id": "presentation_view_deliveryview_setup_components",
-      "community": 0,
+      "community": 1,
       "norm_label": "._setup_components()"
     },
     {
@@ -2988,7 +2988,7 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/presentation/view.py",
       "source_location": "L85",
       "id": "presentation_view_deliveryview_update_buttons_state",
-      "community": 5,
+      "community": 1,
       "norm_label": "._update_buttons_state()"
     },
     {
@@ -2997,7 +2997,7 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/presentation/view.py",
       "source_location": "L91",
       "id": "presentation_view_deliveryview_get_date",
-      "community": 5,
+      "community": 1,
       "norm_label": ".get_date()"
     },
     {
@@ -3006,7 +3006,7 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/presentation/view.py",
       "source_location": "L95",
       "id": "presentation_view_deliveryview_update_data",
-      "community": 5,
+      "community": 1,
       "norm_label": ".update_data()"
     },
     {
@@ -3015,7 +3015,7 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/presentation/view.py",
       "source_location": "L103",
       "id": "presentation_view_deliveryview_prepare_to_fetch",
-      "community": 5,
+      "community": 1,
       "norm_label": ".prepare_to_fetch()"
     },
     {
@@ -3023,7 +3023,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/features/home/sub_features/delivery/presentation/view.py",
       "source_location": "L92",
-      "community": 0,
+      "community": 1,
       "norm_label": "r'''retorna a data selecionada no formato dd/mm/yy",
       "id": "presentation_view_rationale_92"
     },
@@ -3032,7 +3032,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/features/home/sub_features/delivery/presentation/view.py",
       "source_location": "L96",
-      "community": 0,
+      "community": 1,
       "norm_label": "r'''atualiza os dados da view",
       "id": "presentation_view_rationale_96"
     },
@@ -3041,7 +3041,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/features/home/sub_features/delivery/presentation/view.py",
       "source_location": "L104",
-      "community": 0,
+      "community": 1,
       "norm_label": "r'''prepara a view para uma nova consulta",
       "id": "presentation_view_rationale_104"
     },
@@ -3051,7 +3051,7 @@
       "source_file": "maria_cacau/features/home/sub_features/status_bar/__init__.py",
       "source_location": "L1",
       "id": "maria_cacau_features_home_sub_features_status_bar_init_py",
-      "community": 26,
+      "community": 25,
       "norm_label": "__init__.py"
     },
     {
@@ -3060,7 +3060,7 @@
       "source_file": "maria_cacau/features/home/sub_features/status_bar/status_bar_view.py",
       "source_location": "L1",
       "id": "maria_cacau_features_home_sub_features_status_bar_status_bar_view_py",
-      "community": 14,
+      "community": 3,
       "norm_label": "status_bar_view.py"
     },
     {
@@ -3069,7 +3069,7 @@
       "source_file": "maria_cacau/features/home/sub_features/status_bar/status_bar_view.py",
       "source_location": "L9",
       "id": "status_bar_status_bar_view_guistatusbar",
-      "community": 14,
+      "community": 3,
       "norm_label": "guistatusbar"
     },
     {
@@ -3078,7 +3078,7 @@
       "source_file": "",
       "source_location": "",
       "id": "qstatusbar",
-      "community": 14,
+      "community": 3,
       "norm_label": "qstatusbar"
     },
     {
@@ -3087,7 +3087,7 @@
       "source_file": "maria_cacau/features/home/sub_features/status_bar/status_bar_view.py",
       "source_location": "L14",
       "id": "status_bar_status_bar_view_guistatusbar_init",
-      "community": 14,
+      "community": 3,
       "norm_label": ".__init__()"
     },
     {
@@ -3096,7 +3096,7 @@
       "source_file": "maria_cacau/features/home/sub_features/status_bar/status_bar_view.py",
       "source_location": "L32",
       "id": "status_bar_status_bar_view_guistatusbar_set_credentials",
-      "community": 14,
+      "community": 3,
       "norm_label": ".set_credentials()"
     },
     {
@@ -3105,7 +3105,7 @@
       "source_file": "maria_cacau/features/home/sub_features/status_bar/status_bar_view.py",
       "source_location": "L38",
       "id": "status_bar_status_bar_view_guistatusbar_set_sheet",
-      "community": 14,
+      "community": 3,
       "norm_label": ".set_sheet()"
     },
     {
@@ -3114,7 +3114,7 @@
       "source_file": "maria_cacau/features/home/sub_features/status_bar/status_bar_view.py",
       "source_location": "L45",
       "id": "status_bar_status_bar_view_guistatusbar_set_loading",
-      "community": 14,
+      "community": 3,
       "norm_label": ".set_loading()"
     },
     {
@@ -3123,7 +3123,7 @@
       "source_file": "maria_cacau/features/home/sub_features/status_bar/status_bar_view.py",
       "source_location": "L54",
       "id": "status_bar_status_bar_view_guistatusbar_set_success",
-      "community": 14,
+      "community": 3,
       "norm_label": ".set_success()"
     },
     {
@@ -3132,7 +3132,7 @@
       "source_file": "maria_cacau/features/home/sub_features/status_bar/status_bar_view.py",
       "source_location": "L61",
       "id": "status_bar_status_bar_view_guistatusbar_set_ready",
-      "community": 14,
+      "community": 3,
       "norm_label": ".set_ready()"
     },
     {
@@ -3141,7 +3141,7 @@
       "source_file": "maria_cacau/features/home/sub_features/status_bar/status_bar_view.py",
       "source_location": "L65",
       "id": "status_bar_status_bar_view_guistatusbar_tick",
-      "community": 14,
+      "community": 3,
       "norm_label": "._tick()"
     },
     {
@@ -3150,7 +3150,7 @@
       "source_file": "maria_cacau/features/home/sub_features/status_bar/status_bar_view.py",
       "source_location": "L73",
       "id": "status_bar_status_bar_view_guistatusbar_restore",
-      "community": 14,
+      "community": 3,
       "norm_label": "._restore()"
     },
     {
@@ -3159,7 +3159,7 @@
       "source_file": "maria_cacau/features/home/sub_features/status_bar/status_bar_view.py",
       "source_location": "L77",
       "id": "status_bar_status_bar_view_guistatusbar_update_info",
-      "community": 14,
+      "community": 3,
       "norm_label": "._update_info()"
     },
     {
@@ -3168,7 +3168,7 @@
       "source_file": "maria_cacau/features/home/sub_features/status_bar/status_bar_view.py",
       "source_location": "L85",
       "id": "status_bar_status_bar_view_guistatusbar_update_color",
-      "community": 14,
+      "community": 3,
       "norm_label": "._update_color()"
     },
     {
@@ -3177,7 +3177,7 @@
       "source_file": "maria_cacau/features/home/sub_features/status_bar/status_bar_view.py",
       "source_location": "L89",
       "id": "status_bar_status_bar_view_guistatusbar_set_color",
-      "community": 14,
+      "community": 3,
       "norm_label": "._set_color()"
     },
     {
@@ -3185,7 +3185,7 @@
       "file_type": "rationale",
       "source_file": "features/home/sub_features/status_bar/status_bar_view.py",
       "source_location": "L1",
-      "community": 14,
+      "community": 3,
       "norm_label": "barra de status da aplicacao: planilha conectada, credenciais e estado de carreg",
       "id": "status_bar_status_bar_view_rationale_1"
     },
@@ -3195,7 +3195,7 @@
       "source_file": "maria_cacau/features/home/sub_features/nota_fiscal/controller.py",
       "source_location": "L1",
       "id": "maria_cacau_features_home_sub_features_nota_fiscal_controller_py",
-      "community": 0,
+      "community": 5,
       "norm_label": "controller.py"
     },
     {
@@ -3204,7 +3204,7 @@
       "source_file": "maria_cacau/features/home/sub_features/nota_fiscal/controller.py",
       "source_location": "L4",
       "id": "nota_fiscal_controller_notafiscalcontroller",
-      "community": 0,
+      "community": 5,
       "norm_label": "notafiscalcontroller"
     },
     {
@@ -3213,7 +3213,7 @@
       "source_file": "maria_cacau/features/home/sub_features/nota_fiscal/controller.py",
       "source_location": "L5",
       "id": "nota_fiscal_controller_notafiscalcontroller_init",
-      "community": 0,
+      "community": 5,
       "norm_label": ".__init__()"
     },
     {
@@ -3222,7 +3222,7 @@
       "source_file": "maria_cacau/features/home/sub_features/nota_fiscal/__init__.py",
       "source_location": "L1",
       "id": "maria_cacau_features_home_sub_features_nota_fiscal_init_py",
-      "community": 0,
+      "community": 5,
       "norm_label": "__init__.py"
     },
     {
@@ -3231,7 +3231,7 @@
       "source_file": "maria_cacau/features/home/sub_features/nota_fiscal/view.py",
       "source_location": "L1",
       "id": "maria_cacau_features_home_sub_features_nota_fiscal_view_py",
-      "community": 0,
+      "community": 5,
       "norm_label": "view.py"
     },
     {
@@ -3240,7 +3240,7 @@
       "source_file": "maria_cacau/features/home/sub_features/nota_fiscal/view.py",
       "source_location": "L8",
       "id": "nota_fiscal_view_notafiscalview",
-      "community": 0,
+      "community": 5,
       "norm_label": "notafiscalview"
     },
     {
@@ -3249,7 +3249,7 @@
       "source_file": "maria_cacau/features/home/sub_features/nota_fiscal/view.py",
       "source_location": "L9",
       "id": "nota_fiscal_view_notafiscalview_init",
-      "community": 0,
+      "community": 5,
       "norm_label": ".__init__()"
     },
     {
@@ -3258,7 +3258,7 @@
       "source_file": "maria_cacau/features/home/sub_features/nota_fiscal/view.py",
       "source_location": "L14",
       "id": "nota_fiscal_view_view_title",
-      "community": 0,
+      "community": 5,
       "norm_label": "view_title()"
     },
     {
@@ -3267,7 +3267,7 @@
       "source_file": "maria_cacau/features/home/sub_features/nota_fiscal/view.py",
       "source_location": "L17",
       "id": "nota_fiscal_view_notafiscalview_setup_ui",
-      "community": 0,
+      "community": 5,
       "norm_label": "._setup_ui()"
     },
     {
@@ -3276,7 +3276,7 @@
       "source_file": "maria_cacau/features/home/sub_features/nota_fiscal/view.py",
       "source_location": "L21",
       "id": "nota_fiscal_view_notafiscalview_setup_components",
-      "community": 0,
+      "community": 5,
       "norm_label": "._setup_components()"
     },
     {
@@ -3285,7 +3285,7 @@
       "source_file": "maria_cacau/features/home/sub_features/nota_fiscal/view.py",
       "source_location": "L25",
       "id": "nota_fiscal_view_notafiscalview_setup_layout",
-      "community": 0,
+      "community": 5,
       "norm_label": "._setup_layout()"
     },
     {
@@ -3294,7 +3294,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/__init__.py",
       "source_location": "L1",
       "id": "maria_cacau_features_home_sub_features_summary_init_py",
-      "community": 4,
+      "community": 2,
       "norm_label": "__init__.py"
     },
     {
@@ -3303,7 +3303,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/data/mapper.py",
       "source_location": "L1",
       "id": "maria_cacau_features_home_sub_features_summary_data_mapper_py",
-      "community": 3,
+      "community": 2,
       "norm_label": "mapper.py"
     },
     {
@@ -3312,7 +3312,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/data/mapper.py",
       "source_location": "L23",
       "id": "data_mapper_orderssummarymapper",
-      "community": 3,
+      "community": 2,
       "norm_label": "orderssummarymapper"
     },
     {
@@ -3321,7 +3321,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/data/__init__.py",
       "source_location": "L1",
       "id": "maria_cacau_features_home_sub_features_summary_data_init_py",
-      "community": 4,
+      "community": 2,
       "norm_label": "__init__.py"
     },
     {
@@ -3330,7 +3330,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/data/apis.py",
       "source_location": "L1",
       "id": "maria_cacau_features_home_sub_features_summary_data_apis_py",
-      "community": 3,
+      "community": 2,
       "norm_label": "apis.py"
     },
     {
@@ -3339,7 +3339,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/data/apis.py",
       "source_location": "L6",
       "id": "data_apis_orderssummaryapi",
-      "community": 3,
+      "community": 2,
       "norm_label": "orderssummaryapi"
     },
     {
@@ -3348,7 +3348,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/data/apis.py",
       "source_location": "L11",
       "id": "data_apis_orderssummaryapi_for_period",
-      "community": 3,
+      "community": 2,
       "norm_label": ".for_period()"
     },
     {
@@ -3357,26 +3357,44 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/data/repository.py",
       "source_location": "L1",
       "id": "maria_cacau_features_home_sub_features_summary_data_repository_py",
-      "community": 4,
+      "community": 2,
       "norm_label": "repository.py"
     },
     {
       "label": "SummaryRepository",
       "file_type": "code",
       "source_file": "maria_cacau/features/home/sub_features/summary/data/repository.py",
-      "source_location": "L10",
+      "source_location": "L13",
       "id": "data_repository_summaryrepository",
-      "community": 3,
+      "community": 2,
       "norm_label": "summaryrepository"
+    },
+    {
+      "label": ".__init__()",
+      "file_type": "code",
+      "source_file": "maria_cacau/features/home/sub_features/summary/data/repository.py",
+      "source_location": "L14",
+      "id": "data_repository_summaryrepository_init",
+      "community": 4,
+      "norm_label": ".__init__()"
     },
     {
       "label": ".get_by_period()",
       "file_type": "code",
       "source_file": "maria_cacau/features/home/sub_features/summary/data/repository.py",
-      "source_location": "L11",
+      "source_location": "L18",
       "id": "data_repository_summaryrepository_get_by_period",
-      "community": 3,
+      "community": 2,
       "norm_label": ".get_by_period()"
+    },
+    {
+      "label": "._clear_cache()",
+      "file_type": "code",
+      "source_file": "maria_cacau/features/home/sub_features/summary/data/repository.py",
+      "source_location": "L33",
+      "id": "data_repository_summaryrepository_clear_cache",
+      "community": 8,
+      "norm_label": "._clear_cache()"
     },
     {
       "label": "use_case.py",
@@ -3384,7 +3402,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/domain/use_case.py",
       "source_location": "L1",
       "id": "maria_cacau_features_home_sub_features_summary_domain_use_case_py",
-      "community": 4,
+      "community": 2,
       "norm_label": "use_case.py"
     },
     {
@@ -3393,7 +3411,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/domain/use_case.py",
       "source_location": "L9",
       "id": "domain_use_case_summaryusecase",
-      "community": 4,
+      "community": 2,
       "norm_label": "summaryusecase"
     },
     {
@@ -3402,7 +3420,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/domain/use_case.py",
       "source_location": "L10",
       "id": "domain_use_case_summaryusecase_init",
-      "community": 4,
+      "community": 2,
       "norm_label": ".__init__()"
     },
     {
@@ -3411,7 +3429,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/domain/use_case.py",
       "source_location": "L13",
       "id": "domain_use_case_summaryusecase_get_summary",
-      "community": 4,
+      "community": 2,
       "norm_label": ".get_summary()"
     },
     {
@@ -3420,7 +3438,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/domain/use_case.py",
       "source_location": "L17",
       "id": "domain_use_case_summaryusecase_build_summary",
-      "community": 4,
+      "community": 2,
       "norm_label": "._build_summary()"
     },
     {
@@ -3429,7 +3447,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/domain/use_case.py",
       "source_location": "L51",
       "id": "domain_use_case_to_sorted_counts",
-      "community": 4,
+      "community": 2,
       "norm_label": "_to_sorted_counts()"
     },
     {
@@ -3438,7 +3456,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/domain/signals.py",
       "source_location": "L1",
       "id": "maria_cacau_features_home_sub_features_summary_domain_signals_py",
-      "community": 4,
+      "community": 2,
       "norm_label": "signals.py"
     },
     {
@@ -3447,7 +3465,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/domain/signals.py",
       "source_location": "L8",
       "id": "domain_signals_summarysignals",
-      "community": 4,
+      "community": 11,
       "norm_label": "summarysignals"
     },
     {
@@ -3456,7 +3474,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/domain/models.py",
       "source_location": "L1",
       "id": "maria_cacau_features_home_sub_features_summary_domain_models_py",
-      "community": 4,
+      "community": 2,
       "norm_label": "models.py"
     },
     {
@@ -3465,7 +3483,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/domain/models.py",
       "source_location": "L7",
       "id": "domain_models_productcount",
-      "community": 3,
+      "community": 2,
       "norm_label": "productcount"
     },
     {
@@ -3474,7 +3492,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/domain/models.py",
       "source_location": "L13",
       "id": "domain_models_orderdetail",
-      "community": 3,
+      "community": 2,
       "norm_label": "orderdetail"
     },
     {
@@ -3483,7 +3501,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/domain/models.py",
       "source_location": "L22",
       "id": "domain_models_daysummary",
-      "community": 4,
+      "community": 2,
       "norm_label": "daysummary"
     },
     {
@@ -3492,7 +3510,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/domain/models.py",
       "source_location": "L29",
       "id": "domain_models_productssummary",
-      "community": 4,
+      "community": 2,
       "norm_label": "productssummary"
     },
     {
@@ -3501,7 +3519,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/domain/models.py",
       "source_location": "L38",
       "id": "domain_models_productsviewdata",
-      "community": 4,
+      "community": 2,
       "norm_label": "productsviewdata"
     },
     {
@@ -3510,7 +3528,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/domain/events.py",
       "source_location": "L1",
       "id": "maria_cacau_features_home_sub_features_summary_domain_events_py",
-      "community": 10,
+      "community": 8,
       "norm_label": "events.py"
     },
     {
@@ -3519,7 +3537,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/domain/__init__.py",
       "source_location": "L1",
       "id": "maria_cacau_features_home_sub_features_summary_domain_init_py",
-      "community": 27,
+      "community": 26,
       "norm_label": "__init__.py"
     },
     {
@@ -3528,7 +3546,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/presentation/controller.py",
       "source_location": "L1",
       "id": "maria_cacau_features_home_sub_features_summary_presentation_controller_py",
-      "community": 4,
+      "community": 2,
       "norm_label": "controller.py"
     },
     {
@@ -3537,7 +3555,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/presentation/controller.py",
       "source_location": "L15",
       "id": "presentation_controller_summarycontroller",
-      "community": 5,
+      "community": 1,
       "norm_label": "summarycontroller"
     },
     {
@@ -3546,7 +3564,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/presentation/controller.py",
       "source_location": "L16",
       "id": "presentation_controller_summarycontroller_init",
-      "community": 5,
+      "community": 1,
       "norm_label": ".__init__()"
     },
     {
@@ -3555,7 +3573,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/presentation/controller.py",
       "source_location": "L21",
       "id": "presentation_controller_summarycontroller_setup_actions",
-      "community": 5,
+      "community": 1,
       "norm_label": "._setup_actions()"
     },
     {
@@ -3564,7 +3582,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/presentation/controller.py",
       "source_location": "L33",
       "id": "presentation_controller_summarycontroller_on_generate_report",
-      "community": 5,
+      "community": 1,
       "norm_label": ".on_generate_report()"
     },
     {
@@ -3573,7 +3591,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/presentation/controller.py",
       "source_location": "L40",
       "id": "presentation_controller_summarycontroller_on_copy_report",
-      "community": 5,
+      "community": 1,
       "norm_label": ".on_copy_report()"
     },
     {
@@ -3582,7 +3600,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/presentation/controller.py",
       "source_location": "L43",
       "id": "presentation_controller_summarycontroller_on_copy_graph",
-      "community": 5,
+      "community": 1,
       "norm_label": ".on_copy_graph()"
     },
     {
@@ -3591,7 +3609,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/presentation/controller.py",
       "source_location": "L46",
       "id": "presentation_controller_summarycontroller_on_download_graph",
-      "community": 5,
+      "community": 1,
       "norm_label": ".on_download_graph()"
     },
     {
@@ -3600,7 +3618,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/presentation/controller.py",
       "source_location": "L49",
       "id": "presentation_controller_summarycontroller_on_change_chart_type",
-      "community": 5,
+      "community": 1,
       "norm_label": ".on_change_chart_type()"
     },
     {
@@ -3609,7 +3627,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/presentation/controller.py",
       "source_location": "L54",
       "id": "presentation_controller_summarycontroller_handle_error",
-      "community": 5,
+      "community": 1,
       "norm_label": ".handle_error()"
     },
     {
@@ -3618,7 +3636,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/presentation/controller.py",
       "source_location": "L58",
       "id": "presentation_controller_summarycontroller_handle_report_generated",
-      "community": 5,
+      "community": 1,
       "norm_label": ".handle_report_generated()"
     },
     {
@@ -3627,7 +3645,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/presentation/__init__.py",
       "source_location": "L1",
       "id": "maria_cacau_features_home_sub_features_summary_presentation_init_py",
-      "community": 28,
+      "community": 27,
       "norm_label": "__init__.py"
     },
     {
@@ -3636,7 +3654,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/presentation/viewmodel.py",
       "source_location": "L1",
       "id": "maria_cacau_features_home_sub_features_summary_presentation_viewmodel_py",
-      "community": 4,
+      "community": 2,
       "norm_label": "viewmodel.py"
     },
     {
@@ -3645,7 +3663,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/presentation/viewmodel.py",
       "source_location": "L14",
       "id": "presentation_viewmodel_summaryviewmodel",
-      "community": 4,
+      "community": 2,
       "norm_label": "summaryviewmodel"
     },
     {
@@ -3654,7 +3672,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/presentation/viewmodel.py",
       "source_location": "L15",
       "id": "presentation_viewmodel_summaryviewmodel_init",
-      "community": 4,
+      "community": 2,
       "norm_label": ".__init__()"
     },
     {
@@ -3663,7 +3681,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/presentation/viewmodel.py",
       "source_location": "L19",
       "id": "presentation_viewmodel_summaryviewmodel_on_generate",
-      "community": 5,
+      "community": 1,
       "norm_label": ".on_generate()"
     },
     {
@@ -3672,7 +3690,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/presentation/viewmodel.py",
       "source_location": "L22",
       "id": "presentation_viewmodel_summaryviewmodel_fetch",
-      "community": 4,
+      "community": 2,
       "norm_label": "._fetch()"
     },
     {
@@ -3681,7 +3699,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/presentation/viewmodel.py",
       "source_location": "L32",
       "id": "presentation_viewmodel_summaryviewmodel_build_view_data",
-      "community": 4,
+      "community": 2,
       "norm_label": "._build_view_data()"
     },
     {
@@ -3690,7 +3708,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/presentation/viewmodel.py",
       "source_location": "L38",
       "id": "presentation_viewmodel_summaryviewmodel_build_report",
-      "community": 4,
+      "community": 2,
       "norm_label": "._build_report()"
     },
     {
@@ -3699,7 +3717,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/presentation/viewmodel.py",
       "source_location": "L61",
       "id": "presentation_viewmodel_products_lines",
-      "community": 4,
+      "community": 2,
       "norm_label": "_products_lines()"
     },
     {
@@ -3708,7 +3726,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/presentation/view.py",
       "source_location": "L1",
       "id": "maria_cacau_features_home_sub_features_summary_presentation_view_py",
-      "community": 4,
+      "community": 1,
       "norm_label": "view.py"
     },
     {
@@ -3717,7 +3735,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/presentation/view.py",
       "source_location": "L15",
       "id": "presentation_view_summaryview",
-      "community": 0,
+      "community": 1,
       "norm_label": "summaryview"
     },
     {
@@ -3726,7 +3744,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/presentation/view.py",
       "source_location": "L22",
       "id": "presentation_view_summaryview_init",
-      "community": 0,
+      "community": 1,
       "norm_label": ".__init__()"
     },
     {
@@ -3735,7 +3753,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/presentation/view.py",
       "source_location": "L32",
       "id": "presentation_view_summaryview_setup_ui",
-      "community": 0,
+      "community": 1,
       "norm_label": "._setup_ui()"
     },
     {
@@ -3744,7 +3762,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/presentation/view.py",
       "source_location": "L37",
       "id": "presentation_view_summaryview_setup_components",
-      "community": 0,
+      "community": 1,
       "norm_label": "._setup_components()"
     },
     {
@@ -3753,7 +3771,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/presentation/view.py",
       "source_location": "L81",
       "id": "presentation_view_summaryview_setup_layout",
-      "community": 0,
+      "community": 1,
       "norm_label": "._setup_layout()"
     },
     {
@@ -3762,7 +3780,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/presentation/view.py",
       "source_location": "L112",
       "id": "presentation_view_summaryview_on_chart_type_changed",
-      "community": 0,
+      "community": 1,
       "norm_label": "._on_chart_type_changed()"
     },
     {
@@ -3771,7 +3789,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/presentation/view.py",
       "source_location": "L116",
       "id": "presentation_view_summaryview_update_buttons_state",
-      "community": 0,
+      "community": 1,
       "norm_label": "._update_buttons_state()"
     },
     {
@@ -3780,7 +3798,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/presentation/view.py",
       "source_location": "L124",
       "id": "presentation_view_summaryview_get_date_range",
-      "community": 5,
+      "community": 1,
       "norm_label": ".get_date_range()"
     },
     {
@@ -3789,7 +3807,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/presentation/view.py",
       "source_location": "L130",
       "id": "presentation_view_summaryview_update_data",
-      "community": 0,
+      "community": 1,
       "norm_label": ".update_data()"
     },
     {
@@ -3798,7 +3816,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/presentation/view.py",
       "source_location": "L136",
       "id": "presentation_view_summaryview_prepare_to_fetch",
-      "community": 5,
+      "community": 1,
       "norm_label": ".prepare_to_fetch()"
     },
     {
@@ -3807,7 +3825,7 @@
       "source_file": "maria_cacau/features/sheets/__init__.py",
       "source_location": "L1",
       "id": "maria_cacau_features_sheets_init_py",
-      "community": 29,
+      "community": 28,
       "norm_label": "__init__.py"
     },
     {
@@ -3816,7 +3834,7 @@
       "source_file": "maria_cacau/features/sheets/data/__init__.py",
       "source_location": "L1",
       "id": "maria_cacau_features_sheets_data_init_py",
-      "community": 12,
+      "community": 7,
       "norm_label": "__init__.py"
     },
     {
@@ -3825,7 +3843,7 @@
       "source_file": "maria_cacau/features/sheets/data/apis.py",
       "source_location": "L1",
       "id": "maria_cacau_features_sheets_data_apis_py",
-      "community": 12,
+      "community": 7,
       "norm_label": "apis.py"
     },
     {
@@ -3834,7 +3852,7 @@
       "source_file": "maria_cacau/features/sheets/data/apis.py",
       "source_location": "L5",
       "id": "data_apis_selectsheetapi",
-      "community": 12,
+      "community": 7,
       "norm_label": "selectsheetapi"
     },
     {
@@ -3843,7 +3861,7 @@
       "source_file": "maria_cacau/features/sheets/data/apis.py",
       "source_location": "L6",
       "id": "data_apis_selectsheetapi_init",
-      "community": 12,
+      "community": 7,
       "norm_label": ".__init__()"
     },
     {
@@ -3852,7 +3870,7 @@
       "source_file": "maria_cacau/features/sheets/data/apis.py",
       "source_location": "L16",
       "id": "data_apis_removesheetapi",
-      "community": 12,
+      "community": 7,
       "norm_label": "removesheetapi"
     },
     {
@@ -3861,7 +3879,7 @@
       "source_file": "maria_cacau/features/sheets/data/apis.py",
       "source_location": "L17",
       "id": "data_apis_removesheetapi_init",
-      "community": 12,
+      "community": 7,
       "norm_label": ".__init__()"
     },
     {
@@ -3870,7 +3888,7 @@
       "source_file": "maria_cacau/features/sheets/data/repository.py",
       "source_location": "L1",
       "id": "maria_cacau_features_sheets_data_repository_py",
-      "community": 12,
+      "community": 7,
       "norm_label": "repository.py"
     },
     {
@@ -3879,7 +3897,7 @@
       "source_file": "maria_cacau/features/sheets/data/repository.py",
       "source_location": "L17",
       "id": "data_repository_extract_sheet_id",
-      "community": 12,
+      "community": 7,
       "norm_label": "_extract_sheet_id()"
     },
     {
@@ -3888,7 +3906,7 @@
       "source_file": "maria_cacau/features/sheets/data/repository.py",
       "source_location": "L24",
       "id": "data_repository_sheetsrepository",
-      "community": 12,
+      "community": 7,
       "norm_label": "sheetsrepository"
     },
     {
@@ -3897,7 +3915,7 @@
       "source_file": "maria_cacau/features/sheets/data/repository.py",
       "source_location": "L25",
       "id": "data_repository_sheetsrepository_connect",
-      "community": 12,
+      "community": 7,
       "norm_label": ".connect()"
     },
     {
@@ -3906,7 +3924,7 @@
       "source_file": "maria_cacau/features/sheets/data/repository.py",
       "source_location": "L41",
       "id": "data_repository_sheetsrepository_select",
-      "community": 12,
+      "community": 7,
       "norm_label": ".select()"
     },
     {
@@ -3915,7 +3933,7 @@
       "source_file": "maria_cacau/features/sheets/data/repository.py",
       "source_location": "L47",
       "id": "data_repository_sheetsrepository_find_by_link",
-      "community": 12,
+      "community": 7,
       "norm_label": ".find_by_link()"
     },
     {
@@ -3924,7 +3942,7 @@
       "source_file": "maria_cacau/features/sheets/data/repository.py",
       "source_location": "L55",
       "id": "data_repository_sheetsrepository_load_all",
-      "community": 12,
+      "community": 7,
       "norm_label": ".load_all()"
     },
     {
@@ -3933,7 +3951,7 @@
       "source_file": "maria_cacau/features/sheets/data/repository.py",
       "source_location": "L58",
       "id": "data_repository_sheetsrepository_update_name",
-      "community": 12,
+      "community": 7,
       "norm_label": ".update_name()"
     },
     {
@@ -3942,7 +3960,7 @@
       "source_file": "maria_cacau/features/sheets/data/repository.py",
       "source_location": "L67",
       "id": "data_repository_sheetsrepository_last_sheet_id_from_cache",
-      "community": 12,
+      "community": 7,
       "norm_label": ".last_sheet_id_from_cache()"
     },
     {
@@ -3951,7 +3969,7 @@
       "source_file": "maria_cacau/features/sheets/data/repository.py",
       "source_location": "L72",
       "id": "data_repository_sheetsrepository_load_raw",
-      "community": 12,
+      "community": 7,
       "norm_label": "._load_raw()"
     },
     {
@@ -3959,9 +3977,9 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/features/sheets/data/repository.py",
       "source_location": "L68",
-      "id": "data_repository_rationale_68",
-      "community": 12,
-      "norm_label": "retorna o sheet_id da ultima planilha salva em cache, sem http."
+      "community": 7,
+      "norm_label": "retorna o sheet_id da ultima planilha salva em cache, sem http.",
+      "id": "data_repository_rationale_68"
     },
     {
       "label": "use_case.py",
@@ -4050,7 +4068,7 @@
       "source_file": "maria_cacau/features/sheets/domain/signals.py",
       "source_location": "L6",
       "id": "domain_signals_sheetssignals",
-      "community": 4,
+      "community": 11,
       "norm_label": "sheetssignals"
     },
     {
@@ -4068,7 +4086,7 @@
       "source_file": "maria_cacau/features/sheets/domain/models.py",
       "source_location": "L5",
       "id": "domain_models_sheetmodel",
-      "community": 12,
+      "community": 7,
       "norm_label": "sheetmodel"
     },
     {
@@ -4077,7 +4095,7 @@
       "source_file": "maria_cacau/features/sheets/domain/events.py",
       "source_location": "L1",
       "id": "maria_cacau_features_sheets_domain_events_py",
-      "community": 10,
+      "community": 8,
       "norm_label": "events.py"
     },
     {
@@ -4086,7 +4104,7 @@
       "source_file": "maria_cacau/features/sheets/domain/__init__.py",
       "source_location": "L1",
       "id": "maria_cacau_features_sheets_domain_init_py",
-      "community": 30,
+      "community": 29,
       "norm_label": "__init__.py"
     },
     {
@@ -4102,108 +4120,117 @@
       "label": "SheetsController",
       "file_type": "code",
       "source_file": "maria_cacau/features/sheets/presentation/controller.py",
-      "source_location": "L15",
+      "source_location": "L16",
       "id": "presentation_controller_sheetscontroller",
-      "community": 7,
+      "community": 4,
       "norm_label": "sheetscontroller"
     },
     {
       "label": ".__init__()",
       "file_type": "code",
       "source_file": "maria_cacau/features/sheets/presentation/controller.py",
-      "source_location": "L16",
+      "source_location": "L17",
       "id": "presentation_controller_sheetscontroller_init",
-      "community": 7,
+      "community": 4,
       "norm_label": ".__init__()"
     },
     {
       "label": "._setup_actions()",
       "file_type": "code",
       "source_file": "maria_cacau/features/sheets/presentation/controller.py",
-      "source_location": "L23",
+      "source_location": "L24",
       "id": "presentation_controller_sheetscontroller_setup_actions",
-      "community": 7,
+      "community": 4,
       "norm_label": "._setup_actions()"
     },
     {
       "label": "._load_saved_sheets()",
       "file_type": "code",
       "source_file": "maria_cacau/features/sheets/presentation/controller.py",
-      "source_location": "L31",
+      "source_location": "L33",
       "id": "presentation_controller_sheetscontroller_load_saved_sheets",
-      "community": 7,
+      "community": 4,
       "norm_label": "._load_saved_sheets()"
     },
     {
       "label": "._on_connect()",
       "file_type": "code",
       "source_file": "maria_cacau/features/sheets/presentation/controller.py",
-      "source_location": "L35",
+      "source_location": "L37",
       "id": "presentation_controller_sheetscontroller_on_connect",
-      "community": 7,
+      "community": 4,
       "norm_label": "._on_connect()"
     },
     {
       "label": "._update_sheet_name_if_needed()",
       "file_type": "code",
       "source_file": "maria_cacau/features/sheets/presentation/controller.py",
-      "source_location": "L49",
+      "source_location": "L51",
       "id": "presentation_controller_sheetscontroller_update_sheet_name_if_needed",
-      "community": 7,
+      "community": 4,
       "norm_label": "._update_sheet_name_if_needed()"
     },
     {
       "label": "._show_existing_dialog()",
       "file_type": "code",
       "source_file": "maria_cacau/features/sheets/presentation/controller.py",
-      "source_location": "L55",
+      "source_location": "L57",
       "id": "presentation_controller_sheetscontroller_show_existing_dialog",
-      "community": 7,
+      "community": 4,
       "norm_label": "._show_existing_dialog()"
+    },
+    {
+      "label": "._on_clear_cache()",
+      "file_type": "code",
+      "source_file": "maria_cacau/features/sheets/presentation/controller.py",
+      "source_location": "L78",
+      "id": "presentation_controller_sheetscontroller_on_clear_cache",
+      "community": 4,
+      "norm_label": "._on_clear_cache()"
     },
     {
       "label": "._on_select()",
       "file_type": "code",
       "source_file": "maria_cacau/features/sheets/presentation/controller.py",
-      "source_location": "L76",
+      "source_location": "L82",
       "id": "presentation_controller_sheetscontroller_on_select",
-      "community": 8,
+      "community": 9,
       "norm_label": "._on_select()"
     },
     {
       "label": "._on_renamed()",
       "file_type": "code",
       "source_file": "maria_cacau/features/sheets/presentation/controller.py",
-      "source_location": "L79",
+      "source_location": "L85",
       "id": "presentation_controller_sheetscontroller_on_renamed",
-      "community": 7,
+      "community": 4,
       "norm_label": "._on_renamed()"
     },
     {
       "label": "._on_connected()",
       "file_type": "code",
       "source_file": "maria_cacau/features/sheets/presentation/controller.py",
-      "source_location": "L83",
+      "source_location": "L89",
       "id": "presentation_controller_sheetscontroller_on_connected",
-      "community": 7,
+      "community": 4,
       "norm_label": "._on_connected()"
     },
     {
       "label": "._on_selected()",
       "file_type": "code",
       "source_file": "maria_cacau/features/sheets/presentation/controller.py",
-      "source_location": "L88",
+      "source_location": "L94",
       "id": "presentation_controller_sheetscontroller_on_selected",
-      "community": 7,
+      "community": 4,
       "norm_label": "._on_selected()"
     },
     {
       "label": "._on_error()",
       "file_type": "code",
       "source_file": "maria_cacau/features/sheets/presentation/controller.py",
-      "source_location": "L92",
+      "source_location": "L98",
       "id": "presentation_controller_sheetscontroller_on_error",
-      "community": 5,
+      "community": 1,
       "norm_label": "._on_error()"
     },
     {
@@ -4230,7 +4257,7 @@
       "source_file": "maria_cacau/features/sheets/presentation/viewmodel.py",
       "source_location": "L10",
       "id": "presentation_viewmodel_sheetsviewmodel",
-      "community": 7,
+      "community": 4,
       "norm_label": "sheetsviewmodel"
     },
     {
@@ -4248,7 +4275,7 @@
       "source_file": "maria_cacau/features/sheets/presentation/viewmodel.py",
       "source_location": "L17",
       "id": "presentation_viewmodel_sheetsviewmodel_load_all",
-      "community": 7,
+      "community": 4,
       "norm_label": ".load_all()"
     },
     {
@@ -4257,7 +4284,7 @@
       "source_file": "maria_cacau/features/sheets/presentation/viewmodel.py",
       "source_location": "L20",
       "id": "presentation_viewmodel_sheetsviewmodel_find_by_link",
-      "community": 7,
+      "community": 4,
       "norm_label": ".find_by_link()"
     },
     {
@@ -4266,7 +4293,7 @@
       "source_file": "maria_cacau/features/sheets/presentation/viewmodel.py",
       "source_location": "L25",
       "id": "presentation_viewmodel_sheetsviewmodel_update_name",
-      "community": 7,
+      "community": 4,
       "norm_label": ".update_name()"
     },
     {
@@ -4275,7 +4302,7 @@
       "source_file": "maria_cacau/features/sheets/presentation/viewmodel.py",
       "source_location": "L37",
       "id": "presentation_viewmodel_sheetsviewmodel_connect",
-      "community": 11,
+      "community": 4,
       "norm_label": ".connect()"
     },
     {
@@ -4284,7 +4311,7 @@
       "source_file": "maria_cacau/features/sheets/presentation/viewmodel.py",
       "source_location": "L48",
       "id": "presentation_viewmodel_sheetsviewmodel_select",
-      "community": 11,
+      "community": 4,
       "norm_label": ".select()"
     },
     {
@@ -4293,7 +4320,7 @@
       "source_file": "maria_cacau/features/sheets/presentation/view/sheet_create_view.py",
       "source_location": "L1",
       "id": "maria_cacau_features_sheets_presentation_view_sheet_create_view_py",
-      "community": 7,
+      "community": 4,
       "norm_label": "sheet_create_view.py"
     },
     {
@@ -4302,7 +4329,7 @@
       "source_file": "maria_cacau/features/sheets/presentation/view/sheet_create_view.py",
       "source_location": "L7",
       "id": "view_sheet_create_view_sheetcreateview",
-      "community": 7,
+      "community": 4,
       "norm_label": "sheetcreateview"
     },
     {
@@ -4311,7 +4338,7 @@
       "source_file": "",
       "source_location": "",
       "id": "qdialog",
-      "community": 7,
+      "community": 4,
       "norm_label": "qdialog"
     },
     {
@@ -4320,7 +4347,7 @@
       "source_file": "maria_cacau/features/sheets/presentation/view/sheet_create_view.py",
       "source_location": "L8",
       "id": "view_sheet_create_view_sheetcreateview_init",
-      "community": 7,
+      "community": 4,
       "norm_label": ".__init__()"
     },
     {
@@ -4329,7 +4356,7 @@
       "source_file": "maria_cacau/features/sheets/presentation/view/sheet_create_view.py",
       "source_location": "L13",
       "id": "view_sheet_create_view_link",
-      "community": 7,
+      "community": 4,
       "norm_label": "link()"
     },
     {
@@ -4338,7 +4365,7 @@
       "source_file": "maria_cacau/features/sheets/presentation/view/sheet_create_view.py",
       "source_location": "L17",
       "id": "view_sheet_create_view_name",
-      "community": 7,
+      "community": 4,
       "norm_label": "name()"
     },
     {
@@ -4347,7 +4374,7 @@
       "source_file": "maria_cacau/features/sheets/presentation/view/sheet_create_view.py",
       "source_location": "L20",
       "id": "view_sheet_create_view_sheetcreateview_setup_ui",
-      "community": 7,
+      "community": 4,
       "norm_label": "._setup_ui()"
     },
     {
@@ -4356,7 +4383,7 @@
       "source_file": "maria_cacau/features/sheets/presentation/view/sheet_create_view.py",
       "source_location": "L24",
       "id": "view_sheet_create_view_sheetcreateview_setup_components",
-      "community": 7,
+      "community": 4,
       "norm_label": "._setup_components()"
     },
     {
@@ -4365,7 +4392,7 @@
       "source_file": "maria_cacau/features/sheets/presentation/view/sheet_create_view.py",
       "source_location": "L39",
       "id": "view_sheet_create_view_sheetcreateview_setup_layout",
-      "community": 7,
+      "community": 4,
       "norm_label": "._setup_layout()"
     },
     {
@@ -4374,7 +4401,7 @@
       "source_file": "maria_cacau/features/sheets/presentation/view/sheets_menu_view.py",
       "source_location": "L1",
       "id": "maria_cacau_features_sheets_presentation_view_sheets_menu_view_py",
-      "community": 7,
+      "community": 4,
       "norm_label": "sheets_menu_view.py"
     },
     {
@@ -4383,7 +4410,7 @@
       "source_file": "maria_cacau/features/sheets/presentation/view/sheets_menu_view.py",
       "source_location": "L8",
       "id": "view_sheets_menu_view_sheetsmenuview",
-      "community": 7,
+      "community": 4,
       "norm_label": "sheetsmenuview"
     },
     {
@@ -4392,70 +4419,70 @@
       "source_file": "",
       "source_location": "",
       "id": "qmenu",
-      "community": 7,
+      "community": 4,
       "norm_label": "qmenu"
     },
     {
       "label": ".__init__()",
       "file_type": "code",
       "source_file": "maria_cacau/features/sheets/presentation/view/sheets_menu_view.py",
-      "source_location": "L12",
+      "source_location": "L13",
       "id": "view_sheets_menu_view_sheetsmenuview_init",
-      "community": 7,
+      "community": 4,
       "norm_label": ".__init__()"
     },
     {
       "label": "view_title()",
       "file_type": "code",
       "source_file": "maria_cacau/features/sheets/presentation/view/sheets_menu_view.py",
-      "source_location": "L17",
+      "source_location": "L18",
       "id": "view_sheets_menu_view_view_title",
-      "community": 7,
+      "community": 4,
       "norm_label": "view_title()"
     },
     {
       "label": "._setup_ui()",
       "file_type": "code",
       "source_file": "maria_cacau/features/sheets/presentation/view/sheets_menu_view.py",
-      "source_location": "L20",
+      "source_location": "L21",
       "id": "view_sheets_menu_view_sheetsmenuview_setup_ui",
-      "community": 7,
+      "community": 4,
       "norm_label": "._setup_ui()"
     },
     {
       "label": "._setup_components()",
       "file_type": "code",
       "source_file": "maria_cacau/features/sheets/presentation/view/sheets_menu_view.py",
-      "source_location": "L24",
+      "source_location": "L25",
       "id": "view_sheets_menu_view_sheetsmenuview_setup_components",
-      "community": 7,
+      "community": 4,
       "norm_label": "._setup_components()"
     },
     {
       "label": "._setup_layout()",
       "file_type": "code",
       "source_file": "maria_cacau/features/sheets/presentation/view/sheets_menu_view.py",
-      "source_location": "L36",
+      "source_location": "L38",
       "id": "view_sheets_menu_view_sheetsmenuview_setup_layout",
-      "community": 7,
+      "community": 4,
       "norm_label": "._setup_layout()"
     },
     {
       "label": ".add_or_update_sheet()",
       "file_type": "code",
       "source_file": "maria_cacau/features/sheets/presentation/view/sheets_menu_view.py",
-      "source_location": "L42",
+      "source_location": "L44",
       "id": "view_sheets_menu_view_sheetsmenuview_add_or_update_sheet",
-      "community": 7,
+      "community": 4,
       "norm_label": ".add_or_update_sheet()"
     },
     {
       "label": ".set_active()",
       "file_type": "code",
       "source_file": "maria_cacau/features/sheets/presentation/view/sheets_menu_view.py",
-      "source_location": "L55",
+      "source_location": "L57",
       "id": "view_sheets_menu_view_sheetsmenuview_set_active",
-      "community": 7,
+      "community": 4,
       "norm_label": ".set_active()"
     },
     {
@@ -4464,7 +4491,7 @@
       "source_file": "maria_cacau/features/sheets/presentation/view/__init__.py",
       "source_location": "L1",
       "id": "maria_cacau_features_sheets_presentation_view_init_py",
-      "community": 7,
+      "community": 4,
       "norm_label": "__init__.py"
     },
     {
@@ -4473,7 +4500,7 @@
       "source_file": "maria_cacau/features/auth/__init__.py",
       "source_location": "L1",
       "id": "maria_cacau_features_auth_init_py",
-      "community": 31,
+      "community": 30,
       "norm_label": "__init__.py"
     },
     {
@@ -4482,7 +4509,7 @@
       "source_file": "maria_cacau/features/auth/data/__init__.py",
       "source_location": "L1",
       "id": "maria_cacau_features_auth_data_init_py",
-      "community": 3,
+      "community": 2,
       "norm_label": "__init__.py"
     },
     {
@@ -4491,7 +4518,7 @@
       "source_file": "maria_cacau/features/auth/data/apis.py",
       "source_location": "L1",
       "id": "maria_cacau_features_auth_data_apis_py",
-      "community": 3,
+      "community": 2,
       "norm_label": "apis.py"
     },
     {
@@ -4500,7 +4527,7 @@
       "source_file": "maria_cacau/features/auth/data/apis.py",
       "source_location": "L7",
       "id": "data_apis_connectauthapi",
-      "community": 3,
+      "community": 7,
       "norm_label": "connectauthapi"
     },
     {
@@ -4509,7 +4536,7 @@
       "source_file": "maria_cacau/features/auth/data/apis.py",
       "source_location": "L8",
       "id": "data_apis_connectauthapi_init",
-      "community": 3,
+      "community": 7,
       "norm_label": ".__init__()"
     },
     {
@@ -4518,7 +4545,7 @@
       "source_file": "maria_cacau/features/auth/data/apis.py",
       "source_location": "L16",
       "id": "data_apis_connectauthapi_with_credentials",
-      "community": 3,
+      "community": 7,
       "norm_label": ".with_credentials()"
     },
     {
@@ -4527,7 +4554,7 @@
       "source_file": "maria_cacau/features/auth/data/apis.py",
       "source_location": "L21",
       "id": "data_apis_disconnectauthapi",
-      "community": 3,
+      "community": 7,
       "norm_label": "disconnectauthapi"
     },
     {
@@ -4536,7 +4563,7 @@
       "source_file": "maria_cacau/features/auth/data/apis.py",
       "source_location": "L22",
       "id": "data_apis_disconnectauthapi_init",
-      "community": 3,
+      "community": 7,
       "norm_label": ".__init__()"
     },
     {
@@ -4545,7 +4572,7 @@
       "source_file": "maria_cacau/features/auth/data/repository.py",
       "source_location": "L1",
       "id": "maria_cacau_features_auth_data_repository_py",
-      "community": 3,
+      "community": 2,
       "norm_label": "repository.py"
     },
     {
@@ -4554,7 +4581,7 @@
       "source_file": "maria_cacau/features/auth/data/repository.py",
       "source_location": "L13",
       "id": "data_repository_authrepository",
-      "community": 3,
+      "community": 7,
       "norm_label": "authrepository"
     },
     {
@@ -4563,7 +4590,7 @@
       "source_file": "maria_cacau/features/auth/data/repository.py",
       "source_location": "L14",
       "id": "data_repository_authrepository_configure",
-      "community": 3,
+      "community": 7,
       "norm_label": ".configure()"
     },
     {
@@ -4572,7 +4599,7 @@
       "source_file": "maria_cacau/features/auth/data/repository.py",
       "source_location": "L21",
       "id": "data_repository_authrepository_read_credentials",
-      "community": 3,
+      "community": 7,
       "norm_label": ".read_credentials()"
     },
     {
@@ -4581,7 +4608,7 @@
       "source_file": "maria_cacau/features/auth/data/repository.py",
       "source_location": "L26",
       "id": "data_repository_authrepository_clear",
-      "community": 3,
+      "community": 7,
       "norm_label": ".clear()"
     },
     {
@@ -4589,7 +4616,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/features/auth/data/repository.py",
       "source_location": "L15",
-      "community": 3,
+      "community": 7,
       "norm_label": "le o json do caminho, persiste em storage seguro e envia ao backend.",
       "id": "data_repository_rationale_15"
     },
@@ -4598,7 +4625,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/features/auth/data/repository.py",
       "source_location": "L22",
-      "community": 3,
+      "community": 7,
       "norm_label": "le credenciais salvas e autentica o backend. retorna false se nao houver.",
       "id": "data_repository_rationale_22"
     },
@@ -4607,9 +4634,9 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/features/auth/data/repository.py",
       "source_location": "L27",
-      "id": "data_repository_rationale_27",
-      "community": 3,
-      "norm_label": "remove credenciais do storage e desautentica o backend."
+      "community": 7,
+      "norm_label": "remove credenciais do storage e desautentica o backend.",
+      "id": "data_repository_rationale_27"
     },
     {
       "label": "use_case.py",
@@ -4617,7 +4644,7 @@
       "source_file": "maria_cacau/features/auth/domain/use_case.py",
       "source_location": "L1",
       "id": "maria_cacau_features_auth_domain_use_case_py",
-      "community": 10,
+      "community": 8,
       "norm_label": "use_case.py"
     },
     {
@@ -4626,7 +4653,7 @@
       "source_file": "maria_cacau/features/auth/domain/use_case.py",
       "source_location": "L8",
       "id": "domain_use_case_authusecase",
-      "community": 10,
+      "community": 8,
       "norm_label": "authusecase"
     },
     {
@@ -4635,7 +4662,7 @@
       "source_file": "maria_cacau/features/auth/domain/use_case.py",
       "source_location": "L9",
       "id": "domain_use_case_authusecase_init",
-      "community": 10,
+      "community": 8,
       "norm_label": ".__init__()"
     },
     {
@@ -4644,7 +4671,7 @@
       "source_file": "maria_cacau/features/auth/domain/use_case.py",
       "source_location": "L12",
       "id": "domain_use_case_authusecase_configure",
-      "community": 10,
+      "community": 8,
       "norm_label": ".configure()"
     },
     {
@@ -4653,7 +4680,7 @@
       "source_file": "maria_cacau/features/auth/domain/use_case.py",
       "source_location": "L17",
       "id": "domain_use_case_authusecase_clear",
-      "community": 10,
+      "community": 8,
       "norm_label": ".clear()"
     },
     {
@@ -4661,18 +4688,18 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/features/auth/domain/use_case.py",
       "source_location": "L13",
-      "id": "domain_use_case_rationale_13",
-      "community": 10,
-      "norm_label": "le o arquivo json, salva em storage seguro e autentica o backend."
+      "community": 8,
+      "norm_label": "le o arquivo json, salva em storage seguro e autentica o backend.",
+      "id": "domain_use_case_rationale_13"
     },
     {
       "label": "Remove credenciais do storage e desautentica o backend.",
       "file_type": "rationale",
       "source_file": "maria_cacau/features/auth/domain/use_case.py",
       "source_location": "L18",
-      "id": "domain_use_case_rationale_18",
-      "community": 10,
-      "norm_label": "remove credenciais do storage e desautentica o backend."
+      "community": 8,
+      "norm_label": "remove credenciais do storage e desautentica o backend.",
+      "id": "domain_use_case_rationale_18"
     },
     {
       "label": "signals.py",
@@ -4680,7 +4707,7 @@
       "source_file": "maria_cacau/features/auth/domain/signals.py",
       "source_location": "L1",
       "id": "maria_cacau_features_auth_domain_signals_py",
-      "community": 10,
+      "community": 8,
       "norm_label": "signals.py"
     },
     {
@@ -4689,7 +4716,7 @@
       "source_file": "maria_cacau/features/auth/domain/signals.py",
       "source_location": "L8",
       "id": "domain_signals_authsignals",
-      "community": 10,
+      "community": 8,
       "norm_label": "authsignals"
     },
     {
@@ -4698,7 +4725,7 @@
       "source_file": "maria_cacau/features/auth/domain/events.py",
       "source_location": "L1",
       "id": "maria_cacau_features_auth_domain_events_py",
-      "community": 10,
+      "community": 8,
       "norm_label": "events.py"
     },
     {
@@ -4707,7 +4734,7 @@
       "source_file": "maria_cacau/features/auth/domain/__init__.py",
       "source_location": "L1",
       "id": "maria_cacau_features_auth_domain_init_py",
-      "community": 32,
+      "community": 31,
       "norm_label": "__init__.py"
     },
     {
@@ -4716,7 +4743,7 @@
       "source_file": "maria_cacau/features/auth/domain/init_use_case.py",
       "source_location": "L1",
       "id": "maria_cacau_features_auth_domain_init_use_case_py",
-      "community": 3,
+      "community": 2,
       "norm_label": "init_use_case.py"
     },
     {
@@ -4725,7 +4752,7 @@
       "source_file": "maria_cacau/features/auth/domain/init_use_case.py",
       "source_location": "L8",
       "id": "domain_init_use_case_appinitusecase",
-      "community": 3,
+      "community": 7,
       "norm_label": "appinitusecase"
     },
     {
@@ -4734,7 +4761,7 @@
       "source_file": "maria_cacau/features/auth/domain/init_use_case.py",
       "source_location": "L9",
       "id": "domain_init_use_case_appinitusecase_init",
-      "community": 3,
+      "community": 7,
       "norm_label": ".__init__()"
     },
     {
@@ -4743,7 +4770,7 @@
       "source_file": "maria_cacau/features/auth/domain/init_use_case.py",
       "source_location": "L13",
       "id": "domain_init_use_case_appinitusecase_initialize",
-      "community": 3,
+      "community": 7,
       "norm_label": ".initialize()"
     },
     {
@@ -4752,7 +4779,7 @@
       "source_file": "maria_cacau/features/auth/presentation/controller.py",
       "source_location": "L1",
       "id": "maria_cacau_features_auth_presentation_controller_py",
-      "community": 10,
+      "community": 8,
       "norm_label": "controller.py"
     },
     {
@@ -4761,7 +4788,7 @@
       "source_file": "maria_cacau/features/auth/presentation/controller.py",
       "source_location": "L16",
       "id": "presentation_controller_authcontroller",
-      "community": 10,
+      "community": 8,
       "norm_label": "authcontroller"
     },
     {
@@ -4770,7 +4797,7 @@
       "source_file": "maria_cacau/features/auth/presentation/controller.py",
       "source_location": "L17",
       "id": "presentation_controller_authcontroller_init",
-      "community": 10,
+      "community": 8,
       "norm_label": ".__init__()"
     },
     {
@@ -4779,7 +4806,7 @@
       "source_file": "maria_cacau/features/auth/presentation/controller.py",
       "source_location": "L23",
       "id": "presentation_controller_authcontroller_setup_actions",
-      "community": 10,
+      "community": 8,
       "norm_label": "._setup_actions()"
     },
     {
@@ -4788,7 +4815,7 @@
       "source_file": "maria_cacau/features/auth/presentation/controller.py",
       "source_location": "L31",
       "id": "presentation_controller_authcontroller_on_configure",
-      "community": 10,
+      "community": 8,
       "norm_label": "._on_configure()"
     },
     {
@@ -4797,7 +4824,7 @@
       "source_file": "maria_cacau/features/auth/presentation/controller.py",
       "source_location": "L38",
       "id": "presentation_controller_authcontroller_on_clear",
-      "community": 10,
+      "community": 8,
       "norm_label": "._on_clear()"
     },
     {
@@ -4806,7 +4833,7 @@
       "source_file": "maria_cacau/features/auth/presentation/controller.py",
       "source_location": "L48",
       "id": "presentation_controller_authcontroller_on_configured",
-      "community": 10,
+      "community": 8,
       "norm_label": "._on_configured()"
     },
     {
@@ -4815,7 +4842,7 @@
       "source_file": "maria_cacau/features/auth/presentation/controller.py",
       "source_location": "L51",
       "id": "presentation_controller_authcontroller_on_cleared",
-      "community": 10,
+      "community": 8,
       "norm_label": "._on_cleared()"
     },
     {
@@ -4824,7 +4851,7 @@
       "source_file": "maria_cacau/features/auth/presentation/controller.py",
       "source_location": "L54",
       "id": "presentation_controller_authcontroller_on_error",
-      "community": 5,
+      "community": 1,
       "norm_label": "._on_error()"
     },
     {
@@ -4833,7 +4860,7 @@
       "source_file": "maria_cacau/features/auth/presentation/__init__.py",
       "source_location": "L1",
       "id": "maria_cacau_features_auth_presentation_init_py",
-      "community": 10,
+      "community": 8,
       "norm_label": "__init__.py"
     },
     {
@@ -4842,7 +4869,7 @@
       "source_file": "maria_cacau/features/auth/presentation/viewmodel.py",
       "source_location": "L1",
       "id": "maria_cacau_features_auth_presentation_viewmodel_py",
-      "community": 10,
+      "community": 8,
       "norm_label": "viewmodel.py"
     },
     {
@@ -4851,7 +4878,7 @@
       "source_file": "maria_cacau/features/auth/presentation/viewmodel.py",
       "source_location": "L11",
       "id": "presentation_viewmodel_authviewmodel",
-      "community": 10,
+      "community": 8,
       "norm_label": "authviewmodel"
     },
     {
@@ -4860,7 +4887,7 @@
       "source_file": "maria_cacau/features/auth/presentation/viewmodel.py",
       "source_location": "L12",
       "id": "presentation_viewmodel_authviewmodel_init",
-      "community": 10,
+      "community": 8,
       "norm_label": ".__init__()"
     },
     {
@@ -4869,7 +4896,7 @@
       "source_file": "maria_cacau/features/auth/presentation/viewmodel.py",
       "source_location": "L17",
       "id": "presentation_viewmodel_authviewmodel_configure",
-      "community": 2,
+      "community": 4,
       "norm_label": ".configure()"
     },
     {
@@ -4878,7 +4905,7 @@
       "source_file": "maria_cacau/features/auth/presentation/viewmodel.py",
       "source_location": "L28",
       "id": "presentation_viewmodel_authviewmodel_clear",
-      "community": 0,
+      "community": 8,
       "norm_label": ".clear()"
     },
     {
@@ -4887,7 +4914,7 @@
       "source_file": "maria_cacau/features/auth/presentation/view.py",
       "source_location": "L1",
       "id": "maria_cacau_features_auth_presentation_view_py",
-      "community": 4,
+      "community": 1,
       "norm_label": "view.py"
     },
     {
@@ -4896,7 +4923,7 @@
       "source_file": "maria_cacau/features/auth/presentation/view.py",
       "source_location": "L10",
       "id": "presentation_view_authview",
-      "community": 10,
+      "community": 8,
       "norm_label": "authview"
     },
     {
@@ -4905,7 +4932,7 @@
       "source_file": "maria_cacau/features/auth/presentation/view.py",
       "source_location": "L14",
       "id": "presentation_view_authview_init",
-      "community": 10,
+      "community": 8,
       "norm_label": ".__init__()"
     },
     {
@@ -4914,7 +4941,7 @@
       "source_file": "maria_cacau/features/auth/presentation/view.py",
       "source_location": "L22",
       "id": "presentation_view_authview_setup_actions",
-      "community": 10,
+      "community": 8,
       "norm_label": "._setup_actions()"
     },
     {
@@ -4923,7 +4950,7 @@
       "source_file": "maria_cacau/backend/__init__.py",
       "source_location": "L1",
       "id": "maria_cacau_backend_init_py",
-      "community": 33,
+      "community": 32,
       "norm_label": "__init__.py"
     },
     {
@@ -4932,7 +4959,7 @@
       "source_file": "maria_cacau/backend/_server.py",
       "source_location": "L1",
       "id": "maria_cacau_backend_server_py",
-      "community": 11,
+      "community": 12,
       "norm_label": "_server.py"
     },
     {
@@ -4941,7 +4968,7 @@
       "source_file": "maria_cacau/backend/_server.py",
       "source_location": "L15",
       "id": "backend_server_handle_data_source_error",
-      "community": 11,
+      "community": 12,
       "norm_label": "handle_data_source_error()"
     },
     {
@@ -4950,7 +4977,7 @@
       "source_file": "maria_cacau/backend/_server.py",
       "source_location": "L21",
       "id": "backend_server_handle_backend_error",
-      "community": 11,
+      "community": 12,
       "norm_label": "handle_backend_error()"
     },
     {
@@ -4959,7 +4986,7 @@
       "source_file": "maria_cacau/backend/_server.py",
       "source_location": "L26",
       "id": "backend_server_handle_unexpected_error",
-      "community": 11,
+      "community": 12,
       "norm_label": "handle_unexpected_error()"
     },
     {
@@ -4968,7 +4995,7 @@
       "source_file": "maria_cacau/backend/_server.py",
       "source_location": "L34",
       "id": "backend_server_backendserver",
-      "community": 2,
+      "community": 4,
       "norm_label": "backendserver"
     },
     {
@@ -4977,7 +5004,7 @@
       "source_file": "maria_cacau/backend/_server.py",
       "source_location": "L35",
       "id": "backend_server_backendserver_execute",
-      "community": 2,
+      "community": 4,
       "norm_label": ".execute()"
     },
     {
@@ -4986,7 +5013,7 @@
       "source_file": "maria_cacau/backend/data_source/_google_sheets.py",
       "source_location": "L1",
       "id": "maria_cacau_backend_data_source_google_sheets_py",
-      "community": 1,
+      "community": 0,
       "norm_label": "_google_sheets.py"
     },
     {
@@ -4995,7 +5022,7 @@
       "source_file": "maria_cacau/backend/data_source/_google_sheets.py",
       "source_location": "L15",
       "id": "data_source_google_sheets_googlesheetsdatasource",
-      "community": 1,
+      "community": 0,
       "norm_label": "googlesheetsdatasource"
     },
     {
@@ -5004,7 +5031,7 @@
       "source_file": "maria_cacau/backend/data_source/_google_sheets.py",
       "source_location": "L18",
       "id": "data_source_google_sheets_googlesheetsdatasource_init",
-      "community": 1,
+      "community": 0,
       "norm_label": ".__init__()"
     },
     {
@@ -5013,7 +5040,7 @@
       "source_file": "maria_cacau/backend/data_source/_google_sheets.py",
       "source_location": "L26",
       "id": "data_source_google_sheets_googlesheetsdatasource_is_ready",
-      "community": 1,
+      "community": 0,
       "norm_label": ".is_ready()"
     },
     {
@@ -5022,7 +5049,7 @@
       "source_file": "maria_cacau/backend/data_source/_google_sheets.py",
       "source_location": "L29",
       "id": "data_source_google_sheets_googlesheetsdatasource_set_credentials",
-      "community": 1,
+      "community": 0,
       "norm_label": ".set_credentials()"
     },
     {
@@ -5031,7 +5058,7 @@
       "source_file": "maria_cacau/backend/data_source/_google_sheets.py",
       "source_location": "L37",
       "id": "data_source_google_sheets_googlesheetsdatasource_clear_credentials",
-      "community": 1,
+      "community": 0,
       "norm_label": ".clear_credentials()"
     },
     {
@@ -5040,7 +5067,7 @@
       "source_file": "maria_cacau/backend/data_source/_google_sheets.py",
       "source_location": "L41",
       "id": "data_source_google_sheets_googlesheetsdatasource_clear_sheet",
-      "community": 1,
+      "community": 0,
       "norm_label": ".clear_sheet()"
     },
     {
@@ -5049,7 +5076,7 @@
       "source_file": "maria_cacau/backend/data_source/_google_sheets.py",
       "source_location": "L45",
       "id": "data_source_google_sheets_googlesheetsdatasource_set_sheet",
-      "community": 1,
+      "community": 0,
       "norm_label": ".set_sheet()"
     },
     {
@@ -5058,7 +5085,7 @@
       "source_file": "maria_cacau/backend/data_source/_google_sheets.py",
       "source_location": "L51",
       "id": "data_source_google_sheets_googlesheetsdatasource_fetch_orders_by_date",
-      "community": 1,
+      "community": 0,
       "norm_label": ".fetch_orders_by_date()"
     },
     {
@@ -5067,7 +5094,7 @@
       "source_file": "maria_cacau/backend/data_source/_google_sheets.py",
       "source_location": "L57",
       "id": "data_source_google_sheets_googlesheetsdatasource_fetch_orders_by_period",
-      "community": 1,
+      "community": 0,
       "norm_label": ".fetch_orders_by_period()"
     },
     {
@@ -5076,7 +5103,7 @@
       "source_file": "maria_cacau/backend/data_source/_google_sheets.py",
       "source_location": "L67",
       "id": "data_source_google_sheets_googlesheetsdatasource_setup_vm",
-      "community": 1,
+      "community": 0,
       "norm_label": "._setup_vm()"
     },
     {
@@ -5084,7 +5111,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/data_source/_google_sheets.py",
       "source_location": "L16",
-      "community": 1,
+      "community": 0,
       "norm_label": "implementacao de datasourceprotocol para google sheets via gspread.",
       "id": "data_source_google_sheets_rationale_16"
     },
@@ -5094,7 +5121,7 @@
       "source_file": "maria_cacau/backend/data_source/__init__.py",
       "source_location": "L1",
       "id": "maria_cacau_backend_data_source_init_py",
-      "community": 1,
+      "community": 0,
       "norm_label": "__init__.py"
     },
     {
@@ -5103,7 +5130,7 @@
       "source_file": "maria_cacau/backend/data_source/_protocol.py",
       "source_location": "L1",
       "id": "maria_cacau_backend_data_source_protocol_py",
-      "community": 8,
+      "community": 9,
       "norm_label": "_protocol.py"
     },
     {
@@ -5112,7 +5139,7 @@
       "source_file": "maria_cacau/backend/data_source/_protocol.py",
       "source_location": "L5",
       "id": "data_source_protocol_datasourceprotocol",
-      "community": 8,
+      "community": 9,
       "norm_label": "datasourceprotocol"
     },
     {
@@ -5121,7 +5148,7 @@
       "source_file": "maria_cacau/backend/data_source/_protocol.py",
       "source_location": "L8",
       "id": "data_source_protocol_datasourceprotocol_is_ready",
-      "community": 8,
+      "community": 9,
       "norm_label": ".is_ready()"
     },
     {
@@ -5130,7 +5157,7 @@
       "source_file": "maria_cacau/backend/data_source/_protocol.py",
       "source_location": "L12",
       "id": "data_source_protocol_datasourceprotocol_set_credentials",
-      "community": 8,
+      "community": 9,
       "norm_label": ".set_credentials()"
     },
     {
@@ -5139,7 +5166,7 @@
       "source_file": "maria_cacau/backend/data_source/_protocol.py",
       "source_location": "L16",
       "id": "data_source_protocol_datasourceprotocol_clear_credentials",
-      "community": 8,
+      "community": 9,
       "norm_label": ".clear_credentials()"
     },
     {
@@ -5148,7 +5175,7 @@
       "source_file": "maria_cacau/backend/data_source/_protocol.py",
       "source_location": "L20",
       "id": "data_source_protocol_datasourceprotocol_clear_sheet",
-      "community": 8,
+      "community": 9,
       "norm_label": ".clear_sheet()"
     },
     {
@@ -5157,7 +5184,7 @@
       "source_file": "maria_cacau/backend/data_source/_protocol.py",
       "source_location": "L24",
       "id": "data_source_protocol_datasourceprotocol_set_sheet",
-      "community": 8,
+      "community": 9,
       "norm_label": ".set_sheet()"
     },
     {
@@ -5166,7 +5193,7 @@
       "source_file": "maria_cacau/backend/data_source/_protocol.py",
       "source_location": "L28",
       "id": "data_source_protocol_datasourceprotocol_fetch_orders_by_date",
-      "community": 8,
+      "community": 9,
       "norm_label": ".fetch_orders_by_date()"
     },
     {
@@ -5175,7 +5202,7 @@
       "source_file": "maria_cacau/backend/data_source/_protocol.py",
       "source_location": "L32",
       "id": "data_source_protocol_datasourceprotocol_fetch_orders_by_period",
-      "community": 8,
+      "community": 9,
       "norm_label": ".fetch_orders_by_period()"
     },
     {
@@ -5183,7 +5210,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/data_source/_protocol.py",
       "source_location": "L6",
-      "community": 8,
+      "community": 9,
       "norm_label": "contrato agnostico de fonte de dados para pedidos.",
       "id": "data_source_protocol_rationale_6"
     },
@@ -5192,7 +5219,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/data_source/_protocol.py",
       "source_location": "L9",
-      "community": 8,
+      "community": 9,
       "norm_label": "retorna true se credentials e sheet estao configurados em memoria.",
       "id": "data_source_protocol_rationale_9"
     },
@@ -5201,7 +5228,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/data_source/_protocol.py",
       "source_location": "L13",
-      "community": 8,
+      "community": 9,
       "norm_label": "autentica com o json bruto da service account e guarda o client em memoria.",
       "id": "data_source_protocol_rationale_13"
     },
@@ -5210,7 +5237,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/data_source/_protocol.py",
       "source_location": "L17",
-      "community": 8,
+      "community": 9,
       "norm_label": "define a planilha ativa e dispara prewarm em background.",
       "id": "data_source_protocol_rationale_17"
     },
@@ -5219,7 +5246,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/data_source/_protocol.py",
       "source_location": "L21",
-      "community": 8,
+      "community": 9,
       "norm_label": "retorna pedidos da data informada (dd/mm/yyyy).",
       "id": "data_source_protocol_rationale_21"
     },
@@ -5228,7 +5255,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/data_source/_protocol.py",
       "source_location": "L25",
-      "community": 8,
+      "community": 9,
       "norm_label": "retorna pedidos no intervalo de datas informado (dd/mm/yyyy).",
       "id": "data_source_protocol_rationale_25"
     },
@@ -5237,7 +5264,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/data_source/_protocol.py",
       "source_location": "L29",
-      "community": 8,
+      "community": 9,
       "norm_label": "retorna pedidos no intervalo de datas informado (dd/mm/yyyy).",
       "id": "data_source_protocol_rationale_29"
     },
@@ -5246,7 +5273,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/data_source/_protocol.py",
       "source_location": "L33",
-      "community": 8,
+      "community": 9,
       "norm_label": "retorna pedidos no intervalo de datas informado (dd/mm/yyyy).",
       "id": "data_source_protocol_rationale_33"
     },
@@ -5256,7 +5283,7 @@
       "source_file": "maria_cacau/backend/data_source/sheet_mapper.py",
       "source_location": "L1",
       "id": "maria_cacau_backend_data_source_sheet_mapper_py",
-      "community": 1,
+      "community": 0,
       "norm_label": "sheet_mapper.py"
     },
     {
@@ -5265,7 +5292,7 @@
       "source_file": "maria_cacau/backend/data_source/sheet_mapper.py",
       "source_location": "L9",
       "id": "data_source_sheet_mapper_sheettabs",
-      "community": 1,
+      "community": 0,
       "norm_label": "sheettabs"
     },
     {
@@ -5274,7 +5301,7 @@
       "source_file": "maria_cacau/backend/data_source/sheet_mapper.py",
       "source_location": "L14",
       "id": "data_source_sheet_mapper_sheetcols",
-      "community": 1,
+      "community": 0,
       "norm_label": "sheetcols"
     },
     {
@@ -5283,7 +5310,7 @@
       "source_file": "maria_cacau/backend/data_source/sheet_mapper.py",
       "source_location": "L62",
       "id": "data_source_sheet_mapper_productcols",
-      "community": 1,
+      "community": 0,
       "norm_label": "productcols"
     },
     {
@@ -5292,7 +5319,7 @@
       "source_file": "maria_cacau/backend/data_source/sheet_mapper.py",
       "source_location": "L70",
       "id": "data_source_sheet_mapper_productcols_slot",
-      "community": 1,
+      "community": 0,
       "norm_label": ".slot()"
     },
     {
@@ -5301,7 +5328,7 @@
       "source_file": "maria_cacau/backend/data_source/sheet_mapper.py",
       "source_location": "L74",
       "id": "data_source_sheet_mapper_paymentcols",
-      "community": 1,
+      "community": 0,
       "norm_label": "paymentcols"
     },
     {
@@ -5318,7 +5345,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/data_source/sheet_mapper.py",
       "source_location": "L1",
-      "community": 1,
+      "community": 0,
       "norm_label": "mapeamento de colunas e tabs da planilha.",
       "id": "data_source_sheet_mapper_rationale_1"
     },
@@ -5327,7 +5354,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/data_source/sheet_mapper.py",
       "source_location": "L15",
-      "community": 1,
+      "community": 0,
       "norm_label": "colunas fixas da aba cadastro, agrupadas por dominio.",
       "id": "data_source_sheet_mapper_rationale_15"
     },
@@ -5336,7 +5363,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/data_source/sheet_mapper.py",
       "source_location": "L63",
-      "community": 1,
+      "community": 0,
       "norm_label": "colunas dos slots de produto (1\u20137). usar com .slot(n).",
       "id": "data_source_sheet_mapper_rationale_63"
     },
@@ -5345,7 +5372,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/data_source/sheet_mapper.py",
       "source_location": "L75",
-      "community": 1,
+      "community": 0,
       "norm_label": "colunas das parcelas de pagamento (1\u20136). usar com .slot(n).",
       "id": "data_source_sheet_mapper_rationale_75"
     },
@@ -5355,7 +5382,7 @@
       "source_file": "maria_cacau/backend/data_source/_normalizer.py",
       "source_location": "L1",
       "id": "maria_cacau_backend_data_source_normalizer_py",
-      "community": 1,
+      "community": 0,
       "norm_label": "_normalizer.py"
     },
     {
@@ -5364,7 +5391,7 @@
       "source_file": "maria_cacau/backend/data_source/_normalizer.py",
       "source_location": "L6",
       "id": "data_source_normalizer_sheetnormalizer",
-      "community": 1,
+      "community": 0,
       "norm_label": "sheetnormalizer"
     },
     {
@@ -5373,7 +5400,7 @@
       "source_file": "maria_cacau/backend/data_source/_normalizer.py",
       "source_location": "L20",
       "id": "data_source_normalizer_normalize",
-      "community": 1,
+      "community": 0,
       "norm_label": "normalize()"
     },
     {
@@ -5382,7 +5409,7 @@
       "source_file": "maria_cacau/backend/data_source/_normalizer.py",
       "source_location": "L28",
       "id": "data_source_normalizer_rename_keys",
-      "community": 1,
+      "community": 0,
       "norm_label": "_rename_keys()"
     },
     {
@@ -5391,7 +5418,7 @@
       "source_file": "maria_cacau/backend/data_source/_normalizer.py",
       "source_location": "L32",
       "id": "data_source_normalizer_fix_prod4",
-      "community": 1,
+      "community": 0,
       "norm_label": "_fix_prod4()"
     },
     {
@@ -5400,7 +5427,7 @@
       "source_file": "maria_cacau/backend/data_source/_normalizer.py",
       "source_location": "L52",
       "id": "data_source_normalizer_rename_at",
-      "community": 1,
+      "community": 0,
       "norm_label": "_rename_at()"
     },
     {
@@ -5408,7 +5435,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/data_source/_normalizer.py",
       "source_location": "L1",
-      "community": 1,
+      "community": 0,
       "norm_label": "normaliza headers inconsistentes da planilha para os valores canonicos dos enums",
       "id": "data_source_normalizer_rationale_1"
     },
@@ -5417,7 +5444,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/data_source/_normalizer.py",
       "source_location": "L7",
-      "community": 1,
+      "community": 0,
       "norm_label": "traduz headers reais da planilha para os nomes canonicos definidos nos enums.",
       "id": "data_source_normalizer_rationale_7"
     },
@@ -5426,7 +5453,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/data_source/_normalizer.py",
       "source_location": "L33",
-      "community": 1,
+      "community": 0,
       "norm_label": "renomeia a coluna que segue prod3 para prod4, independente do header atual.",
       "id": "data_source_normalizer_rationale_33"
     },
@@ -5436,7 +5463,7 @@
       "source_file": "maria_cacau/backend/data_source/_viewmodel.py",
       "source_location": "L1",
       "id": "maria_cacau_backend_data_source_viewmodel_py",
-      "community": 1,
+      "community": 0,
       "norm_label": "_viewmodel.py"
     },
     {
@@ -5445,7 +5472,7 @@
       "source_file": "maria_cacau/backend/data_source/_viewmodel.py",
       "source_location": "L9",
       "id": "data_source_viewmodel_sheetsviewmodel",
-      "community": 1,
+      "community": 0,
       "norm_label": "_sheetsviewmodel"
     },
     {
@@ -5454,7 +5481,7 @@
       "source_file": "maria_cacau/backend/data_source/_viewmodel.py",
       "source_location": "L12",
       "id": "data_source_viewmodel_sheetsviewmodel_init",
-      "community": 1,
+      "community": 0,
       "norm_label": ".__init__()"
     },
     {
@@ -5463,7 +5490,7 @@
       "source_file": "maria_cacau/backend/data_source/_viewmodel.py",
       "source_location": "L19",
       "id": "data_source_viewmodel_database",
-      "community": 1,
+      "community": 0,
       "norm_label": "database()"
     },
     {
@@ -5472,7 +5499,7 @@
       "source_file": "maria_cacau/backend/data_source/_viewmodel.py",
       "source_location": "L22",
       "id": "data_source_viewmodel_sheetsviewmodel_prewarm",
-      "community": 1,
+      "community": 0,
       "norm_label": ".prewarm()"
     },
     {
@@ -5481,7 +5508,7 @@
       "source_file": "maria_cacau/backend/data_source/_viewmodel.py",
       "source_location": "L28",
       "id": "data_source_viewmodel_sheetsviewmodel_load_schema",
-      "community": 1,
+      "community": 0,
       "norm_label": "._load_schema()"
     },
     {
@@ -5490,7 +5517,7 @@
       "source_file": "maria_cacau/backend/data_source/_viewmodel.py",
       "source_location": "L42",
       "id": "data_source_viewmodel_fetch",
-      "community": 1,
+      "community": 0,
       "norm_label": "fetch()"
     },
     {
@@ -5498,7 +5525,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/data_source/_viewmodel.py",
       "source_location": "L10",
-      "community": 1,
+      "community": 0,
       "norm_label": "encapsula o acesso a planilha: schema cacheado, prewarm e fetch.",
       "id": "data_source_viewmodel_rationale_10"
     },
@@ -5507,7 +5534,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/data_source/_viewmodel.py",
       "source_location": "L29",
-      "community": 1,
+      "community": 0,
       "norm_label": "carrega cabecalho e indice da coluna data na primeira chamada; no-op nas seguint",
       "id": "data_source_viewmodel_rationale_29"
     },
@@ -5516,7 +5543,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/data_source/_viewmodel.py",
       "source_location": "L43",
-      "community": 1,
+      "community": 0,
       "norm_label": "busca pedidos por datas usando dois passes para minimizar chamadas a api.",
       "id": "data_source_viewmodel_rationale_43"
     },
@@ -5526,7 +5553,7 @@
       "source_file": "maria_cacau/backend/data_source/_utils.py",
       "source_location": "L1",
       "id": "maria_cacau_backend_data_source_utils_py",
-      "community": 1,
+      "community": 0,
       "norm_label": "_utils.py"
     },
     {
@@ -5535,7 +5562,7 @@
       "source_file": "maria_cacau/backend/data_source/_utils.py",
       "source_location": "L5",
       "id": "data_source_utils_normalize_date",
-      "community": 1,
+      "community": 0,
       "norm_label": "normalize_date()"
     },
     {
@@ -5544,7 +5571,7 @@
       "source_file": "maria_cacau/backend/data_source/_utils.py",
       "source_location": "L15",
       "id": "data_source_utils_to_dicts",
-      "community": 1,
+      "community": 0,
       "norm_label": "to_dicts()"
     },
     {
@@ -5553,7 +5580,7 @@
       "source_file": "maria_cacau/backend/data_source/_utils.py",
       "source_location": "L21",
       "id": "data_source_utils_to_ranges",
-      "community": 1,
+      "community": 0,
       "norm_label": "to_ranges()"
     },
     {
@@ -5562,7 +5589,7 @@
       "source_file": "maria_cacau/backend/data_source/_utils.py",
       "source_location": "L34",
       "id": "data_source_utils_date_range",
-      "community": 1,
+      "community": 0,
       "norm_label": "date_range()"
     },
     {
@@ -5570,7 +5597,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/data_source/_utils.py",
       "source_location": "L6",
-      "community": 1,
+      "community": 0,
       "norm_label": "normaliza uma data para dd/mm/yyyy aceitando os formatos dd/mm/yy e dd/mm/yyyy.",
       "id": "data_source_utils_rationale_6"
     },
@@ -5579,7 +5606,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/data_source/_utils.py",
       "source_location": "L16",
-      "community": 1,
+      "community": 0,
       "norm_label": "converte linhas da planilha em lista de dicts usando o cabecalho como chaves (lo",
       "id": "data_source_utils_rationale_16"
     },
@@ -5588,7 +5615,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/data_source/_utils.py",
       "source_location": "L22",
-      "community": 1,
+      "community": 0,
       "norm_label": "agrupa numeros de linha consecutivos em ranges a1 notation e divide em batches d",
       "id": "data_source_utils_rationale_22"
     },
@@ -5597,7 +5624,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/data_source/_utils.py",
       "source_location": "L35",
-      "community": 1,
+      "community": 0,
       "norm_label": "retorna o conjunto de todas as datas (dd/mm/yyyy) entre start e end, inclusive.",
       "id": "data_source_utils_rationale_35"
     },
@@ -5607,7 +5634,7 @@
       "source_file": "maria_cacau/backend/data_source/errors/_handler.py",
       "source_location": "L1",
       "id": "maria_cacau_backend_data_source_errors_handler_py",
-      "community": 1,
+      "community": 0,
       "norm_label": "_handler.py"
     },
     {
@@ -5616,7 +5643,7 @@
       "source_file": "maria_cacau/backend/data_source/errors/_handler.py",
       "source_location": "L14",
       "id": "errors_handler_is_valid_date",
-      "community": 1,
+      "community": 0,
       "norm_label": "_is_valid_date()"
     },
     {
@@ -5625,7 +5652,7 @@
       "source_file": "maria_cacau/backend/data_source/errors/_handler.py",
       "source_location": "L18",
       "id": "errors_handler_parse_date",
-      "community": 1,
+      "community": 0,
       "norm_label": "_parse_date()"
     },
     {
@@ -5634,7 +5661,7 @@
       "source_file": "maria_cacau/backend/data_source/errors/_handler.py",
       "source_location": "L22",
       "id": "errors_handler_sheetsguard",
-      "community": 1,
+      "community": 0,
       "norm_label": "_sheetsguard"
     },
     {
@@ -5643,7 +5670,7 @@
       "source_file": "maria_cacau/backend/data_source/errors/_handler.py",
       "source_location": "L27",
       "id": "errors_handler_credentials_file",
-      "community": 1,
+      "community": 0,
       "norm_label": "credentials_file()"
     },
     {
@@ -5652,7 +5679,7 @@
       "source_file": "maria_cacau/backend/data_source/errors/_handler.py",
       "source_location": "L34",
       "id": "errors_handler_local_storage",
-      "community": 1,
+      "community": 0,
       "norm_label": "local_storage()"
     },
     {
@@ -5661,7 +5688,7 @@
       "source_file": "maria_cacau/backend/data_source/errors/_handler.py",
       "source_location": "L41",
       "id": "errors_handler_authentication",
-      "community": 1,
+      "community": 0,
       "norm_label": "authentication()"
     },
     {
@@ -5670,7 +5697,7 @@
       "source_file": "maria_cacau/backend/data_source/errors/_handler.py",
       "source_location": "L55",
       "id": "errors_handler_sheetsguard_validate_credentials",
-      "community": 1,
+      "community": 0,
       "norm_label": ".validate_credentials()"
     },
     {
@@ -5679,7 +5706,7 @@
       "source_file": "maria_cacau/backend/data_source/errors/_handler.py",
       "source_location": "L59",
       "id": "errors_handler_sheetsguard_validate_sheet_id",
-      "community": 1,
+      "community": 0,
       "norm_label": ".validate_sheet_id()"
     },
     {
@@ -5688,7 +5715,7 @@
       "source_file": "maria_cacau/backend/data_source/errors/_handler.py",
       "source_location": "L63",
       "id": "errors_handler_sheetsguard_validate_date",
-      "community": 1,
+      "community": 0,
       "norm_label": ".validate_date()"
     },
     {
@@ -5697,7 +5724,7 @@
       "source_file": "maria_cacau/backend/data_source/errors/_handler.py",
       "source_location": "L67",
       "id": "errors_handler_sheetsguard_validate_date_range",
-      "community": 1,
+      "community": 0,
       "norm_label": ".validate_date_range()"
     },
     {
@@ -5706,7 +5733,7 @@
       "source_file": "maria_cacau/backend/data_source/errors/_handler.py",
       "source_location": "L77",
       "id": "errors_handler_handle_api",
-      "community": 1,
+      "community": 0,
       "norm_label": "handle_api()"
     },
     {
@@ -5715,7 +5742,7 @@
       "source_file": "maria_cacau/backend/data_source/errors/_handler.py",
       "source_location": "L95",
       "id": "errors_handler_handle_sheet_setup",
-      "community": 1,
+      "community": 0,
       "norm_label": "handle_sheet_setup()"
     },
     {
@@ -5724,7 +5751,7 @@
       "source_file": "maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L1",
       "id": "maria_cacau_backend_data_source_errors_errors_py",
-      "community": 1,
+      "community": 0,
       "norm_label": "_errors.py"
     },
     {
@@ -5733,7 +5760,7 @@
       "source_file": "maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L1",
       "id": "errors_errors_datasourceerror",
-      "community": 1,
+      "community": 0,
       "norm_label": "datasourceerror"
     },
     {
@@ -5742,7 +5769,7 @@
       "source_file": "maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L7",
       "id": "errors_errors_credentialsfilenotfounderror",
-      "community": 1,
+      "community": 0,
       "norm_label": "credentialsfilenotfounderror"
     },
     {
@@ -5751,7 +5778,7 @@
       "source_file": "maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L12",
       "id": "errors_errors_credentialsfilenotfounderror_init",
-      "community": 1,
+      "community": 0,
       "norm_label": ".__init__()"
     },
     {
@@ -5760,7 +5787,7 @@
       "source_file": "maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L17",
       "id": "errors_errors_credentialssaveerror",
-      "community": 1,
+      "community": 0,
       "norm_label": "credentialssaveerror"
     },
     {
@@ -5769,7 +5796,7 @@
       "source_file": "maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L22",
       "id": "errors_errors_credentialssaveerror_init",
-      "community": 1,
+      "community": 0,
       "norm_label": ".__init__()"
     },
     {
@@ -5778,7 +5805,7 @@
       "source_file": "maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L26",
       "id": "errors_errors_credentialsfilecorruptederror",
-      "community": 1,
+      "community": 0,
       "norm_label": "credentialsfilecorruptederror"
     },
     {
@@ -5787,7 +5814,7 @@
       "source_file": "maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L31",
       "id": "errors_errors_credentialsfilecorruptederror_init",
-      "community": 1,
+      "community": 0,
       "norm_label": ".__init__()"
     },
     {
@@ -5796,7 +5823,7 @@
       "source_file": "maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L35",
       "id": "errors_errors_credentialsformaterror",
-      "community": 1,
+      "community": 0,
       "norm_label": "credentialsformaterror"
     },
     {
@@ -5805,7 +5832,7 @@
       "source_file": "maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L40",
       "id": "errors_errors_credentialsformaterror_init",
-      "community": 1,
+      "community": 0,
       "norm_label": ".__init__()"
     },
     {
@@ -5814,7 +5841,7 @@
       "source_file": "maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L44",
       "id": "errors_errors_invalidcredentialserror",
-      "community": 1,
+      "community": 0,
       "norm_label": "invalidcredentialserror"
     },
     {
@@ -5823,7 +5850,7 @@
       "source_file": "maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L49",
       "id": "errors_errors_invalidcredentialserror_init",
-      "community": 1,
+      "community": 0,
       "norm_label": ".__init__()"
     },
     {
@@ -5832,7 +5859,7 @@
       "source_file": "maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L53",
       "id": "errors_errors_networkunavailableerror",
-      "community": 1,
+      "community": 0,
       "norm_label": "networkunavailableerror"
     },
     {
@@ -5841,7 +5868,7 @@
       "source_file": "maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L58",
       "id": "errors_errors_networkunavailableerror_init",
-      "community": 1,
+      "community": 0,
       "norm_label": ".__init__()"
     },
     {
@@ -5850,7 +5877,7 @@
       "source_file": "maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L62",
       "id": "errors_errors_networktimeouterror",
-      "community": 1,
+      "community": 0,
       "norm_label": "networktimeouterror"
     },
     {
@@ -5859,7 +5886,7 @@
       "source_file": "maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L67",
       "id": "errors_errors_networktimeouterror_init",
-      "community": 1,
+      "community": 0,
       "norm_label": ".__init__()"
     },
     {
@@ -5868,7 +5895,7 @@
       "source_file": "maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L71",
       "id": "errors_errors_tokenexpirederror",
-      "community": 1,
+      "community": 0,
       "norm_label": "tokenexpirederror"
     },
     {
@@ -5877,7 +5904,7 @@
       "source_file": "maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L76",
       "id": "errors_errors_tokenexpirederror_init",
-      "community": 1,
+      "community": 0,
       "norm_label": ".__init__()"
     },
     {
@@ -5886,7 +5913,7 @@
       "source_file": "maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L80",
       "id": "errors_errors_sheetidinvaliderror",
-      "community": 1,
+      "community": 0,
       "norm_label": "sheetidinvaliderror"
     },
     {
@@ -5895,7 +5922,7 @@
       "source_file": "maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L85",
       "id": "errors_errors_sheetidinvaliderror_init",
-      "community": 1,
+      "community": 0,
       "norm_label": ".__init__()"
     },
     {
@@ -5904,7 +5931,7 @@
       "source_file": "maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L90",
       "id": "errors_errors_sheetnotfounderror",
-      "community": 1,
+      "community": 0,
       "norm_label": "sheetnotfounderror"
     },
     {
@@ -5913,7 +5940,7 @@
       "source_file": "maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L95",
       "id": "errors_errors_sheetnotfounderror_init",
-      "community": 1,
+      "community": 0,
       "norm_label": ".__init__()"
     },
     {
@@ -5922,7 +5949,7 @@
       "source_file": "maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L99",
       "id": "errors_errors_sheetaccessdeniederror",
-      "community": 1,
+      "community": 0,
       "norm_label": "sheetaccessdeniederror"
     },
     {
@@ -5931,7 +5958,7 @@
       "source_file": "maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L104",
       "id": "errors_errors_sheetaccessdeniederror_init",
-      "community": 1,
+      "community": 0,
       "norm_label": ".__init__()"
     },
     {
@@ -5940,7 +5967,7 @@
       "source_file": "maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L108",
       "id": "errors_errors_invaliddateformaterror",
-      "community": 1,
+      "community": 0,
       "norm_label": "invaliddateformaterror"
     },
     {
@@ -5949,7 +5976,7 @@
       "source_file": "maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L113",
       "id": "errors_errors_invaliddateformaterror_init",
-      "community": 1,
+      "community": 0,
       "norm_label": ".__init__()"
     },
     {
@@ -5958,7 +5985,7 @@
       "source_file": "maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L118",
       "id": "errors_errors_invaliddaterangeerror",
-      "community": 1,
+      "community": 0,
       "norm_label": "invaliddaterangeerror"
     },
     {
@@ -5967,7 +5994,7 @@
       "source_file": "maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L123",
       "id": "errors_errors_invaliddaterangeerror_init",
-      "community": 1,
+      "community": 0,
       "norm_label": ".__init__()"
     },
     {
@@ -5976,7 +6003,7 @@
       "source_file": "maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L129",
       "id": "errors_errors_apiquotaexceedederror",
-      "community": 1,
+      "community": 0,
       "norm_label": "apiquotaexceedederror"
     },
     {
@@ -5985,7 +6012,7 @@
       "source_file": "maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L134",
       "id": "errors_errors_apiquotaexceedederror_init",
-      "community": 1,
+      "community": 0,
       "norm_label": ".__init__()"
     },
     {
@@ -5994,7 +6021,7 @@
       "source_file": "maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L138",
       "id": "errors_errors_apiunexpectedresponseerror",
-      "community": 1,
+      "community": 0,
       "norm_label": "apiunexpectedresponseerror"
     },
     {
@@ -6003,7 +6030,7 @@
       "source_file": "maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L143",
       "id": "errors_errors_apiunexpectedresponseerror_init",
-      "community": 1,
+      "community": 0,
       "norm_label": ".__init__()"
     },
     {
@@ -6012,7 +6039,7 @@
       "source_file": "maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L148",
       "id": "errors_errors_unexpectedsheetstructureerror",
-      "community": 1,
+      "community": 0,
       "norm_label": "unexpectedsheetstructureerror"
     },
     {
@@ -6021,7 +6048,7 @@
       "source_file": "maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L153",
       "id": "errors_errors_unexpectedsheetstructureerror_init",
-      "community": 1,
+      "community": 0,
       "norm_label": ".__init__()"
     },
     {
@@ -6030,7 +6057,7 @@
       "source_file": "maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L159",
       "id": "errors_errors_prewarmfailederror",
-      "community": 1,
+      "community": 0,
       "norm_label": "prewarmfailederror"
     },
     {
@@ -6039,7 +6066,7 @@
       "source_file": "maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L164",
       "id": "errors_errors_prewarmfailederror_init",
-      "community": 1,
+      "community": 0,
       "norm_label": ".__init__()"
     },
     {
@@ -6048,7 +6075,7 @@
       "source_file": "maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L169",
       "id": "errors_errors_datasourcenotreadyerror",
-      "community": 1,
+      "community": 0,
       "norm_label": "datasourcenotreadyerror"
     },
     {
@@ -6057,7 +6084,7 @@
       "source_file": "maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L174",
       "id": "errors_errors_datasourcenotreadyerror_init",
-      "community": 1,
+      "community": 0,
       "norm_label": ".__init__()"
     },
     {
@@ -6066,7 +6093,7 @@
       "source_file": "maria_cacau/backend/features/__init__.py",
       "source_location": "L1",
       "id": "maria_cacau_backend_features_init_py",
-      "community": 34,
+      "community": 33,
       "norm_label": "__init__.py"
     },
     {
@@ -6075,7 +6102,7 @@
       "source_file": "maria_cacau/backend/features/auth/service.py",
       "source_location": "L1",
       "id": "maria_cacau_backend_features_auth_service_py",
-      "community": 8,
+      "community": 9,
       "norm_label": "service.py"
     },
     {
@@ -6084,7 +6111,7 @@
       "source_file": "maria_cacau/backend/features/auth/service.py",
       "source_location": "L6",
       "id": "auth_service_authservice",
-      "community": 8,
+      "community": 9,
       "norm_label": "authservice"
     },
     {
@@ -6093,7 +6120,7 @@
       "source_file": "maria_cacau/backend/features/auth/service.py",
       "source_location": "L7",
       "id": "auth_service_authservice_connect",
-      "community": 8,
+      "community": 9,
       "norm_label": ".connect()"
     },
     {
@@ -6102,7 +6129,7 @@
       "source_file": "maria_cacau/backend/features/auth/service.py",
       "source_location": "L12",
       "id": "auth_service_authservice_disconnect",
-      "community": 8,
+      "community": 9,
       "norm_label": ".disconnect()"
     },
     {
@@ -6110,7 +6137,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/routes/auth/service.py",
       "source_location": "L1",
-      "community": 8,
+      "community": 9,
       "norm_label": "service de autenticacao \u2014 gerencia o estado de conexao do datasource.",
       "id": "auth_service_rationale_1"
     },
@@ -6120,7 +6147,7 @@
       "source_file": "maria_cacau/backend/features/auth/route.py",
       "source_location": "L1",
       "id": "maria_cacau_backend_features_auth_route_py",
-      "community": 8,
+      "community": 9,
       "norm_label": "route.py"
     },
     {
@@ -6129,7 +6156,7 @@
       "source_file": "maria_cacau/backend/features/auth/route.py",
       "source_location": "L12",
       "id": "auth_route_connect",
-      "community": 0,
+      "community": 4,
       "norm_label": "connect()"
     },
     {
@@ -6138,7 +6165,7 @@
       "source_file": "maria_cacau/backend/features/auth/route.py",
       "source_location": "L19",
       "id": "auth_route_disconnect",
-      "community": 8,
+      "community": 9,
       "norm_label": "disconnect()"
     },
     {
@@ -6146,7 +6173,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/routes/auth/route.py",
       "source_location": "L1",
-      "community": 8,
+      "community": 9,
       "norm_label": "rotas de autenticacao",
       "id": "auth_route_rationale_1"
     },
@@ -6156,7 +6183,7 @@
       "source_file": "maria_cacau/backend/features/auth/__init__.py",
       "source_location": "L1",
       "id": "maria_cacau_backend_features_auth_init_py",
-      "community": 8,
+      "community": 9,
       "norm_label": "__init__.py"
     },
     {
@@ -6165,7 +6192,7 @@
       "source_file": "maria_cacau/backend/features/orders/__init__.py",
       "source_location": "L1",
       "id": "maria_cacau_backend_features_orders_init_py",
-      "community": 1,
+      "community": 0,
       "norm_label": "__init__.py"
     },
     {
@@ -6174,7 +6201,7 @@
       "source_file": "maria_cacau/backend/features/orders/__init__.py",
       "source_location": "L14",
       "id": "orders_init_check_connection",
-      "community": 1,
+      "community": 0,
       "norm_label": "check_connection()"
     },
     {
@@ -6408,7 +6435,7 @@
       "source_file": "maria_cacau/backend/features/orders/subfeatures/__init__.py",
       "source_location": "L1",
       "id": "maria_cacau_backend_features_orders_subfeatures_init_py",
-      "community": 9,
+      "community": 10,
       "norm_label": "__init__.py"
     },
     {
@@ -6417,7 +6444,7 @@
       "source_file": "maria_cacau/backend/features/orders/subfeatures/payments/service.py",
       "source_location": "L1",
       "id": "maria_cacau_backend_features_orders_subfeatures_payments_service_py",
-      "community": 9,
+      "community": 10,
       "norm_label": "service.py"
     },
     {
@@ -6426,7 +6453,7 @@
       "source_file": "maria_cacau/backend/features/orders/subfeatures/payments/service.py",
       "source_location": "L10",
       "id": "payments_service_paymentsmapper",
-      "community": 9,
+      "community": 10,
       "norm_label": "paymentsmapper"
     },
     {
@@ -6435,7 +6462,7 @@
       "source_file": "maria_cacau/backend/features/orders/subfeatures/payments/service.py",
       "source_location": "L14",
       "id": "payments_service_to_response",
-      "community": 9,
+      "community": 10,
       "norm_label": "to_response()"
     },
     {
@@ -6444,7 +6471,7 @@
       "source_file": "maria_cacau/backend/features/orders/subfeatures/payments/service.py",
       "source_location": "L21",
       "id": "payments_service_paymentsservice",
-      "community": 9,
+      "community": 10,
       "norm_label": "paymentsservice"
     },
     {
@@ -6453,7 +6480,7 @@
       "source_file": "maria_cacau/backend/features/orders/subfeatures/payments/service.py",
       "source_location": "L24",
       "id": "payments_service_paymentsservice_init",
-      "community": 9,
+      "community": 10,
       "norm_label": ".__init__()"
     },
     {
@@ -6462,7 +6489,7 @@
       "source_file": "maria_cacau/backend/features/orders/subfeatures/payments/service.py",
       "source_location": "L27",
       "id": "payments_service_paymentsservice_get_pendent",
-      "community": 9,
+      "community": 10,
       "norm_label": ".get_pendent()"
     },
     {
@@ -6470,7 +6497,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/features/orders/subfeatures/payments/service.py",
       "source_location": "L1",
-      "community": 9,
+      "community": 10,
       "norm_label": "service e mapper de pagamentos pendentes.",
       "id": "payments_service_rationale_1"
     },
@@ -6479,7 +6506,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/features/orders/subfeatures/payments/service.py",
       "source_location": "L11",
-      "community": 9,
+      "community": 10,
       "norm_label": "serializa o resultado do paymentsservice para dict json-ready.",
       "id": "payments_service_rationale_11"
     },
@@ -6488,7 +6515,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/features/orders/subfeatures/payments/service.py",
       "source_location": "L22",
-      "community": 9,
+      "community": 10,
       "norm_label": "filtra pedidos com pagamento pendente e monta os objetos de dominio.",
       "id": "payments_service_rationale_22"
     },
@@ -6497,7 +6524,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/features/orders/subfeatures/payments/service.py",
       "source_location": "L28",
-      "community": 9,
+      "community": 10,
       "norm_label": "retorna pedidos com amount_pendent > 0 para a data informada.",
       "id": "payments_service_rationale_28"
     },
@@ -6507,7 +6534,7 @@
       "source_file": "maria_cacau/backend/features/orders/subfeatures/payments/route.py",
       "source_location": "L1",
       "id": "maria_cacau_backend_features_orders_subfeatures_payments_route_py",
-      "community": 9,
+      "community": 10,
       "norm_label": "route.py"
     },
     {
@@ -6516,7 +6543,7 @@
       "source_file": "maria_cacau/backend/features/orders/subfeatures/payments/route.py",
       "source_location": "L12",
       "id": "payments_route_get_payments_pendent",
-      "community": 9,
+      "community": 10,
       "norm_label": "get_payments_pendent()"
     },
     {
@@ -6524,7 +6551,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/features/orders/subfeatures/payments/route.py",
       "source_location": "L1",
-      "community": 9,
+      "community": 10,
       "norm_label": "rota de pagamentos \u2014 get /orders/payments-pendent.",
       "id": "payments_route_rationale_1"
     },
@@ -6534,7 +6561,7 @@
       "source_file": "maria_cacau/backend/features/orders/subfeatures/payments/__init__.py",
       "source_location": "L1",
       "id": "maria_cacau_backend_features_orders_subfeatures_payments_init_py",
-      "community": 35,
+      "community": 34,
       "norm_label": "__init__.py"
     },
     {
@@ -6543,7 +6570,7 @@
       "source_file": "maria_cacau/backend/features/orders/subfeatures/payments/repository.py",
       "source_location": "L1",
       "id": "maria_cacau_backend_features_orders_subfeatures_payments_repository_py",
-      "community": 9,
+      "community": 10,
       "norm_label": "repository.py"
     },
     {
@@ -6552,7 +6579,7 @@
       "source_file": "maria_cacau/backend/features/orders/subfeatures/payments/repository.py",
       "source_location": "L11",
       "id": "payments_repository_paymentsrepository",
-      "community": 9,
+      "community": 10,
       "norm_label": "paymentsrepository"
     },
     {
@@ -6561,7 +6588,7 @@
       "source_file": "maria_cacau/backend/features/orders/subfeatures/payments/repository.py",
       "source_location": "L17",
       "id": "payments_repository_paymentsrepository_get_by_date",
-      "community": 9,
+      "community": 10,
       "norm_label": ".get_by_date()"
     },
     {
@@ -6570,7 +6597,7 @@
       "source_file": "maria_cacau/backend/features/orders/subfeatures/payments/repository.py",
       "source_location": "L25",
       "id": "payments_repository_to_dataframe",
-      "community": 9,
+      "community": 10,
       "norm_label": "_to_dataframe()"
     },
     {
@@ -6579,7 +6606,7 @@
       "source_file": "maria_cacau/backend/features/orders/subfeatures/payments/repository.py",
       "source_location": "L51",
       "id": "payments_repository_cast_numeric",
-      "community": 9,
+      "community": 10,
       "norm_label": "_cast_numeric()"
     },
     {
@@ -6587,7 +6614,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/features/orders/subfeatures/payments/repository.py",
       "source_location": "L1",
-      "community": 9,
+      "community": 10,
       "norm_label": "repositorio de pagamentos \u2014 busca e prepara dados da planilha para o paymentsser",
       "id": "payments_repository_rationale_1"
     },
@@ -6596,7 +6623,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/features/orders/subfeatures/payments/repository.py",
       "source_location": "L12",
-      "community": 9,
+      "community": 10,
       "norm_label": "acessa o data source e entrega um dataframe tipado para o paymentsservice.",
       "id": "payments_repository_rationale_12"
     },
@@ -6605,7 +6632,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/features/orders/subfeatures/payments/repository.py",
       "source_location": "L18",
-      "community": 9,
+      "community": 10,
       "norm_label": "retorna todos os pedidos de uma data com colunas numericas convertidas para floa",
       "id": "payments_repository_rationale_18"
     },
@@ -6614,7 +6641,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/features/orders/subfeatures/payments/repository.py",
       "source_location": "L26",
-      "community": 36,
+      "community": 35,
       "norm_label": "converte list[dict] em dataframe com cast numerico de todas as colunas de valor.",
       "id": "payments_repository_rationale_26"
     },
@@ -6623,7 +6650,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/features/orders/subfeatures/payments/repository.py",
       "source_location": "L52",
-      "community": 37,
+      "community": 36,
       "norm_label": "faz cast numerico de uma coluna se ela existir no dataframe.",
       "id": "payments_repository_rationale_52"
     },
@@ -6633,7 +6660,7 @@
       "source_file": "maria_cacau/backend/features/orders/subfeatures/summary/service.py",
       "source_location": "L1",
       "id": "maria_cacau_backend_features_orders_subfeatures_summary_service_py",
-      "community": 15,
+      "community": 14,
       "norm_label": "service.py"
     },
     {
@@ -6642,7 +6669,7 @@
       "source_file": "maria_cacau/backend/features/orders/subfeatures/summary/service.py",
       "source_location": "L9",
       "id": "summary_service_ordersmapper",
-      "community": 15,
+      "community": 14,
       "norm_label": "ordersmapper"
     },
     {
@@ -6651,7 +6678,7 @@
       "source_file": "maria_cacau/backend/features/orders/subfeatures/summary/service.py",
       "source_location": "L13",
       "id": "summary_service_to_response",
-      "community": 15,
+      "community": 14,
       "norm_label": "to_response()"
     },
     {
@@ -6660,7 +6687,7 @@
       "source_file": "maria_cacau/backend/features/orders/subfeatures/summary/service.py",
       "source_location": "L20",
       "id": "summary_service_ordersservice",
-      "community": 15,
+      "community": 14,
       "norm_label": "ordersservice"
     },
     {
@@ -6669,7 +6696,7 @@
       "source_file": "maria_cacau/backend/features/orders/subfeatures/summary/service.py",
       "source_location": "L23",
       "id": "summary_service_ordersservice_init",
-      "community": 15,
+      "community": 14,
       "norm_label": ".__init__()"
     },
     {
@@ -6678,7 +6705,7 @@
       "source_file": "maria_cacau/backend/features/orders/subfeatures/summary/service.py",
       "source_location": "L26",
       "id": "summary_service_ordersservice_get_by_period",
-      "community": 15,
+      "community": 14,
       "norm_label": ".get_by_period()"
     },
     {
@@ -6686,7 +6713,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/features/orders/subfeatures/summary/service.py",
       "source_location": "L1",
-      "community": 15,
+      "community": 14,
       "norm_label": "service e mapper de resumo de pedidos por periodo.",
       "id": "summary_service_rationale_1"
     },
@@ -6695,7 +6722,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/features/orders/subfeatures/summary/service.py",
       "source_location": "L10",
-      "community": 15,
+      "community": 14,
       "norm_label": "serializa o resultado do ordersservice para dict json-ready.",
       "id": "summary_service_rationale_10"
     },
@@ -6704,7 +6731,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/features/orders/subfeatures/summary/service.py",
       "source_location": "L21",
-      "community": 15,
+      "community": 14,
       "norm_label": "retorna o resumo de pedidos para o periodo informado.",
       "id": "summary_service_rationale_21"
     },
@@ -6713,7 +6740,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/features/orders/subfeatures/summary/service.py",
       "source_location": "L27",
-      "community": 15,
+      "community": 14,
       "norm_label": "retorna todos os pedidos do periodo informado.",
       "id": "summary_service_rationale_27"
     },
@@ -6723,7 +6750,7 @@
       "source_file": "maria_cacau/backend/features/orders/subfeatures/summary/route.py",
       "source_location": "L1",
       "id": "maria_cacau_backend_features_orders_subfeatures_summary_route_py",
-      "community": 15,
+      "community": 14,
       "norm_label": "route.py"
     },
     {
@@ -6732,7 +6759,7 @@
       "source_file": "maria_cacau/backend/features/orders/subfeatures/summary/route.py",
       "source_location": "L12",
       "id": "summary_route_get_orders",
-      "community": 15,
+      "community": 14,
       "norm_label": "get_orders()"
     },
     {
@@ -6740,7 +6767,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/features/orders/subfeatures/summary/route.py",
       "source_location": "L1",
-      "community": 15,
+      "community": 14,
       "norm_label": "rota de pedidos \u2014 get /orders.",
       "id": "summary_route_rationale_1"
     },
@@ -6750,7 +6777,7 @@
       "source_file": "maria_cacau/backend/features/orders/subfeatures/summary/__init__.py",
       "source_location": "L1",
       "id": "maria_cacau_backend_features_orders_subfeatures_summary_init_py",
-      "community": 38,
+      "community": 37,
       "norm_label": "__init__.py"
     },
     {
@@ -6759,7 +6786,7 @@
       "source_file": "maria_cacau/backend/features/orders/subfeatures/summary/repository.py",
       "source_location": "L1",
       "id": "maria_cacau_backend_features_orders_subfeatures_summary_repository_py",
-      "community": 15,
+      "community": 14,
       "norm_label": "repository.py"
     },
     {
@@ -6768,7 +6795,7 @@
       "source_file": "maria_cacau/backend/features/orders/subfeatures/summary/repository.py",
       "source_location": "L11",
       "id": "summary_repository_orderssummaryrepository",
-      "community": 15,
+      "community": 14,
       "norm_label": "orderssummaryrepository"
     },
     {
@@ -6777,7 +6804,7 @@
       "source_file": "maria_cacau/backend/features/orders/subfeatures/summary/repository.py",
       "source_location": "L17",
       "id": "summary_repository_orderssummaryrepository_get_by_period",
-      "community": 15,
+      "community": 14,
       "norm_label": ".get_by_period()"
     },
     {
@@ -6786,7 +6813,7 @@
       "source_file": "maria_cacau/backend/features/orders/subfeatures/summary/repository.py",
       "source_location": "L25",
       "id": "summary_repository_to_dataframe",
-      "community": 15,
+      "community": 14,
       "norm_label": "_to_dataframe()"
     },
     {
@@ -6795,7 +6822,7 @@
       "source_file": "maria_cacau/backend/features/orders/subfeatures/summary/repository.py",
       "source_location": "L50",
       "id": "summary_repository_cast_numeric",
-      "community": 15,
+      "community": 14,
       "norm_label": "_cast_numeric()"
     },
     {
@@ -6803,7 +6830,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/features/orders/subfeatures/summary/repository.py",
       "source_location": "L1",
-      "community": 15,
+      "community": 14,
       "norm_label": "repositorio de pedidos \u2014 busca por periodo para o ordersservice.",
       "id": "summary_repository_rationale_1"
     },
@@ -6812,7 +6839,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/features/orders/subfeatures/summary/repository.py",
       "source_location": "L12",
-      "community": 15,
+      "community": 14,
       "norm_label": "retorna todos os pedidos de um periodo como dataframe.",
       "id": "summary_repository_rationale_12"
     },
@@ -6821,7 +6848,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/features/orders/subfeatures/summary/repository.py",
       "source_location": "L18",
-      "community": 15,
+      "community": 14,
       "norm_label": "retorna todos os pedidos de um periodo com colunas numericas convertidas para fl",
       "id": "summary_repository_rationale_18"
     },
@@ -6830,7 +6857,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/features/orders/subfeatures/summary/repository.py",
       "source_location": "L26",
-      "community": 39,
+      "community": 38,
       "norm_label": "converte list[dict] em dataframe com cast numerico de todas as colunas de valor.",
       "id": "summary_repository_rationale_26"
     },
@@ -6839,7 +6866,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/features/orders/subfeatures/summary/repository.py",
       "source_location": "L51",
-      "community": 40,
+      "community": 39,
       "norm_label": "faz cast numerico de uma coluna se ela existir no dataframe.",
       "id": "summary_repository_rationale_51"
     },
@@ -6849,7 +6876,7 @@
       "source_file": "maria_cacau/backend/features/orders/subfeatures/deliveries/service.py",
       "source_location": "L1",
       "id": "maria_cacau_backend_features_orders_subfeatures_deliveries_service_py",
-      "community": 9,
+      "community": 10,
       "norm_label": "service.py"
     },
     {
@@ -6858,7 +6885,7 @@
       "source_file": "maria_cacau/backend/features/orders/subfeatures/deliveries/service.py",
       "source_location": "L10",
       "id": "deliveries_service_deliveriesmapper",
-      "community": 9,
+      "community": 10,
       "norm_label": "deliveriesmapper"
     },
     {
@@ -6867,7 +6894,7 @@
       "source_file": "maria_cacau/backend/features/orders/subfeatures/deliveries/service.py",
       "source_location": "L14",
       "id": "deliveries_service_to_response",
-      "community": 9,
+      "community": 10,
       "norm_label": "to_response()"
     },
     {
@@ -6876,7 +6903,7 @@
       "source_file": "maria_cacau/backend/features/orders/subfeatures/deliveries/service.py",
       "source_location": "L18",
       "id": "deliveries_service_deliveriesservice",
-      "community": 9,
+      "community": 10,
       "norm_label": "deliveriesservice"
     },
     {
@@ -6885,7 +6912,7 @@
       "source_file": "maria_cacau/backend/features/orders/subfeatures/deliveries/service.py",
       "source_location": "L21",
       "id": "deliveries_service_deliveriesservice_init",
-      "community": 9,
+      "community": 10,
       "norm_label": ".__init__()"
     },
     {
@@ -6894,7 +6921,7 @@
       "source_file": "maria_cacau/backend/features/orders/subfeatures/deliveries/service.py",
       "source_location": "L24",
       "id": "deliveries_service_deliveriesservice_get_by_date",
-      "community": 9,
+      "community": 10,
       "norm_label": ".get_by_date()"
     },
     {
@@ -6902,7 +6929,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/features/orders/subfeatures/deliveries/service.py",
       "source_location": "L1",
-      "community": 9,
+      "community": 10,
       "norm_label": "service e mapper de entregas \u2014 agrupa pedidos do dia por tipo de entrega.",
       "id": "deliveries_service_rationale_1"
     },
@@ -6911,7 +6938,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/features/orders/subfeatures/deliveries/service.py",
       "source_location": "L11",
-      "community": 9,
+      "community": 10,
       "norm_label": "serializa deliveriessummary para dict json-ready.",
       "id": "deliveries_service_rationale_11"
     },
@@ -6920,7 +6947,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/features/orders/subfeatures/deliveries/service.py",
       "source_location": "L19",
-      "community": 9,
+      "community": 10,
       "norm_label": "aplica regra de negocio sobre os pedidos do dia e retorna o resumo de entregas.",
       "id": "deliveries_service_rationale_19"
     },
@@ -6929,7 +6956,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/features/orders/subfeatures/deliveries/service.py",
       "source_location": "L25",
-      "community": 9,
+      "community": 10,
       "norm_label": "retorna contagem de pedidos agrupada por tipo de entrega para a data informada.",
       "id": "deliveries_service_rationale_25"
     },
@@ -6939,7 +6966,7 @@
       "source_file": "maria_cacau/backend/features/orders/subfeatures/deliveries/models.py",
       "source_location": "L1",
       "id": "maria_cacau_backend_features_orders_subfeatures_deliveries_models_py",
-      "community": 9,
+      "community": 10,
       "norm_label": "models.py"
     },
     {
@@ -6948,7 +6975,7 @@
       "source_file": "maria_cacau/backend/features/orders/subfeatures/deliveries/models.py",
       "source_location": "L7",
       "id": "deliveries_models_deliverytypecount",
-      "community": 9,
+      "community": 10,
       "norm_label": "deliverytypecount"
     },
     {
@@ -6957,7 +6984,7 @@
       "source_file": "maria_cacau/backend/features/orders/subfeatures/deliveries/models.py",
       "source_location": "L13",
       "id": "deliveries_models_deliveriessummary",
-      "community": 3,
+      "community": 2,
       "norm_label": "deliveriessummary"
     },
     {
@@ -6965,7 +6992,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/features/orders/subfeatures/deliveries/models.py",
       "source_location": "L1",
-      "community": 9,
+      "community": 10,
       "norm_label": "models de dominio da feature de entregas.",
       "id": "deliveries_models_rationale_1"
     },
@@ -6975,7 +7002,7 @@
       "source_file": "maria_cacau/backend/features/orders/subfeatures/deliveries/route.py",
       "source_location": "L1",
       "id": "maria_cacau_backend_features_orders_subfeatures_deliveries_route_py",
-      "community": 9,
+      "community": 10,
       "norm_label": "route.py"
     },
     {
@@ -6984,7 +7011,7 @@
       "source_file": "maria_cacau/backend/features/orders/subfeatures/deliveries/route.py",
       "source_location": "L12",
       "id": "deliveries_route_get_deliveries",
-      "community": 9,
+      "community": 10,
       "norm_label": "get_deliveries()"
     },
     {
@@ -6992,7 +7019,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/features/orders/subfeatures/deliveries/route.py",
       "source_location": "L1",
-      "community": 9,
+      "community": 10,
       "norm_label": "rota de entregas \u2014 get /orders/deliveries.",
       "id": "deliveries_route_rationale_1"
     },
@@ -7002,7 +7029,7 @@
       "source_file": "maria_cacau/backend/features/orders/subfeatures/deliveries/__init__.py",
       "source_location": "L1",
       "id": "maria_cacau_backend_features_orders_subfeatures_deliveries_init_py",
-      "community": 41,
+      "community": 40,
       "norm_label": "__init__.py"
     },
     {
@@ -7011,7 +7038,7 @@
       "source_file": "maria_cacau/backend/features/orders/subfeatures/deliveries/repository.py",
       "source_location": "L1",
       "id": "maria_cacau_backend_features_orders_subfeatures_deliveries_repository_py",
-      "community": 9,
+      "community": 10,
       "norm_label": "repository.py"
     },
     {
@@ -7020,7 +7047,7 @@
       "source_file": "maria_cacau/backend/features/orders/subfeatures/deliveries/repository.py",
       "source_location": "L8",
       "id": "deliveries_repository_deliveriesrepository",
-      "community": 9,
+      "community": 10,
       "norm_label": "deliveriesrepository"
     },
     {
@@ -7029,7 +7056,7 @@
       "source_file": "maria_cacau/backend/features/orders/subfeatures/deliveries/repository.py",
       "source_location": "L14",
       "id": "deliveries_repository_deliveriesrepository_get_by_date",
-      "community": 9,
+      "community": 10,
       "norm_label": ".get_by_date()"
     },
     {
@@ -7037,7 +7064,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/features/orders/subfeatures/deliveries/repository.py",
       "source_location": "L1",
-      "community": 9,
+      "community": 10,
       "norm_label": "repositorio de entregas \u2014 busca e prepara dados da planilha para o deliveriesser",
       "id": "deliveries_repository_rationale_1"
     },
@@ -7046,7 +7073,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/features/orders/subfeatures/deliveries/repository.py",
       "source_location": "L9",
-      "community": 9,
+      "community": 10,
       "norm_label": "acessa o data source e entrega um dataframe para o deliveriesservice.      nao f",
       "id": "deliveries_repository_rationale_9"
     },
@@ -7055,7 +7082,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/features/orders/subfeatures/deliveries/repository.py",
       "source_location": "L15",
-      "community": 9,
+      "community": 10,
       "norm_label": "retorna todos os pedidos de uma data como dataframe bruto.",
       "id": "deliveries_repository_rationale_15"
     },
@@ -7065,7 +7092,7 @@
       "source_file": "maria_cacau/backend/features/sheet/service.py",
       "source_location": "L1",
       "id": "maria_cacau_backend_features_sheet_service_py",
-      "community": 8,
+      "community": 9,
       "norm_label": "service.py"
     },
     {
@@ -7074,7 +7101,7 @@
       "source_file": "maria_cacau/backend/features/sheet/service.py",
       "source_location": "L6",
       "id": "sheet_service_sheetservice",
-      "community": 8,
+      "community": 9,
       "norm_label": "sheetservice"
     },
     {
@@ -7083,7 +7110,7 @@
       "source_file": "maria_cacau/backend/features/sheet/service.py",
       "source_location": "L7",
       "id": "sheet_service_sheetservice_select",
-      "community": 8,
+      "community": 9,
       "norm_label": ".select()"
     },
     {
@@ -7092,7 +7119,7 @@
       "source_file": "maria_cacau/backend/features/sheet/service.py",
       "source_location": "L10",
       "id": "sheet_service_sheetservice_remove",
-      "community": 8,
+      "community": 9,
       "norm_label": ".remove()"
     },
     {
@@ -7100,7 +7127,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/features/sheet/service.py",
       "source_location": "L1",
-      "community": 8,
+      "community": 9,
       "norm_label": "service de planilha \u2014 gerencia a planilha ativa no datasource.",
       "id": "sheet_service_rationale_1"
     },
@@ -7110,7 +7137,7 @@
       "source_file": "maria_cacau/backend/features/sheet/route.py",
       "source_location": "L1",
       "id": "maria_cacau_backend_features_sheet_route_py",
-      "community": 8,
+      "community": 9,
       "norm_label": "route.py"
     },
     {
@@ -7119,7 +7146,7 @@
       "source_file": "maria_cacau/backend/features/sheet/route.py",
       "source_location": "L12",
       "id": "sheet_route_select_sheet",
-      "community": 8,
+      "community": 9,
       "norm_label": "select_sheet()"
     },
     {
@@ -7128,7 +7155,7 @@
       "source_file": "maria_cacau/backend/features/sheet/route.py",
       "source_location": "L18",
       "id": "sheet_route_remove_sheet",
-      "community": 8,
+      "community": 9,
       "norm_label": "remove_sheet()"
     },
     {
@@ -7137,7 +7164,7 @@
       "source_file": "maria_cacau/backend/features/sheet/__init__.py",
       "source_location": "L1",
       "id": "maria_cacau_backend_features_sheet_init_py",
-      "community": 8,
+      "community": 9,
       "norm_label": "__init__.py"
     },
     {
@@ -7146,7 +7173,7 @@
       "source_file": "maria_cacau/backend/utils/__init__.py",
       "source_location": "L1",
       "id": "maria_cacau_backend_utils_init_py",
-      "community": 17,
+      "community": 15,
       "norm_label": "__init__.py"
     },
     {
@@ -7155,7 +7182,7 @@
       "source_file": "maria_cacau/backend/utils/numbers.py",
       "source_location": "L1",
       "id": "maria_cacau_backend_utils_numbers_py",
-      "community": 17,
+      "community": 15,
       "norm_label": "numbers.py"
     },
     {
@@ -7164,7 +7191,7 @@
       "source_file": "maria_cacau/backend/utils/numbers.py",
       "source_location": "L4",
       "id": "utils_numbers_normalize_decimal",
-      "community": 17,
+      "community": 15,
       "norm_label": "normalize_decimal()"
     },
     {
@@ -7172,7 +7199,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/utils/numbers.py",
       "source_location": "L1",
-      "community": 17,
+      "community": 15,
       "norm_label": "utilitarios de formatacao numerica.",
       "id": "utils_numbers_rationale_1"
     },
@@ -7181,7 +7208,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/utils/numbers.py",
       "source_location": "L5",
-      "community": 17,
+      "community": 15,
       "norm_label": "converte numero no formato brasileiro para o formato ingles.      remove o separ",
       "id": "utils_numbers_rationale_5"
     },
@@ -7191,7 +7218,7 @@
       "source_file": "maria_cacau/backend/errors/_errors.py",
       "source_location": "L1",
       "id": "maria_cacau_backend_errors_errors_py",
-      "community": 11,
+      "community": 12,
       "norm_label": "_errors.py"
     },
     {
@@ -7200,7 +7227,7 @@
       "source_file": "maria_cacau/backend/errors/_errors.py",
       "source_location": "L1",
       "id": "errors_errors_backenderror",
-      "community": 11,
+      "community": 12,
       "norm_label": "backenderror"
     },
     {
@@ -7209,7 +7236,7 @@
       "source_file": "maria_cacau/backend/errors/_errors.py",
       "source_location": "L7",
       "id": "errors_errors_backenderror_to_dict",
-      "community": 11,
+      "community": 12,
       "norm_label": ".to_dict()"
     },
     {
@@ -7218,7 +7245,7 @@
       "source_file": "maria_cacau/backend/errors/__init__.py",
       "source_location": "L1",
       "id": "maria_cacau_backend_errors_init_py",
-      "community": 11,
+      "community": 12,
       "norm_label": "__init__.py"
     },
     {
@@ -7227,7 +7254,7 @@
       "source_file": "maria_cacau/backend/errors/_mapper.py",
       "source_location": "L1",
       "id": "maria_cacau_backend_errors_mapper_py",
-      "community": 11,
+      "community": 12,
       "norm_label": "_mapper.py"
     },
     {
@@ -7236,7 +7263,7 @@
       "source_file": "maria_cacau/backend/errors/_mapper.py",
       "source_location": "L26",
       "id": "errors_mapper_translate",
-      "community": 11,
+      "community": 12,
       "norm_label": "translate()"
     },
     {
@@ -7245,7 +7272,7 @@
       "source_file": "maria_cacau/backend/errors/_mapper.py",
       "source_location": "L35",
       "id": "errors_mapper_generic_mapper",
-      "community": 11,
+      "community": 12,
       "norm_label": "generic_mapper()"
     },
     {
@@ -7254,7 +7281,7 @@
       "source_file": "maria_cacau/assets/__init__.py",
       "source_location": "L1",
       "id": "maria_cacau_assets_init_py",
-      "community": 42,
+      "community": 41,
       "norm_label": "__init__.py"
     },
     {
@@ -7263,7 +7290,7 @@
       "source_file": "maria_cacau/assets/strings.py",
       "source_location": "L1",
       "id": "maria_cacau_assets_strings_py",
-      "community": 43,
+      "community": 42,
       "norm_label": "strings.py"
     },
     {
@@ -7272,7 +7299,7 @@
       "source_file": "pocs/prototipacao/figma/figma-plugin.js",
       "source_location": "L1",
       "id": "pocs_prototipacao_figma_figma_plugin_js",
-      "community": 8,
+      "community": 9,
       "norm_label": "figma-plugin.js"
     },
     {
@@ -7281,7 +7308,7 @@
       "source_file": "pocs/prototipacao/figma/figma-plugin.js",
       "source_location": "L7",
       "id": "figma_figma_plugin_main",
-      "community": 8,
+      "community": 9,
       "norm_label": "main()"
     },
     {
@@ -7290,7 +7317,7 @@
       "source_file": "pocs/prototipacao/figma/figma-vetorial-14estados.js",
       "source_location": "L1",
       "id": "pocs_prototipacao_figma_figma_vetorial_14estados_js",
-      "community": 8,
+      "community": 9,
       "norm_label": "figma-vetorial-14estados.js"
     },
     {
@@ -7299,7 +7326,7 @@
       "source_file": "pocs/prototipacao/figma/figma-vetorial-14estados.js",
       "source_location": "L5",
       "id": "figma_figma_vetorial_14estados_main",
-      "community": 8,
+      "community": 9,
       "norm_label": "main()"
     },
     {
@@ -7308,7 +7335,7 @@
       "source_file": "pocs/prototipacao/figma/figma-14estados-generated.js",
       "source_location": "L1",
       "id": "pocs_prototipacao_figma_figma_14estados_generated_js",
-      "community": 8,
+      "community": 9,
       "norm_label": "figma-14estados-generated.js"
     },
     {
@@ -7317,7 +7344,7 @@
       "source_file": "pocs/prototipacao/figma/figma-14estados-generated.js",
       "source_location": "L5",
       "id": "figma_figma_14estados_generated_main",
-      "community": 8,
+      "community": 9,
       "norm_label": "main()"
     },
     {
@@ -7326,7 +7353,7 @@
       "source_file": "pocs/prototipacao/figma/figma-vetorial-mc-frames-f0.js",
       "source_location": "L1",
       "id": "pocs_prototipacao_figma_figma_vetorial_mc_frames_f0_js",
-      "community": 8,
+      "community": 9,
       "norm_label": "figma-vetorial-mc-frames-f0.js"
     },
     {
@@ -7335,7 +7362,7 @@
       "source_file": "pocs/prototipacao/figma/figma-vetorial-mc-frames-f0.js",
       "source_location": "L5",
       "id": "figma_figma_vetorial_mc_frames_f0_main",
-      "community": 8,
+      "community": 9,
       "norm_label": "main()"
     },
     {
@@ -7344,7 +7371,7 @@
       "source_file": "pocs/design-system/poc_date_picker.py",
       "source_location": "L1",
       "id": "pocs_design_system_poc_date_picker_py",
-      "community": 0,
+      "community": 5,
       "norm_label": "poc_date_picker.py"
     },
     {
@@ -7353,7 +7380,7 @@
       "source_file": "pocs/design-system/poc_date_picker.py",
       "source_location": "L60",
       "id": "design_system_poc_date_picker_date_field",
-      "community": 0,
+      "community": 5,
       "norm_label": "_date_field()"
     },
     {
@@ -7362,7 +7389,7 @@
       "source_file": "pocs/design-system/poc_date_picker.py",
       "source_location": "L78",
       "id": "design_system_poc_date_picker_daterangepicker",
-      "community": 0,
+      "community": 5,
       "norm_label": "daterangepicker"
     },
     {
@@ -7371,7 +7398,7 @@
       "source_file": "pocs/design-system/poc_date_picker.py",
       "source_location": "L79",
       "id": "design_system_poc_date_picker_daterangepicker_init",
-      "community": 0,
+      "community": 5,
       "norm_label": ".__init__()"
     },
     {
@@ -7380,7 +7407,7 @@
       "source_file": "pocs/design-system/poc_date_picker.py",
       "source_location": "L123",
       "id": "design_system_poc_date_picker_daterangepicker_on_consultar",
-      "community": 0,
+      "community": 5,
       "norm_label": "._on_consultar()"
     },
     {
@@ -7389,7 +7416,7 @@
       "source_file": "pocs/design-system/poc_date_picker.py",
       "source_location": "L128",
       "id": "design_system_poc_date_picker_daterangepicker_on_limpar",
-      "community": 0,
+      "community": 5,
       "norm_label": "._on_limpar()"
     },
     {
@@ -7397,16 +7424,34 @@
       "file_type": "rationale",
       "source_file": "pocs/design-system/poc_date_picker.py",
       "source_location": "L1",
-      "community": 0,
+      "community": 5,
       "norm_label": "poc \u2014 date picker moderno com qdateedit + qss.",
       "id": "design_system_poc_date_picker_rationale_1"
+    },
+    {
+      "label": "Busca entregas do dia; converte HTTPResponseError em ErrorModel antes de relan\u00e7a",
+      "file_type": "rationale",
+      "source_file": "maria_cacau/features/home/sub_features/delivery/data/repository.py",
+      "source_location": "L12",
+      "community": 2,
+      "norm_label": "busca entregas do dia; converte httpresponseerror em errormodel antes de relanca",
+      "id": "data_repository_rationale_12"
+    },
+    {
+      "label": "Busca pagamentos pendentes do dia; converte HTTPResponseError em ErrorModel ante",
+      "file_type": "rationale",
+      "source_file": "maria_cacau/features/home/sub_features/delivery/data/repository.py",
+      "source_location": "L20",
+      "community": 2,
+      "norm_label": "busca pagamentos pendentes do dia; converte httpresponseerror em errormodel ante",
+      "id": "data_repository_rationale_20"
     },
     {
       "label": "# TODO: substituir por AuthUseCase.has_credentials() \u2014 ver features/auth",
       "file_type": "rationale",
       "source_file": "maria_cacau/features/sheets/data/repository.py",
       "source_location": "L37",
-      "community": 12,
+      "community": 7,
       "norm_label": "# todo: substituir por authusecase.has_credentials() \u2014 ver features/auth",
       "id": "data_repository_rationale_37"
     },
@@ -7415,7 +7460,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/features/auth/data/repository.py",
       "source_location": "L30",
-      "community": 3,
+      "community": 7,
       "norm_label": "remove credenciais do storage e desautentica o backend.",
       "id": "data_repository_rationale_30"
     },
@@ -7424,7 +7469,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/features/auth/domain/use_case.py",
       "source_location": "L11",
-      "community": 44,
+      "community": 43,
       "norm_label": "le o arquivo json, salva em storage seguro e autentica o backend.",
       "id": "domain_use_case_rationale_11"
     },
@@ -7433,7 +7478,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/features/auth/domain/use_case.py",
       "source_location": "L15",
-      "community": 45,
+      "community": 44,
       "norm_label": "autentica usando credenciais ja salvas. retorna false se nao houver.",
       "id": "domain_use_case_rationale_15"
     },
@@ -7442,7 +7487,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/features/auth/domain/use_case.py",
       "source_location": "L19",
-      "community": 46,
+      "community": 45,
       "norm_label": "remove credenciais do storage e desautentica o backend.",
       "id": "domain_use_case_rationale_19"
     },
@@ -7451,7 +7496,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/features/auth/presentation/controller.py",
       "source_location": "L49",
-      "community": 10,
+      "community": 8,
       "norm_label": "tenta autenticar no startup usando credenciais salvas em storage.",
       "id": "presentation_controller_rationale_49"
     },
@@ -7460,7 +7505,7 @@
       "file_type": "rationale",
       "source_file": "features/home/home_view.py",
       "source_location": "L1",
-      "community": 12,
+      "community": 3,
       "norm_label": "janela principal da aplicacao e orquestracao das sub-features.",
       "id": "home_home_view_rationale_1"
     },
@@ -7469,7 +7514,7 @@
       "file_type": "rationale",
       "source_file": "core/sheets/service.py",
       "source_location": "L1",
-      "community": 6,
+      "community": 3,
       "norm_label": "autenticacao e acesso ao google sheets.",
       "id": "sheets_service_rationale_1"
     },
@@ -7478,7 +7523,7 @@
       "file_type": "rationale",
       "source_file": "core/sheets/service.py",
       "source_location": "L42",
-      "community": 6,
+      "community": 3,
       "norm_label": "tenta autenticar usando credenciais salvas. retorna false se nao houver.",
       "id": "sheets_service_rationale_42"
     },
@@ -7487,7 +7532,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/core/sheets/service.py",
       "source_location": "L49",
-      "community": 6,
+      "community": 3,
       "norm_label": "tenta autenticar usando credenciais salvas. retorna false se nao houver.",
       "id": "sheets_service_rationale_49"
     },
@@ -7496,7 +7541,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/core/sheets/service.py",
       "source_location": "L66",
-      "community": 6,
+      "community": 3,
       "norm_label": "inicia o pre-aquecimento do token oauth em background.         qualquer requisic",
       "id": "sheets_service_rationale_66"
     },
@@ -7505,7 +7550,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/core/sheets/service.py",
       "source_location": "L87",
-      "community": 6,
+      "community": 3,
       "norm_label": "bloqueia ate o prewarm terminar (ou timeout). sem custo se ja estiver pronto.",
       "id": "sheets_service_rationale_87"
     },
@@ -7514,7 +7559,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/core/sheets/service.py",
       "source_location": "L91",
-      "community": 6,
+      "community": 3,
       "norm_label": "remove as credenciais salvas. retorna false se nao havia nada salvo.",
       "id": "sheets_service_rationale_91"
     },
@@ -7523,7 +7568,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/core/sheets/service.py",
       "source_location": "L100",
-      "community": 6,
+      "community": 3,
       "norm_label": "retorna true se uma planilha foi vinculada.",
       "id": "sheets_service_rationale_100"
     },
@@ -7532,7 +7577,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/core/sheets/service.py",
       "source_location": "L104",
-      "community": 6,
+      "community": 3,
       "norm_label": "define qual planilha vai ser lida pelo id ou url do google sheets.",
       "id": "sheets_service_rationale_104"
     },
@@ -7541,7 +7586,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/core/sheets/service.py",
       "source_location": "L108",
-      "community": 6,
+      "community": 3,
       "norm_label": "retorna as linhas brutas da planilha (lista de listas de strings).",
       "id": "sheets_service_rationale_108"
     },
@@ -7550,7 +7595,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/core/sheets/service.py",
       "source_location": "L118",
-      "community": 6,
+      "community": 3,
       "norm_label": "le todas as linhas da aba cadastro usando dois passes para economizar api.",
       "id": "sheets_service_rationale_118"
     },
@@ -7559,7 +7604,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/core/sheets/service.py",
       "source_location": "L176",
-      "community": 6,
+      "community": 3,
       "norm_label": "le linhas da aba cadastro para um conjunto especifico de datas.          mesmo m",
       "id": "sheets_service_rationale_176"
     },
@@ -7568,7 +7613,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/core/sheets/sheet_columns.py",
       "source_location": "L1",
-      "community": 47,
+      "community": 46,
       "norm_label": "colunas usadas da planilha",
       "id": "sheets_sheet_columns_rationale_1"
     },
@@ -7577,7 +7622,7 @@
       "file_type": "rationale",
       "source_file": "core/sheets/manager.py",
       "source_location": "L1",
-      "community": 48,
+      "community": 47,
       "norm_label": "orquestra a autenticacao e o acesso as abas da planilha.",
       "id": "sheets_manager_rationale_1"
     },
@@ -7586,7 +7631,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/core/sheets/manager.py",
       "source_location": "L17",
-      "community": 49,
+      "community": 48,
       "norm_label": "autentica e aponta para a planilha. nao le dados ainda.",
       "id": "sheets_manager_rationale_17"
     },
@@ -7595,7 +7640,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/core/sheets/manager.py",
       "source_location": "L25",
-      "community": 50,
+      "community": 49,
       "norm_label": "le e processa as 20 datas mais recentes da aba cadastro (chamado uma vez, no ati",
       "id": "sheets_manager_rationale_25"
     },
@@ -7604,7 +7649,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/core/sheets/manager.py",
       "source_location": "L31",
-      "community": 51,
+      "community": 50,
       "norm_label": "le entregas de uma data especifica direto da planilha (sem cache global).",
       "id": "sheets_manager_rationale_31"
     },
@@ -7613,7 +7658,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/core/sheets/manager.py",
       "source_location": "L56",
-      "community": 52,
+      "community": 51,
       "norm_label": "descarta os dados em memoria, forcando nova leitura na proxima consulta.",
       "id": "sheets_manager_rationale_56"
     },
@@ -7622,7 +7667,7 @@
       "file_type": "rationale",
       "source_file": "core/sheets/handlers/cadastro.py",
       "source_location": "L1",
-      "community": 0,
+      "community": 1,
       "norm_label": "processa os dados da aba cadastro da planilha google sheets.",
       "id": "handlers_cadastro_rationale_1"
     },
@@ -7631,7 +7676,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/data_source/_google_sheets.py",
       "source_location": "L17",
-      "community": 1,
+      "community": 0,
       "norm_label": "implementacao de datasourceprotocol para google sheets via gspread.",
       "id": "data_source_google_sheets_rationale_17"
     },
@@ -7640,7 +7685,7 @@
       "file_type": "rationale",
       "source_file": "features/home/sub_features/products_resume/products_resume_view.py",
       "source_location": "L1",
-      "community": 0,
+      "community": 1,
       "norm_label": "area de resumo de produtos: contagem de itens por periodo.",
       "id": "products_resume_products_resume_view_rationale_1"
     },
@@ -7649,7 +7694,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/features/orders/subfeatures/summary/service.py",
       "source_location": "L7",
-      "community": 53,
+      "community": 52,
       "norm_label": "serializa o resultado do ordersservice para dict json-ready.",
       "id": "summary_service_rationale_7"
     },
@@ -7658,7 +7703,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/features/orders/subfeatures/summary/service.py",
       "source_location": "L15",
-      "community": 54,
+      "community": 53,
       "norm_label": "aplica regra de negocio sobre os pedidos de um periodo e retorna o resumo.",
       "id": "summary_service_rationale_15"
     },
@@ -7667,7 +7712,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/features/orders/subfeatures/summary/repository.py",
       "source_location": "L6",
-      "community": 55,
+      "community": 54,
       "norm_label": "acessa o data source e entrega um dataframe para o ordersservice.",
       "id": "summary_repository_rationale_6"
     },
@@ -7676,7 +7721,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/features/orders/subfeatures/summary/repository.py",
       "source_location": "L9",
-      "community": 56,
+      "community": 55,
       "norm_label": "acessa o data source e entrega um dataframe para o ordersservice.",
       "id": "summary_repository_rationale_9"
     },
@@ -7685,7 +7730,7 @@
       "file_type": "rationale",
       "source_file": "features/home/sub_features/freight_query/freight_query_view.py",
       "source_location": "L1",
-      "community": 0,
+      "community": 1,
       "norm_label": "area de consulta de frete: interface grafica e logica de consulta.",
       "id": "freight_query_freight_query_view_rationale_1"
     },
@@ -7694,7 +7739,7 @@
       "file_type": "rationale",
       "source_file": "features/home/sub_features/nota_fiscal/nota_fiscal_view.py",
       "source_location": "L1",
-      "community": 0,
+      "community": 1,
       "norm_label": "area de nota fiscal \u2014 em desenvolvimento.",
       "id": "nota_fiscal_nota_fiscal_view_rationale_1"
     },
@@ -7703,7 +7748,7 @@
       "file_type": "rationale",
       "source_file": "features/home/sub_features/cpf_validation/cpf_validation_view.py",
       "source_location": "L1",
-      "community": 6,
+      "community": 3,
       "norm_label": "area de validacao de cpf: interface grafica e logica de verificacao.",
       "id": "cpf_validation_cpf_validation_view_rationale_1"
     },
@@ -7712,7 +7757,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/features/home/sub_features/delivery/presentation/view.py",
       "source_location": "L91",
-      "community": 0,
+      "community": 1,
       "norm_label": "r'''retorna a data selecionada no formato dd/mm/yy",
       "id": "presentation_view_rationale_91"
     },
@@ -7721,7 +7766,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/features/home/sub_features/delivery/presentation/view.py",
       "source_location": "L95",
-      "community": 0,
+      "community": 1,
       "norm_label": "r'''atualiza os dados da view",
       "id": "presentation_view_rationale_95"
     },
@@ -7730,7 +7775,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/features/home/sub_features/delivery/presentation/view.py",
       "source_location": "L103",
-      "community": 0,
+      "community": 1,
       "norm_label": "r'''prepara a view para uma nova consulta",
       "id": "presentation_view_rationale_103"
     },
@@ -7739,7 +7784,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/core/network/api.py",
       "source_location": "L30",
-      "community": 2,
+      "community": 6,
       "norm_label": "o tipo precisa aceitar **kwargs (dataclass ou similar).",
       "id": "network_api_rationale_30"
     },
@@ -7748,7 +7793,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/core/error/errors.py",
       "source_location": "L7",
-      "community": 57,
+      "community": 56,
       "norm_label": "estrutura de uma mensagem de erro/info para exibicao no popup.",
       "id": "error_errors_rationale_7"
     },
@@ -7757,7 +7802,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/core/error/errors.py",
       "source_location": "L103",
-      "community": 58,
+      "community": 57,
       "norm_label": "confirmacao de certificado configurado com sucesso.",
       "id": "error_errors_rationale_103"
     },
@@ -7766,7 +7811,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/core/error/errors.py",
       "source_location": "L112",
-      "community": 59,
+      "community": 58,
       "norm_label": "confirmacao de credenciais removidas com sucesso.",
       "id": "error_errors_rationale_112"
     },
@@ -7775,7 +7820,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/core/error/errors.py",
       "source_location": "L121",
-      "community": 60,
+      "community": 59,
       "norm_label": "confirmacao de planilha selecionada com sucesso.",
       "id": "error_errors_rationale_121"
     },
@@ -7784,7 +7829,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/core/error/errors.py",
       "source_location": "L130",
-      "community": 61,
+      "community": 60,
       "norm_label": "confirmacao de leitura bem-sucedida da planilha.",
       "id": "error_errors_rationale_130"
     },
@@ -7793,7 +7838,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/features/home/home_view.py",
       "source_location": "L208",
-      "community": 12,
+      "community": 3,
       "norm_label": "# todo: migrar",
       "id": "home_home_view_rationale_208"
     },
@@ -7802,7 +7847,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/features/home/sub_features/orders_pendent/use_case.py",
       "source_location": "L1",
-      "community": 62,
+      "community": 61,
       "norm_label": "logica de negocio para obter as deliveries e pagamentos pendentes.",
       "id": "orders_pendent_use_case_rationale_1"
     },
@@ -7811,7 +7856,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/features/home/sub_features/orders_pendent/signals.py",
       "source_location": "L1",
-      "community": 63,
+      "community": 62,
       "norm_label": "sinais compartilhadaos dentro do modulo",
       "id": "orders_pendent_signals_rationale_1"
     },
@@ -7820,7 +7865,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/features/home/sub_features/orders_pendent/controller.py",
       "source_location": "L1",
-      "community": 64,
+      "community": 63,
       "norm_label": "area de entregas pendentes: controller da view.",
       "id": "orders_pendent_controller_rationale_1"
     },
@@ -7829,7 +7874,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/features/home/sub_features/orders_pendent/models.py",
       "source_location": "L1",
-      "community": 65,
+      "community": 64,
       "norm_label": "models utilizados no modulo",
       "id": "orders_pendent_models_rationale_1"
     },
@@ -7838,7 +7883,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/features/home/sub_features/orders_pendent/events.py",
       "source_location": "L1",
-      "community": 66,
+      "community": 65,
       "norm_label": "eventos relacionados as entregas pendentes.",
       "id": "orders_pendent_events_rationale_1"
     },
@@ -7847,7 +7892,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/features/home/sub_features/orders_pendent/viewmodel.py",
       "source_location": "L1",
-      "community": 67,
+      "community": 66,
       "norm_label": "regra de negocios das entregas",
       "id": "orders_pendent_viewmodel_rationale_1"
     },
@@ -7856,7 +7901,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/features/home/sub_features/orders_pendent/view.py",
       "source_location": "L1",
-      "community": 0,
+      "community": 1,
       "norm_label": "area de entregas pendentes: resumo diario com inadimplencias.",
       "id": "orders_pendent_view_rationale_1"
     },
@@ -7865,7 +7910,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/features/home/sub_features/orders_pendent/view.py",
       "source_location": "L91",
-      "community": 0,
+      "community": 1,
       "norm_label": "r'''retorna a data selecionada no formato dd/mm/yy",
       "id": "orders_pendent_view_rationale_91"
     },
@@ -7874,7 +7919,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/features/home/sub_features/orders_pendent/view.py",
       "source_location": "L95",
-      "community": 0,
+      "community": 1,
       "norm_label": "r'''atualiza os dados da view",
       "id": "orders_pendent_view_rationale_95"
     },
@@ -7883,7 +7928,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/features/home/sub_features/orders_pendent/view-old.py",
       "source_location": "L1",
-      "community": 0,
+      "community": 1,
       "norm_label": "area de entregas pendentes: resumo diario com inadimplencias.",
       "id": "orders_pendent_view_old_rationale_1"
     },
@@ -7892,7 +7937,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/features/home/sub_features/orders_pendent/repository.py",
       "source_location": "L1",
-      "community": 68,
+      "community": 67,
       "norm_label": "conexao com servico da planilha/base de dados",
       "id": "orders_pendent_repository_rationale_1"
     },
@@ -7901,7 +7946,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/data_source/_utils.py",
       "source_location": "L5",
-      "community": 69,
+      "community": 68,
       "norm_label": "normaliza uma data para dd/mm/yyyy aceitando os formatos dd/mm/yy e dd/mm/yyyy.",
       "id": "data_source_utils_rationale_5"
     },
@@ -7910,7 +7955,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/data_source/_utils.py",
       "source_location": "L15",
-      "community": 70,
+      "community": 69,
       "norm_label": "converte linhas da planilha em lista de dicts usando o cabecalho como chaves (lo",
       "id": "data_source_utils_rationale_15"
     },
@@ -7919,7 +7964,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/data_source/_utils.py",
       "source_location": "L21",
-      "community": 71,
+      "community": 70,
       "norm_label": "agrupa numeros de linha consecutivos em ranges a1 notation e divide em batches d",
       "id": "data_source_utils_rationale_21"
     },
@@ -7928,7 +7973,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/data_source/_utils.py",
       "source_location": "L34",
-      "community": 72,
+      "community": 71,
       "norm_label": "retorna o conjunto de todas as datas (dd/mm/yyyy) entre start e end, inclusive.",
       "id": "data_source_utils_rationale_34"
     },
@@ -7955,7 +8000,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/features/orders/subfeatures/payments/repository.py",
       "source_location": "L11",
-      "community": 73,
+      "community": 72,
       "norm_label": "acessa o data source e entrega um dataframe tipado para o paymentsservice.",
       "id": "payments_repository_rationale_11"
     },
@@ -7964,7 +8009,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/features/orders/subfeatures/payments/repository.py",
       "source_location": "L17",
-      "community": 74,
+      "community": 73,
       "norm_label": "retorna todos os pedidos de uma data com colunas numericas convertidas para floa",
       "id": "payments_repository_rationale_17"
     },
@@ -7973,7 +8018,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/features/orders/subfeatures/payments/repository.py",
       "source_location": "L25",
-      "community": 75,
+      "community": 74,
       "norm_label": "converte list[dict] em dataframe com cast numerico de todas as colunas de valor.",
       "id": "payments_repository_rationale_25"
     },
@@ -7982,7 +8027,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/features/orders/subfeatures/payments/repository.py",
       "source_location": "L51",
-      "community": 76,
+      "community": 75,
       "norm_label": "faz cast numerico de uma coluna se ela existir no dataframe.",
       "id": "payments_repository_rationale_51"
     },
@@ -7991,7 +8036,7 @@
       "file_type": "rationale",
       "source_file": "core/errors.py",
       "source_location": "L1",
-      "community": 77,
+      "community": 76,
       "norm_label": "codigos de erro da aplicacao com estrutura apperror.",
       "id": "core_errors_rationale_1"
     },
@@ -8000,7 +8045,7 @@
       "file_type": "rationale",
       "source_file": "core/errors.py",
       "source_location": "L7",
-      "community": 78,
+      "community": 77,
       "norm_label": "estrutura de uma mensagem de erro/info para exibicao no popup.",
       "id": "core_errors_rationale_7"
     },
@@ -8009,7 +8054,7 @@
       "file_type": "rationale",
       "source_file": "core/errors.py",
       "source_location": "L103",
-      "community": 79,
+      "community": 78,
       "norm_label": "confirmacao de certificado configurado com sucesso.",
       "id": "core_errors_rationale_103"
     },
@@ -8018,7 +8063,7 @@
       "file_type": "rationale",
       "source_file": "core/errors.py",
       "source_location": "L112",
-      "community": 80,
+      "community": 79,
       "norm_label": "confirmacao de credenciais removidas com sucesso.",
       "id": "core_errors_rationale_112"
     },
@@ -8027,7 +8072,7 @@
       "file_type": "rationale",
       "source_file": "core/errors.py",
       "source_location": "L121",
-      "community": 81,
+      "community": 80,
       "norm_label": "confirmacao de planilha selecionada com sucesso.",
       "id": "core_errors_rationale_121"
     },
@@ -8036,7 +8081,7 @@
       "file_type": "rationale",
       "source_file": "core/errors.py",
       "source_location": "L130",
-      "community": 82,
+      "community": 81,
       "norm_label": "confirmacao de leitura bem-sucedida da planilha.",
       "id": "core_errors_rationale_130"
     },
@@ -8045,7 +8090,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/features/home/home_view.py",
       "source_location": "L210",
-      "community": 12,
+      "community": 3,
       "norm_label": "# todo: migrar",
       "id": "home_home_view_rationale_210"
     },
@@ -8054,7 +8099,7 @@
       "file_type": "rationale",
       "source_file": "core/charts.py",
       "source_location": "L97",
-      "community": 83,
+      "community": 82,
       "norm_label": "retorna (w, h) para o canvas.         h = altura do viewport (sem desperdicio/ov",
       "id": "core_charts_rationale_97"
     },
@@ -8063,7 +8108,7 @@
       "file_type": "rationale",
       "source_file": "core/sheets/service.py",
       "source_location": "L41",
-      "community": 6,
+      "community": 3,
       "norm_label": "le o .json da service account, autentica e salva em ~/.mariacacau/.",
       "id": "sheets_service_rationale_41"
     },
@@ -8072,7 +8117,7 @@
       "file_type": "rationale",
       "source_file": "core/sheets/service.py",
       "source_location": "L48",
-      "community": 6,
+      "community": 3,
       "norm_label": "tenta autenticar usando credenciais salvas. retorna false se nao houver.",
       "id": "sheets_service_rationale_48"
     },
@@ -8081,7 +8126,7 @@
       "file_type": "rationale",
       "source_file": "core/sheets/service.py",
       "source_location": "L65",
-      "community": 6,
+      "community": 3,
       "norm_label": "inicia o pre-aquecimento do token oauth em background.         qualquer requisic",
       "id": "sheets_service_rationale_65"
     },
@@ -8090,7 +8135,7 @@
       "file_type": "rationale",
       "source_file": "core/sheets/service.py",
       "source_location": "L86",
-      "community": 6,
+      "community": 3,
       "norm_label": "le todas as linhas da aba cadastro usando dois passes para economizar api.",
       "id": "sheets_service_rationale_86"
     },
@@ -8099,7 +8144,7 @@
       "file_type": "rationale",
       "source_file": "core/sheets/service.py",
       "source_location": "L90",
-      "community": 6,
+      "community": 3,
       "norm_label": "remove as credenciais salvas. retorna false se nao havia nada salvo.",
       "id": "sheets_service_rationale_90"
     },
@@ -8108,7 +8153,7 @@
       "file_type": "rationale",
       "source_file": "core/sheets/service.py",
       "source_location": "L99",
-      "community": 6,
+      "community": 3,
       "norm_label": "retorna true se uma planilha foi vinculada.",
       "id": "sheets_service_rationale_99"
     },
@@ -8117,7 +8162,7 @@
       "file_type": "rationale",
       "source_file": "core/sheets/service.py",
       "source_location": "L103",
-      "community": 6,
+      "community": 3,
       "norm_label": "define qual planilha vai ser lida pelo id ou url do google sheets.",
       "id": "sheets_service_rationale_103"
     },
@@ -8126,7 +8171,7 @@
       "file_type": "rationale",
       "source_file": "core/sheets/service.py",
       "source_location": "L107",
-      "community": 6,
+      "community": 3,
       "norm_label": "retorna as linhas brutas da planilha (lista de listas de strings).",
       "id": "sheets_service_rationale_107"
     },
@@ -8135,7 +8180,7 @@
       "file_type": "rationale",
       "source_file": "core/sheets/service.py",
       "source_location": "L117",
-      "community": 6,
+      "community": 3,
       "norm_label": "le todas as linhas da aba cadastro usando dois passes para economizar api.",
       "id": "sheets_service_rationale_117"
     },
@@ -8144,7 +8189,7 @@
       "file_type": "rationale",
       "source_file": "core/sheets/service.py",
       "source_location": "L175",
-      "community": 6,
+      "community": 3,
       "norm_label": "le linhas da aba cadastro para um conjunto especifico de datas.          mesmo m",
       "id": "sheets_service_rationale_175"
     },
@@ -8153,7 +8198,7 @@
       "file_type": "rationale",
       "source_file": "core/sheets/manager.py",
       "source_location": "L16",
-      "community": 84,
+      "community": 83,
       "norm_label": "autentica e aponta para a planilha. nao le dados ainda.",
       "id": "sheets_manager_rationale_16"
     },
@@ -8162,7 +8207,7 @@
       "file_type": "rationale",
       "source_file": "core/sheets/manager.py",
       "source_location": "L24",
-      "community": 85,
+      "community": 84,
       "norm_label": "le e processa as 20 datas mais recentes da aba cadastro (chamado uma vez, no ati",
       "id": "sheets_manager_rationale_24"
     },
@@ -8171,7 +8216,7 @@
       "file_type": "rationale",
       "source_file": "core/sheets/manager.py",
       "source_location": "L30",
-      "community": 86,
+      "community": 85,
       "norm_label": "le entregas de uma data especifica direto da planilha (sem cache global).",
       "id": "sheets_manager_rationale_30"
     },
@@ -8180,7 +8225,7 @@
       "file_type": "rationale",
       "source_file": "core/sheets/manager.py",
       "source_location": "L55",
-      "community": 87,
+      "community": 86,
       "norm_label": "descarta os dados em memoria, forcando nova leitura na proxima consulta.",
       "id": "sheets_manager_rationale_55"
     },
@@ -8189,7 +8234,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/core/network/_response.py",
       "source_location": "L11",
-      "community": 88,
+      "community": 87,
       "norm_label": "r\"\"\"decodifica o body para um objeto.",
       "id": "network_response_rationale_11"
     },
@@ -8198,7 +8243,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/core/network/_response.py",
       "source_location": "L16",
-      "community": 89,
+      "community": 88,
       "norm_label": "r\"\"\"indica se a resposta foi bem sucedida (status code 2xx).",
       "id": "network_response_rationale_16"
     },
@@ -8207,7 +8252,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/core/network/api.py",
       "source_location": "L31",
-      "community": 2,
+      "community": 6,
       "norm_label": "o tipo precisa aceitar **kwargs (dataclass ou similar).",
       "id": "network_api_rationale_31"
     },
@@ -8216,7 +8261,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/core/network/_client.py",
       "source_location": "L13",
-      "community": 2,
+      "community": 6,
       "norm_label": "contrato que qualquer client precisa cumprir.",
       "id": "network_client_rationale_13"
     },
@@ -8225,7 +8270,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/core/network/_client.py",
       "source_location": "L20",
-      "community": 2,
+      "community": 6,
       "norm_label": "roteia requests para o backend local (in-process).     nenhuma rede envolvida \u2014",
       "id": "network_client_rationale_20"
     },
@@ -8234,7 +8279,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/core/network/_config.py",
       "source_location": "L15",
-      "community": 2,
+      "community": 6,
       "norm_label": "configura o client ativo.",
       "id": "network_config_rationale_15"
     },
@@ -8243,7 +8288,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/core/network/_config.py",
       "source_location": "L20",
-      "community": 2,
+      "community": 6,
       "norm_label": "substitui o client \u2014 util para testes ou wiremock.",
       "id": "network_config_rationale_20"
     },
@@ -8252,7 +8297,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/core/network/_config.py",
       "source_location": "L25",
-      "community": 2,
+      "community": 6,
       "norm_label": "remove o override. volta ao client padrao.",
       "id": "network_config_rationale_25"
     },
@@ -8261,7 +8306,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/core/network/_config.py",
       "source_location": "L30",
-      "community": 2,
+      "community": 6,
       "norm_label": "retorna o client ativo (override se existir, padrao caso contrario).",
       "id": "network_config_rationale_30"
     },
@@ -8270,7 +8315,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/features/home/home_view.py",
       "source_location": "L204",
-      "community": 12,
+      "community": 3,
       "norm_label": "# todo: migrar",
       "id": "home_home_view_rationale_204"
     },
@@ -8279,7 +8324,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/features/home/sub_features/orders_pendent/view.py",
       "source_location": "L90",
-      "community": 0,
+      "community": 1,
       "norm_label": "r'''retorna a data selecionada no formato dd/mm/yy",
       "id": "orders_pendent_view_rationale_90"
     },
@@ -8288,7 +8333,7 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/features/home/sub_features/orders_pendent/view.py",
       "source_location": "L94",
-      "community": 0,
+      "community": 1,
       "norm_label": "r'''atualiza os dados da view",
       "id": "orders_pendent_view_rationale_94"
     },
@@ -8297,7 +8342,7 @@
       "file_type": "rationale",
       "source_file": "features/home/sub_features/orders_pendent/orders_pendent_view.py",
       "source_location": "L1",
-      "community": 0,
+      "community": 1,
       "norm_label": "area de entregas pendentes: resumo diario com inadimplencias.",
       "id": "orders_pendent_orders_pendent_view_rationale_1"
     },
@@ -8306,7 +8351,7 @@
       "file_type": "rationale",
       "source_file": "core/sheets/service.py",
       "source_location": "L35",
-      "community": 6,
+      "community": 3,
       "norm_label": "le o .json da service account, autentica e salva em ~/.mariacacau/.",
       "id": "sheets_service_rationale_35"
     },
@@ -8315,7 +8360,7 @@
       "file_type": "rationale",
       "source_file": "core/sheets/service.py",
       "source_location": "L59",
-      "community": 6,
+      "community": 3,
       "norm_label": "remove as credenciais salvas. retorna false se nao havia nada salvo.",
       "id": "sheets_service_rationale_59"
     },
@@ -8324,7 +8369,7 @@
       "file_type": "rationale",
       "source_file": "core/sheets/service.py",
       "source_location": "L68",
-      "community": 6,
+      "community": 3,
       "norm_label": "retorna true se uma planilha foi vinculada.",
       "id": "sheets_service_rationale_68"
     },
@@ -8333,7 +8378,7 @@
       "file_type": "rationale",
       "source_file": "core/sheets/service.py",
       "source_location": "L72",
-      "community": 6,
+      "community": 3,
       "norm_label": "define qual planilha vai ser lida pelo id ou url do google sheets.",
       "id": "sheets_service_rationale_72"
     },
@@ -8342,7 +8387,7 @@
       "file_type": "rationale",
       "source_file": "core/sheets/service.py",
       "source_location": "L76",
-      "community": 6,
+      "community": 3,
       "norm_label": "retorna as linhas brutas da planilha (lista de listas de strings).",
       "id": "sheets_service_rationale_76"
     },
@@ -8351,7 +8396,7 @@
       "file_type": "rationale",
       "source_file": "core/sheets/service.py",
       "source_location": "L144",
-      "community": 6,
+      "community": 3,
       "norm_label": "le linhas da aba cadastro para um conjunto especifico de datas.          mesmo m",
       "id": "sheets_service_rationale_144"
     }
@@ -9695,11 +9740,11 @@
       "source_file": "maria_cacau/app/coordinator.py",
       "source_location": "L10",
       "weight": 0.8,
-      "_src": "app_coordinator_appcoordinator",
-      "_tgt": "core_observability_appevent",
+      "_src": "core_observability_appevent",
+      "_tgt": "app_coordinator_appcoordinator",
+      "confidence_score": 0.5,
       "source": "core_observability_appevent",
-      "target": "app_coordinator_appcoordinator",
-      "confidence_score": 0.5
+      "target": "app_coordinator_appcoordinator"
     },
     {
       "relation": "uses",
@@ -10044,8 +10089,8 @@
       "source_file": "maria_cacau/app/coordinator.py",
       "source_location": "L42",
       "weight": 1.0,
-      "_src": "app_coordinator_appcoordinator_initialize",
-      "_tgt": "core_observability_observability_log",
+      "_src": "core_observability_observability_log",
+      "_tgt": "app_coordinator_appcoordinator_initialize",
       "source": "core_observability_observability_log",
       "target": "app_coordinator_appcoordinator_initialize"
     },
@@ -10056,8 +10101,8 @@
       "source_file": "maria_cacau/app/coordinator.py",
       "source_location": "L45",
       "weight": 1.0,
-      "_src": "app_coordinator_appcoordinator_on_quit",
-      "_tgt": "core_observability_observability_log",
+      "_src": "core_observability_observability_log",
+      "_tgt": "app_coordinator_appcoordinator_on_quit",
       "source": "core_observability_observability_log",
       "target": "app_coordinator_appcoordinator_on_quit"
     },
@@ -10084,6 +10129,30 @@
       "_tgt": "presentation_controller_cpfvalidationcontroller_handle_result",
       "source": "core_observability_observability_log",
       "target": "presentation_controller_cpfvalidationcontroller_handle_result"
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "maria_cacau/features/home/sub_features/delivery/data/repository.py",
+      "source_location": "L21",
+      "weight": 1.0,
+      "_src": "data_repository_ordersrepository_get_deliveries",
+      "_tgt": "core_observability_observability_log",
+      "source": "core_observability_observability_log",
+      "target": "data_repository_ordersrepository_get_deliveries"
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "maria_cacau/features/home/sub_features/delivery/data/repository.py",
+      "source_location": "L33",
+      "weight": 1.0,
+      "_src": "data_repository_ordersrepository_get_pendent_payments",
+      "_tgt": "core_observability_observability_log",
+      "source": "core_observability_observability_log",
+      "target": "data_repository_ordersrepository_get_pendent_payments"
     },
     {
       "relation": "calls",
@@ -10144,6 +10213,18 @@
       "_tgt": "presentation_controller_deliverycontroller_handle_report_generated",
       "source": "core_observability_observability_log",
       "target": "presentation_controller_deliverycontroller_handle_report_generated"
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "maria_cacau/features/home/sub_features/summary/data/repository.py",
+      "source_location": "L21",
+      "weight": 1.0,
+      "_src": "data_repository_summaryrepository_get_by_period",
+      "_tgt": "core_observability_observability_log",
+      "source": "core_observability_observability_log",
+      "target": "data_repository_summaryrepository_get_by_period"
     },
     {
       "relation": "calls",
@@ -10216,6 +10297,18 @@
       "_tgt": "presentation_controller_summarycontroller_handle_report_generated",
       "source": "core_observability_observability_log",
       "target": "presentation_controller_summarycontroller_handle_report_generated"
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "maria_cacau/features/sheets/presentation/controller.py",
+      "source_location": "L80",
+      "weight": 1.0,
+      "_src": "presentation_controller_sheetscontroller_on_clear_cache",
+      "_tgt": "core_observability_observability_log",
+      "source": "core_observability_observability_log",
+      "target": "presentation_controller_sheetscontroller_on_clear_cache"
     },
     {
       "relation": "calls",
@@ -12132,8 +12225,8 @@
       "source_file": "maria_cacau/features/auth/domain/init_use_case.py",
       "source_location": "L24",
       "weight": 1.0,
-      "_src": "domain_init_use_case_appinitusecase_initialize",
-      "_tgt": "network_api_call",
+      "_src": "network_api_call",
+      "_tgt": "domain_init_use_case_appinitusecase_initialize",
       "source": "network_api_call",
       "target": "domain_init_use_case_appinitusecase_initialize"
     },
@@ -12396,8 +12489,8 @@
       "source_file": "maria_cacau/app/coordinator.py",
       "source_location": "L24",
       "weight": 1.0,
-      "_src": "app_coordinator_appcoordinator_launch",
-      "_tgt": "network_client_localclient",
+      "_src": "network_client_localclient",
+      "_tgt": "app_coordinator_appcoordinator_launch",
       "source": "network_client_localclient",
       "target": "app_coordinator_appcoordinator_launch"
     },
@@ -12779,11 +12872,11 @@
       "source_file": "maria_cacau/features/auth/data/repository.py",
       "source_location": "L5",
       "weight": 0.8,
-      "_src": "data_repository_rationale_27",
-      "_tgt": "storage_security_securitystorage",
+      "_src": "storage_security_securitystorage",
+      "_tgt": "data_repository_rationale_27",
+      "confidence_score": 0.5,
       "source": "storage_security_securitystorage",
-      "target": "data_repository_rationale_27",
-      "confidence_score": 0.5
+      "target": "data_repository_rationale_27"
     },
     {
       "relation": "uses",
@@ -13380,8 +13473,8 @@
       "source_file": "maria_cacau/features/auth/data/repository.py",
       "source_location": "L23",
       "weight": 1.0,
-      "_src": "data_repository_authrepository_read_credentials",
-      "_tgt": "storage_cache_cachestorage_retrieve",
+      "_src": "storage_cache_cachestorage_retrieve",
+      "_tgt": "data_repository_authrepository_read_credentials",
       "source": "storage_cache_cachestorage_retrieve",
       "target": "data_repository_authrepository_read_credentials"
     },
@@ -14185,9 +14278,9 @@
       "weight": 0.8,
       "_src": "app_coordinator_appcoordinator",
       "_tgt": "backend_server_backendserver",
+      "confidence_score": 0.5,
       "source": "app_coordinator_appcoordinator",
-      "target": "backend_server_backendserver",
-      "confidence_score": 0.5
+      "target": "backend_server_backendserver"
     },
     {
       "relation": "uses",
@@ -14197,9 +14290,9 @@
       "weight": 0.8,
       "_src": "app_coordinator_appcoordinator",
       "_tgt": "domain_init_use_case_appinitusecase",
+      "confidence_score": 0.5,
       "source": "app_coordinator_appcoordinator",
-      "target": "domain_init_use_case_appinitusecase",
-      "confidence_score": 0.5
+      "target": "domain_init_use_case_appinitusecase"
     },
     {
       "relation": "uses",
@@ -14209,9 +14302,9 @@
       "weight": 0.8,
       "_src": "app_coordinator_appcoordinator",
       "_tgt": "app_window_mainwindow",
+      "confidence_score": 0.5,
       "source": "app_coordinator_appcoordinator",
-      "target": "app_window_mainwindow",
-      "confidence_score": 0.5
+      "target": "app_window_mainwindow"
     },
     {
       "relation": "calls",
@@ -14375,11 +14468,11 @@
       "source_file": "maria_cacau/app/window.py",
       "source_location": "L9",
       "weight": 0.8,
-      "_src": "app_window_mainwindow",
-      "_tgt": "app_handler_menuhandler",
+      "_src": "app_handler_menuhandler",
+      "_tgt": "app_window_mainwindow",
+      "confidence_score": 0.5,
       "source": "app_handler_menuhandler",
-      "target": "app_window_mainwindow",
-      "confidence_score": 0.5
+      "target": "app_window_mainwindow"
     },
     {
       "relation": "calls",
@@ -14388,8 +14481,8 @@
       "source_file": "maria_cacau/app/window.py",
       "source_location": "L16",
       "weight": 1.0,
-      "_src": "app_window_mainwindow_init",
-      "_tgt": "app_handler_menuhandler",
+      "_src": "app_handler_menuhandler",
+      "_tgt": "app_window_mainwindow_init",
       "source": "app_handler_menuhandler",
       "target": "app_window_mainwindow_init"
     },
@@ -14436,8 +14529,8 @@
       "source_file": "maria_cacau/app/window.py",
       "source_location": "L35",
       "weight": 1.0,
-      "_src": "app_window_mainwindow_setup_menus",
-      "_tgt": "app_handler_menuhandler_setup_menus",
+      "_src": "app_handler_menuhandler_setup_menus",
+      "_tgt": "app_window_mainwindow_setup_menus",
       "source": "app_handler_menuhandler_setup_menus",
       "target": "app_window_mainwindow_setup_menus"
     },
@@ -14533,9 +14626,9 @@
       "weight": 0.8,
       "_src": "app_window_mainwindow",
       "_tgt": "status_bar_status_bar_view_guistatusbar",
+      "confidence_score": 0.5,
       "source": "app_window_mainwindow",
-      "target": "status_bar_status_bar_view_guistatusbar",
-      "confidence_score": 0.5
+      "target": "status_bar_status_bar_view_guistatusbar"
     },
     {
       "relation": "calls",
@@ -16940,6 +17033,30 @@
     {
       "relation": "uses",
       "confidence": "INFERRED",
+      "source_file": "maria_cacau/features/home/sub_features/delivery/data/repository.py",
+      "source_location": "L7",
+      "weight": 0.8,
+      "_src": "data_repository_ordersrepository",
+      "_tgt": "domain_events_featureevents",
+      "source": "domain_events_featureevents",
+      "target": "data_repository_ordersrepository",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "uses",
+      "confidence": "INFERRED",
+      "source_file": "maria_cacau/features/home/sub_features/summary/data/repository.py",
+      "source_location": "L7",
+      "weight": 0.8,
+      "_src": "data_repository_rationale_1",
+      "_tgt": "domain_events_featureevents",
+      "source": "domain_events_featureevents",
+      "target": "data_repository_rationale_1",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "uses",
+      "confidence": "INFERRED",
       "source_file": "maria_cacau/features/home/sub_features/delivery/presentation/controller.py",
       "source_location": "L8",
       "weight": 0.8,
@@ -16972,6 +17089,18 @@
       "confidence_score": 0.5,
       "source": "domain_events_featureevents",
       "target": "presentation_controller_rationale_57"
+    },
+    {
+      "relation": "uses",
+      "confidence": "INFERRED",
+      "source_file": "maria_cacau/features/home/sub_features/summary/data/repository.py",
+      "source_location": "L7",
+      "weight": 0.8,
+      "_src": "data_repository_summaryrepository",
+      "_tgt": "domain_events_featureevents",
+      "source": "domain_events_featureevents",
+      "target": "data_repository_summaryrepository",
+      "confidence_score": 0.5
     },
     {
       "relation": "uses",
@@ -18105,7 +18234,7 @@
       "relation": "imports_from",
       "confidence": "EXTRACTED",
       "source_file": "maria_cacau/features/home/sub_features/delivery/data/repository.py",
-      "source_location": "L7",
+      "source_location": "L10",
       "weight": 1.0,
       "_src": "maria_cacau_features_home_sub_features_delivery_data_repository_py",
       "_tgt": "maria_cacau_features_home_sub_features_delivery_data_mapper_py",
@@ -18188,30 +18317,6 @@
     {
       "relation": "uses",
       "confidence": "INFERRED",
-      "source_file": "maria_cacau/features/home/sub_features/delivery/data/repository.py",
-      "source_location": "L7",
-      "weight": 0.8,
-      "_src": "data_mapper_errormapper",
-      "_tgt": "data_repository_rationale_12",
-      "confidence_score": 0.5,
-      "source": "data_mapper_errormapper",
-      "target": "data_repository_rationale_12"
-    },
-    {
-      "relation": "uses",
-      "confidence": "INFERRED",
-      "source_file": "maria_cacau/features/home/sub_features/delivery/data/repository.py",
-      "source_location": "L7",
-      "weight": 0.8,
-      "_src": "data_mapper_errormapper",
-      "_tgt": "data_repository_rationale_20",
-      "confidence_score": 0.5,
-      "source": "data_mapper_errormapper",
-      "target": "data_repository_rationale_20"
-    },
-    {
-      "relation": "uses",
-      "confidence": "INFERRED",
       "source_file": "maria_cacau/features/home/sub_features/summary/data/mapper.py",
       "source_location": "L6",
       "weight": 0.8,
@@ -18244,6 +18349,30 @@
       "confidence_score": 0.5,
       "source": "data_mapper_errormapper",
       "target": "data_repository_summaryrepository"
+    },
+    {
+      "relation": "uses",
+      "confidence": "INFERRED",
+      "source_file": "maria_cacau/features/home/sub_features/delivery/data/repository.py",
+      "source_location": "L7",
+      "weight": 0.8,
+      "_src": "data_mapper_errormapper",
+      "_tgt": "data_repository_rationale_12",
+      "confidence_score": 0.5,
+      "source": "data_mapper_errormapper",
+      "target": "data_repository_rationale_12"
+    },
+    {
+      "relation": "uses",
+      "confidence": "INFERRED",
+      "source_file": "maria_cacau/features/home/sub_features/delivery/data/repository.py",
+      "source_location": "L7",
+      "weight": 0.8,
+      "_src": "data_mapper_errormapper",
+      "_tgt": "data_repository_rationale_20",
+      "confidence_score": 0.5,
+      "source": "data_mapper_errormapper",
+      "target": "data_repository_rationale_20"
     },
     {
       "relation": "contains",
@@ -18693,7 +18822,7 @@
       "relation": "imports_from",
       "confidence": "EXTRACTED",
       "source_file": "maria_cacau/features/home/sub_features/delivery/data/repository.py",
-      "source_location": "L6",
+      "source_location": "L9",
       "weight": 1.0,
       "_src": "maria_cacau_features_home_sub_features_delivery_data_repository_py",
       "_tgt": "maria_cacau_features_home_sub_features_delivery_data_apis_py",
@@ -18750,6 +18879,18 @@
       "target": "data_repository_rationale_1"
     },
     {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "maria_cacau/features/home/sub_features/delivery/data/repository.py",
+      "source_location": "L11",
+      "weight": 1.0,
+      "_src": "data_apis_deliveriesapi",
+      "_tgt": "data_repository_ordersrepository_get_deliveries",
+      "source": "data_apis_deliveriesapi",
+      "target": "data_repository_ordersrepository_get_deliveries"
+    },
+    {
       "relation": "uses",
       "confidence": "INFERRED",
       "source_file": "maria_cacau/features/home/sub_features/delivery/data/repository.py",
@@ -18772,18 +18913,6 @@
       "confidence_score": 0.5,
       "source": "data_apis_deliveriesapi",
       "target": "data_repository_rationale_20"
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "confidence_score": 0.8,
-      "source_file": "maria_cacau/features/home/sub_features/delivery/data/repository.py",
-      "source_location": "L11",
-      "weight": 1.0,
-      "_src": "data_apis_deliveriesapi",
-      "_tgt": "data_repository_ordersrepository_get_deliveries",
-      "source": "data_apis_deliveriesapi",
-      "target": "data_repository_ordersrepository_get_deliveries"
     },
     {
       "relation": "inherits",
@@ -18930,6 +19059,18 @@
       "target": "data_repository_rationale_1"
     },
     {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "maria_cacau/features/home/sub_features/delivery/data/repository.py",
+      "source_location": "L18",
+      "weight": 1.0,
+      "_src": "data_apis_paymentspendentapi",
+      "_tgt": "data_repository_ordersrepository_get_pendent_payments",
+      "source": "data_apis_paymentspendentapi",
+      "target": "data_repository_ordersrepository_get_pendent_payments"
+    },
+    {
       "relation": "uses",
       "confidence": "INFERRED",
       "source_file": "maria_cacau/features/home/sub_features/delivery/data/repository.py",
@@ -18952,18 +19093,6 @@
       "confidence_score": 0.5,
       "source": "data_apis_paymentspendentapi",
       "target": "data_repository_rationale_20"
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "confidence_score": 0.8,
-      "source_file": "maria_cacau/features/home/sub_features/delivery/data/repository.py",
-      "source_location": "L18",
-      "weight": 1.0,
-      "_src": "data_apis_paymentspendentapi",
-      "_tgt": "data_repository_ordersrepository_get_pendent_payments",
-      "source": "data_apis_paymentspendentapi",
-      "target": "data_repository_ordersrepository_get_pendent_payments"
     },
     {
       "relation": "calls",
@@ -19017,7 +19146,19 @@
       "relation": "imports_from",
       "confidence": "EXTRACTED",
       "source_file": "maria_cacau/features/home/sub_features/delivery/data/repository.py",
-      "source_location": "L5",
+      "source_location": "L7",
+      "weight": 1.0,
+      "_src": "maria_cacau_features_home_sub_features_delivery_data_repository_py",
+      "_tgt": "maria_cacau_features_home_sub_features_delivery_domain_events_py",
+      "source": "maria_cacau_features_home_sub_features_delivery_data_repository_py",
+      "target": "maria_cacau_features_home_sub_features_delivery_domain_events_py",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "maria_cacau/features/home/sub_features/delivery/data/repository.py",
+      "source_location": "L8",
       "weight": 1.0,
       "_src": "maria_cacau_features_home_sub_features_delivery_data_repository_py",
       "_tgt": "maria_cacau_features_home_sub_features_delivery_domain_models_py",
@@ -19029,7 +19170,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "maria_cacau/features/home/sub_features/delivery/data/repository.py",
-      "source_location": "L10",
+      "source_location": "L13",
       "weight": 1.0,
       "_src": "maria_cacau_features_home_sub_features_delivery_data_repository_py",
       "_tgt": "data_repository_ordersrepository",
@@ -19053,7 +19194,19 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "maria_cacau/features/home/sub_features/delivery/data/repository.py",
-      "source_location": "L11",
+      "source_location": "L14",
+      "weight": 1.0,
+      "_src": "data_repository_ordersrepository",
+      "_tgt": "data_repository_ordersrepository_init",
+      "source": "data_repository_ordersrepository",
+      "target": "data_repository_ordersrepository_init",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "maria_cacau/features/home/sub_features/delivery/data/repository.py",
+      "source_location": "L19",
       "weight": 1.0,
       "_src": "data_repository_ordersrepository",
       "_tgt": "data_repository_ordersrepository_get_deliveries",
@@ -19065,12 +19218,24 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "maria_cacau/features/home/sub_features/delivery/data/repository.py",
-      "source_location": "L19",
+      "source_location": "L31",
       "weight": 1.0,
       "_src": "data_repository_ordersrepository",
       "_tgt": "data_repository_ordersrepository_get_pendent_payments",
       "source": "data_repository_ordersrepository",
       "target": "data_repository_ordersrepository_get_pendent_payments",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "maria_cacau/features/home/sub_features/delivery/data/repository.py",
+      "source_location": "L43",
+      "weight": 1.0,
+      "_src": "data_repository_ordersrepository",
+      "_tgt": "data_repository_ordersrepository_clear_cache",
+      "source": "data_repository_ordersrepository",
+      "target": "data_repository_ordersrepository_clear_cache",
       "confidence_score": 1.0
     },
     {
@@ -19110,28 +19275,28 @@
       "target": "domain_use_case_deliveryusecase_init"
     },
     {
-      "relation": "rationale_for",
-      "confidence": "EXTRACTED",
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
       "source_file": "maria_cacau/features/home/sub_features/delivery/data/repository.py",
-      "source_location": "L12",
+      "source_location": "L17",
       "weight": 1.0,
-      "_src": "data_repository_rationale_12",
-      "_tgt": "data_repository_ordersrepository_get_deliveries",
-      "source": "data_repository_ordersrepository_get_deliveries",
-      "target": "data_repository_rationale_12",
-      "confidence_score": 1.0
+      "_src": "data_repository_ordersrepository_init",
+      "_tgt": "auth_route_connect",
+      "source": "data_repository_ordersrepository_init",
+      "target": "auth_route_connect"
     },
     {
-      "relation": "rationale_for",
-      "confidence": "EXTRACTED",
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
       "source_file": "maria_cacau/features/home/sub_features/delivery/data/repository.py",
-      "source_location": "L20",
+      "source_location": "L44",
       "weight": 1.0,
-      "_src": "data_repository_rationale_20",
-      "_tgt": "data_repository_ordersrepository_get_pendent_payments",
-      "source": "data_repository_ordersrepository_get_pendent_payments",
-      "target": "data_repository_rationale_20",
-      "confidence_score": 1.0
+      "_src": "data_repository_ordersrepository_clear_cache",
+      "_tgt": "presentation_viewmodel_authviewmodel_clear",
+      "source": "data_repository_ordersrepository_clear_cache",
+      "target": "presentation_viewmodel_authviewmodel_clear"
     },
     {
       "relation": "rationale_for",
@@ -19240,102 +19405,6 @@
       "confidence_score": 0.5,
       "source": "data_repository_rationale_1",
       "target": "data_apis_disconnectauthapi"
-    },
-    {
-      "relation": "rationale_for",
-      "confidence": "EXTRACTED",
-      "source_file": "maria_cacau/features/home/sub_features/summary/data/repository.py",
-      "source_location": "L12",
-      "weight": 1.0,
-      "_src": "data_repository_rationale_12",
-      "_tgt": "data_repository_summaryrepository_get_by_period",
-      "source": "data_repository_rationale_12",
-      "target": "data_repository_summaryrepository_get_by_period",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "uses",
-      "confidence": "INFERRED",
-      "source_file": "maria_cacau/features/home/sub_features/delivery/data/repository.py",
-      "source_location": "L5",
-      "weight": 0.8,
-      "_src": "data_repository_rationale_12",
-      "_tgt": "deliveries_models_deliveriessummary",
-      "confidence_score": 0.5,
-      "source": "data_repository_rationale_12",
-      "target": "deliveries_models_deliveriessummary"
-    },
-    {
-      "relation": "uses",
-      "confidence": "INFERRED",
-      "source_file": "maria_cacau/features/home/sub_features/delivery/data/repository.py",
-      "source_location": "L5",
-      "weight": 0.8,
-      "_src": "data_repository_rationale_12",
-      "_tgt": "domain_models_pendentorder",
-      "confidence_score": 0.5,
-      "source": "data_repository_rationale_12",
-      "target": "domain_models_pendentorder"
-    },
-    {
-      "relation": "uses",
-      "confidence": "INFERRED",
-      "source_file": "maria_cacau/features/home/sub_features/summary/data/repository.py",
-      "source_location": "L5",
-      "weight": 0.8,
-      "_src": "data_repository_rationale_12",
-      "_tgt": "domain_models_orderdetail",
-      "confidence_score": 0.5,
-      "source": "data_repository_rationale_12",
-      "target": "domain_models_orderdetail"
-    },
-    {
-      "relation": "uses",
-      "confidence": "INFERRED",
-      "source_file": "maria_cacau/features/home/sub_features/summary/data/repository.py",
-      "source_location": "L6",
-      "weight": 0.8,
-      "_src": "data_repository_rationale_12",
-      "_tgt": "data_apis_orderssummaryapi",
-      "confidence_score": 0.5,
-      "source": "data_repository_rationale_12",
-      "target": "data_apis_orderssummaryapi"
-    },
-    {
-      "relation": "uses",
-      "confidence": "INFERRED",
-      "source_file": "maria_cacau/features/home/sub_features/summary/data/repository.py",
-      "source_location": "L7",
-      "weight": 0.8,
-      "_src": "data_repository_rationale_12",
-      "_tgt": "data_mapper_orderssummarymapper",
-      "confidence_score": 0.5,
-      "source": "data_repository_rationale_12",
-      "target": "data_mapper_orderssummarymapper"
-    },
-    {
-      "relation": "uses",
-      "confidence": "INFERRED",
-      "source_file": "maria_cacau/features/home/sub_features/delivery/data/repository.py",
-      "source_location": "L5",
-      "weight": 0.8,
-      "_src": "data_repository_rationale_20",
-      "_tgt": "deliveries_models_deliveriessummary",
-      "confidence_score": 0.5,
-      "source": "data_repository_rationale_20",
-      "target": "deliveries_models_deliveriessummary"
-    },
-    {
-      "relation": "uses",
-      "confidence": "INFERRED",
-      "source_file": "maria_cacau/features/home/sub_features/delivery/data/repository.py",
-      "source_location": "L5",
-      "weight": 0.8,
-      "_src": "data_repository_rationale_20",
-      "_tgt": "domain_models_pendentorder",
-      "confidence_score": 0.5,
-      "source": "data_repository_rationale_20",
-      "target": "domain_models_pendentorder"
     },
     {
       "relation": "imports_from",
@@ -19648,6 +19717,30 @@
       "source": "maria_cacau_features_home_sub_features_delivery_domain_models_py",
       "target": "maria_cacau_features_home_sub_features_delivery_presentation_view_py",
       "confidence_score": 1.0
+    },
+    {
+      "relation": "uses",
+      "confidence": "INFERRED",
+      "source_file": "maria_cacau/features/home/sub_features/delivery/data/repository.py",
+      "source_location": "L5",
+      "weight": 0.8,
+      "_src": "data_repository_rationale_12",
+      "_tgt": "domain_models_pendentorder",
+      "confidence_score": 0.5,
+      "source": "domain_models_pendentorder",
+      "target": "data_repository_rationale_12"
+    },
+    {
+      "relation": "uses",
+      "confidence": "INFERRED",
+      "source_file": "maria_cacau/features/home/sub_features/delivery/data/repository.py",
+      "source_location": "L5",
+      "weight": 0.8,
+      "_src": "data_repository_rationale_20",
+      "_tgt": "domain_models_pendentorder",
+      "confidence_score": 0.5,
+      "source": "domain_models_pendentorder",
+      "target": "data_repository_rationale_20"
     },
     {
       "relation": "uses",
@@ -21141,7 +21234,7 @@
       "relation": "imports_from",
       "confidence": "EXTRACTED",
       "source_file": "maria_cacau/features/home/sub_features/summary/data/repository.py",
-      "source_location": "L7",
+      "source_location": "L10",
       "weight": 1.0,
       "_src": "maria_cacau_features_home_sub_features_summary_data_repository_py",
       "_tgt": "maria_cacau_features_home_sub_features_summary_data_mapper_py",
@@ -21186,6 +21279,18 @@
       "target": "data_repository_summaryrepository"
     },
     {
+      "relation": "uses",
+      "confidence": "INFERRED",
+      "source_file": "maria_cacau/features/home/sub_features/summary/data/repository.py",
+      "source_location": "L7",
+      "weight": 0.8,
+      "_src": "data_repository_rationale_12",
+      "_tgt": "data_mapper_orderssummarymapper",
+      "confidence_score": 0.5,
+      "source": "data_mapper_orderssummarymapper",
+      "target": "data_repository_rationale_12"
+    },
+    {
       "relation": "imports_from",
       "confidence": "EXTRACTED",
       "source_file": "maria_cacau/features/home/sub_features/summary/data/__init__.py",
@@ -21213,7 +21318,7 @@
       "relation": "imports_from",
       "confidence": "EXTRACTED",
       "source_file": "maria_cacau/features/home/sub_features/summary/data/repository.py",
-      "source_location": "L6",
+      "source_location": "L9",
       "weight": 1.0,
       "_src": "maria_cacau_features_home_sub_features_summary_data_repository_py",
       "_tgt": "maria_cacau_features_home_sub_features_summary_data_apis_py",
@@ -21258,6 +21363,18 @@
       "target": "data_repository_summaryrepository_get_by_period"
     },
     {
+      "relation": "uses",
+      "confidence": "INFERRED",
+      "source_file": "maria_cacau/features/home/sub_features/summary/data/repository.py",
+      "source_location": "L6",
+      "weight": 0.8,
+      "_src": "data_repository_rationale_12",
+      "_tgt": "data_apis_orderssummaryapi",
+      "confidence_score": 0.5,
+      "source": "data_apis_orderssummaryapi",
+      "target": "data_repository_rationale_12"
+    },
+    {
       "relation": "calls",
       "confidence": "INFERRED",
       "confidence_score": 0.8,
@@ -21273,7 +21390,19 @@
       "relation": "imports_from",
       "confidence": "EXTRACTED",
       "source_file": "maria_cacau/features/home/sub_features/summary/data/repository.py",
-      "source_location": "L5",
+      "source_location": "L7",
+      "weight": 1.0,
+      "_src": "maria_cacau_features_home_sub_features_summary_data_repository_py",
+      "_tgt": "maria_cacau_features_home_sub_features_summary_domain_events_py",
+      "source": "maria_cacau_features_home_sub_features_summary_data_repository_py",
+      "target": "maria_cacau_features_home_sub_features_summary_domain_events_py",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "maria_cacau/features/home/sub_features/summary/data/repository.py",
+      "source_location": "L8",
       "weight": 1.0,
       "_src": "maria_cacau_features_home_sub_features_summary_data_repository_py",
       "_tgt": "maria_cacau_features_home_sub_features_summary_domain_models_py",
@@ -21285,7 +21414,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "maria_cacau/features/home/sub_features/summary/data/repository.py",
-      "source_location": "L10",
+      "source_location": "L13",
       "weight": 1.0,
       "_src": "maria_cacau_features_home_sub_features_summary_data_repository_py",
       "_tgt": "data_repository_summaryrepository",
@@ -21309,12 +21438,36 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "maria_cacau/features/home/sub_features/summary/data/repository.py",
-      "source_location": "L11",
+      "source_location": "L14",
+      "weight": 1.0,
+      "_src": "data_repository_summaryrepository",
+      "_tgt": "data_repository_summaryrepository_init",
+      "source": "data_repository_summaryrepository",
+      "target": "data_repository_summaryrepository_init",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "maria_cacau/features/home/sub_features/summary/data/repository.py",
+      "source_location": "L18",
       "weight": 1.0,
       "_src": "data_repository_summaryrepository",
       "_tgt": "data_repository_summaryrepository_get_by_period",
       "source": "data_repository_summaryrepository",
       "target": "data_repository_summaryrepository_get_by_period",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "maria_cacau/features/home/sub_features/summary/data/repository.py",
+      "source_location": "L33",
+      "weight": 1.0,
+      "_src": "data_repository_summaryrepository",
+      "_tgt": "data_repository_summaryrepository_clear_cache",
+      "source": "data_repository_summaryrepository",
+      "target": "data_repository_summaryrepository_clear_cache",
       "confidence_score": 1.0
     },
     {
@@ -21352,6 +21505,30 @@
       "_tgt": "domain_use_case_summaryusecase_init",
       "source": "data_repository_summaryrepository",
       "target": "domain_use_case_summaryusecase_init"
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "maria_cacau/features/home/sub_features/summary/data/repository.py",
+      "source_location": "L16",
+      "weight": 1.0,
+      "_src": "data_repository_summaryrepository_init",
+      "_tgt": "auth_route_connect",
+      "source": "data_repository_summaryrepository_init",
+      "target": "auth_route_connect"
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "maria_cacau/features/home/sub_features/summary/data/repository.py",
+      "source_location": "L34",
+      "weight": 1.0,
+      "_src": "data_repository_summaryrepository_clear_cache",
+      "_tgt": "presentation_viewmodel_authviewmodel_clear",
+      "source": "data_repository_summaryrepository_clear_cache",
+      "target": "presentation_viewmodel_authviewmodel_clear"
     },
     {
       "relation": "imports_from",
@@ -21736,6 +21913,18 @@
       "confidence_score": 0.5,
       "source": "domain_models_productcount",
       "target": "presentation_viewmodel_summaryviewmodel"
+    },
+    {
+      "relation": "uses",
+      "confidence": "INFERRED",
+      "source_file": "maria_cacau/features/home/sub_features/summary/data/repository.py",
+      "source_location": "L5",
+      "weight": 0.8,
+      "_src": "data_repository_rationale_12",
+      "_tgt": "domain_models_orderdetail",
+      "confidence_score": 0.5,
+      "source": "domain_models_orderdetail",
+      "target": "data_repository_rationale_12"
     },
     {
       "relation": "uses",
@@ -22475,11 +22664,11 @@
       "source_file": "maria_cacau/features/sheets/data/repository.py",
       "source_location": "L8",
       "weight": 0.8,
-      "_src": "data_repository_rationale_68",
-      "_tgt": "data_apis_selectsheetapi",
+      "_src": "data_apis_selectsheetapi",
+      "_tgt": "data_repository_rationale_68",
+      "confidence_score": 0.5,
       "source": "data_apis_selectsheetapi",
-      "target": "data_repository_rationale_68",
-      "confidence_score": 0.5
+      "target": "data_repository_rationale_68"
     },
     {
       "relation": "calls",
@@ -22716,8 +22905,8 @@
       "source_file": "maria_cacau/features/auth/domain/init_use_case.py",
       "source_location": "L11",
       "weight": 1.0,
-      "_src": "domain_init_use_case_appinitusecase_init",
-      "_tgt": "data_repository_sheetsrepository",
+      "_src": "data_repository_sheetsrepository",
+      "_tgt": "domain_init_use_case_appinitusecase_init",
       "source": "data_repository_sheetsrepository",
       "target": "domain_init_use_case_appinitusecase_init"
     },
@@ -22872,8 +23061,8 @@
       "source_file": "maria_cacau/features/auth/domain/init_use_case.py",
       "source_location": "L19",
       "weight": 1.0,
-      "_src": "domain_init_use_case_appinitusecase_initialize",
-      "_tgt": "data_repository_sheetsrepository_last_sheet_id_from_cache",
+      "_src": "data_repository_sheetsrepository_last_sheet_id_from_cache",
+      "_tgt": "domain_init_use_case_appinitusecase_initialize",
       "source": "data_repository_sheetsrepository_last_sheet_id_from_cache",
       "target": "domain_init_use_case_appinitusecase_initialize"
     },
@@ -22885,9 +23074,9 @@
       "weight": 0.8,
       "_src": "data_repository_rationale_68",
       "_tgt": "domain_models_sheetmodel",
+      "confidence_score": 0.5,
       "source": "data_repository_rationale_68",
-      "target": "domain_models_sheetmodel",
-      "confidence_score": 0.5
+      "target": "domain_models_sheetmodel"
     },
     {
       "relation": "imports_from",
@@ -23049,7 +23238,7 @@
       "relation": "imports_from",
       "confidence": "EXTRACTED",
       "source_file": "maria_cacau/features/sheets/presentation/controller.py",
-      "source_location": "L10",
+      "source_location": "L11",
       "weight": 1.0,
       "_src": "maria_cacau_features_sheets_presentation_controller_py",
       "_tgt": "maria_cacau_features_sheets_domain_signals_py",
@@ -23085,7 +23274,7 @@
       "relation": "imports_from",
       "confidence": "EXTRACTED",
       "source_file": "maria_cacau/features/sheets/presentation/controller.py",
-      "source_location": "L9",
+      "source_location": "L10",
       "weight": 1.0,
       "_src": "maria_cacau_features_sheets_presentation_controller_py",
       "_tgt": "maria_cacau_features_sheets_domain_models_py",
@@ -23135,8 +23324,8 @@
       "source_file": "maria_cacau/features/sheets/data/repository.py",
       "source_location": "L6",
       "weight": 0.8,
-      "_src": "data_repository_rationale_37",
-      "_tgt": "domain_models_sheetmodel",
+      "_src": "domain_models_sheetmodel",
+      "_tgt": "data_repository_rationale_37",
       "confidence_score": 0.5,
       "source": "domain_models_sheetmodel",
       "target": "data_repository_rationale_37"
@@ -23145,7 +23334,7 @@
       "relation": "imports_from",
       "confidence": "EXTRACTED",
       "source_file": "maria_cacau/features/sheets/presentation/controller.py",
-      "source_location": "L8",
+      "source_location": "L9",
       "weight": 1.0,
       "_src": "maria_cacau_features_sheets_presentation_controller_py",
       "_tgt": "maria_cacau_features_sheets_domain_events_py",
@@ -23157,7 +23346,7 @@
       "relation": "imports_from",
       "confidence": "EXTRACTED",
       "source_file": "maria_cacau/features/sheets/presentation/controller.py",
-      "source_location": "L12",
+      "source_location": "L13",
       "weight": 1.0,
       "_src": "maria_cacau_features_sheets_presentation_controller_py",
       "_tgt": "maria_cacau_features_sheets_presentation_viewmodel_py",
@@ -23169,7 +23358,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "maria_cacau/features/sheets/presentation/controller.py",
-      "source_location": "L15",
+      "source_location": "L16",
       "weight": 1.0,
       "_src": "maria_cacau_features_sheets_presentation_controller_py",
       "_tgt": "presentation_controller_sheetscontroller",
@@ -23193,7 +23382,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "maria_cacau/features/sheets/presentation/controller.py",
-      "source_location": "L16",
+      "source_location": "L17",
       "weight": 1.0,
       "_src": "presentation_controller_sheetscontroller",
       "_tgt": "presentation_controller_sheetscontroller_init",
@@ -23205,7 +23394,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "maria_cacau/features/sheets/presentation/controller.py",
-      "source_location": "L23",
+      "source_location": "L24",
       "weight": 1.0,
       "_src": "presentation_controller_sheetscontroller",
       "_tgt": "presentation_controller_sheetscontroller_setup_actions",
@@ -23217,7 +23406,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "maria_cacau/features/sheets/presentation/controller.py",
-      "source_location": "L31",
+      "source_location": "L33",
       "weight": 1.0,
       "_src": "presentation_controller_sheetscontroller",
       "_tgt": "presentation_controller_sheetscontroller_load_saved_sheets",
@@ -23229,7 +23418,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "maria_cacau/features/sheets/presentation/controller.py",
-      "source_location": "L35",
+      "source_location": "L37",
       "weight": 1.0,
       "_src": "presentation_controller_sheetscontroller",
       "_tgt": "presentation_controller_sheetscontroller_on_connect",
@@ -23241,7 +23430,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "maria_cacau/features/sheets/presentation/controller.py",
-      "source_location": "L49",
+      "source_location": "L51",
       "weight": 1.0,
       "_src": "presentation_controller_sheetscontroller",
       "_tgt": "presentation_controller_sheetscontroller_update_sheet_name_if_needed",
@@ -23253,7 +23442,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "maria_cacau/features/sheets/presentation/controller.py",
-      "source_location": "L55",
+      "source_location": "L57",
       "weight": 1.0,
       "_src": "presentation_controller_sheetscontroller",
       "_tgt": "presentation_controller_sheetscontroller_show_existing_dialog",
@@ -23265,7 +23454,19 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "maria_cacau/features/sheets/presentation/controller.py",
-      "source_location": "L76",
+      "source_location": "L78",
+      "weight": 1.0,
+      "_src": "presentation_controller_sheetscontroller",
+      "_tgt": "presentation_controller_sheetscontroller_on_clear_cache",
+      "source": "presentation_controller_sheetscontroller",
+      "target": "presentation_controller_sheetscontroller_on_clear_cache",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "maria_cacau/features/sheets/presentation/controller.py",
+      "source_location": "L82",
       "weight": 1.0,
       "_src": "presentation_controller_sheetscontroller",
       "_tgt": "presentation_controller_sheetscontroller_on_select",
@@ -23277,7 +23478,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "maria_cacau/features/sheets/presentation/controller.py",
-      "source_location": "L79",
+      "source_location": "L85",
       "weight": 1.0,
       "_src": "presentation_controller_sheetscontroller",
       "_tgt": "presentation_controller_sheetscontroller_on_renamed",
@@ -23289,7 +23490,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "maria_cacau/features/sheets/presentation/controller.py",
-      "source_location": "L83",
+      "source_location": "L89",
       "weight": 1.0,
       "_src": "presentation_controller_sheetscontroller",
       "_tgt": "presentation_controller_sheetscontroller_on_connected",
@@ -23301,7 +23502,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "maria_cacau/features/sheets/presentation/controller.py",
-      "source_location": "L88",
+      "source_location": "L94",
       "weight": 1.0,
       "_src": "presentation_controller_sheetscontroller",
       "_tgt": "presentation_controller_sheetscontroller_on_selected",
@@ -23313,7 +23514,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "maria_cacau/features/sheets/presentation/controller.py",
-      "source_location": "L92",
+      "source_location": "L98",
       "weight": 1.0,
       "_src": "presentation_controller_sheetscontroller",
       "_tgt": "presentation_controller_sheetscontroller_on_error",
@@ -23337,7 +23538,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "maria_cacau/features/sheets/presentation/controller.py",
-      "source_location": "L20",
+      "source_location": "L21",
       "weight": 1.0,
       "_src": "presentation_controller_sheetscontroller_init",
       "_tgt": "presentation_controller_sheetscontroller_setup_actions",
@@ -23349,7 +23550,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "maria_cacau/features/sheets/presentation/controller.py",
-      "source_location": "L21",
+      "source_location": "L22",
       "weight": 1.0,
       "_src": "presentation_controller_sheetscontroller_init",
       "_tgt": "presentation_controller_sheetscontroller_load_saved_sheets",
@@ -23421,7 +23622,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "maria_cacau/features/sheets/presentation/controller.py",
-      "source_location": "L45",
+      "source_location": "L47",
       "weight": 1.0,
       "_src": "presentation_controller_sheetscontroller_on_connect",
       "_tgt": "presentation_controller_sheetscontroller_update_sheet_name_if_needed",
@@ -23469,7 +23670,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "maria_cacau/features/sheets/presentation/controller.py",
-      "source_location": "L50",
+      "source_location": "L52",
       "weight": 1.0,
       "_src": "presentation_controller_sheetscontroller_update_sheet_name_if_needed",
       "_tgt": "presentation_controller_sheetscontroller_show_existing_dialog",
@@ -23805,7 +24006,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "maria_cacau/features/sheets/presentation/view/sheets_menu_view.py",
-      "source_location": "L17",
+      "source_location": "L18",
       "weight": 1.0,
       "_src": "maria_cacau_features_sheets_presentation_view_sheets_menu_view_py",
       "_tgt": "view_sheets_menu_view_view_title",
@@ -23841,7 +24042,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "maria_cacau/features/sheets/presentation/view/sheets_menu_view.py",
-      "source_location": "L12",
+      "source_location": "L13",
       "weight": 1.0,
       "_src": "view_sheets_menu_view_sheetsmenuview",
       "_tgt": "view_sheets_menu_view_sheetsmenuview_init",
@@ -23853,7 +24054,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "maria_cacau/features/sheets/presentation/view/sheets_menu_view.py",
-      "source_location": "L20",
+      "source_location": "L21",
       "weight": 1.0,
       "_src": "view_sheets_menu_view_sheetsmenuview",
       "_tgt": "view_sheets_menu_view_sheetsmenuview_setup_ui",
@@ -23865,7 +24066,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "maria_cacau/features/sheets/presentation/view/sheets_menu_view.py",
-      "source_location": "L24",
+      "source_location": "L25",
       "weight": 1.0,
       "_src": "view_sheets_menu_view_sheetsmenuview",
       "_tgt": "view_sheets_menu_view_sheetsmenuview_setup_components",
@@ -23877,7 +24078,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "maria_cacau/features/sheets/presentation/view/sheets_menu_view.py",
-      "source_location": "L36",
+      "source_location": "L38",
       "weight": 1.0,
       "_src": "view_sheets_menu_view_sheetsmenuview",
       "_tgt": "view_sheets_menu_view_sheetsmenuview_setup_layout",
@@ -23889,7 +24090,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "maria_cacau/features/sheets/presentation/view/sheets_menu_view.py",
-      "source_location": "L42",
+      "source_location": "L44",
       "weight": 1.0,
       "_src": "view_sheets_menu_view_sheetsmenuview",
       "_tgt": "view_sheets_menu_view_sheetsmenuview_add_or_update_sheet",
@@ -23901,7 +24102,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "maria_cacau/features/sheets/presentation/view/sheets_menu_view.py",
-      "source_location": "L55",
+      "source_location": "L57",
       "weight": 1.0,
       "_src": "view_sheets_menu_view_sheetsmenuview",
       "_tgt": "view_sheets_menu_view_sheetsmenuview_set_active",
@@ -23913,7 +24114,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "maria_cacau/features/sheets/presentation/view/sheets_menu_view.py",
-      "source_location": "L25",
+      "source_location": "L26",
       "weight": 1.0,
       "_src": "view_sheets_menu_view_sheetsmenuview_setup_components",
       "_tgt": "qmenu",
@@ -23937,7 +24138,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "maria_cacau/features/sheets/presentation/view/sheets_menu_view.py",
-      "source_location": "L14",
+      "source_location": "L15",
       "weight": 1.0,
       "_src": "view_sheets_menu_view_sheetsmenuview_init",
       "_tgt": "view_sheets_menu_view_sheetsmenuview_setup_ui",
@@ -23949,7 +24150,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "maria_cacau/features/sheets/presentation/view/sheets_menu_view.py",
-      "source_location": "L21",
+      "source_location": "L22",
       "weight": 1.0,
       "_src": "view_sheets_menu_view_sheetsmenuview_setup_ui",
       "_tgt": "view_sheets_menu_view_sheetsmenuview_setup_components",
@@ -23961,7 +24162,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "maria_cacau/features/sheets/presentation/view/sheets_menu_view.py",
-      "source_location": "L22",
+      "source_location": "L23",
       "weight": 1.0,
       "_src": "view_sheets_menu_view_sheetsmenuview_setup_ui",
       "_tgt": "view_sheets_menu_view_sheetsmenuview_setup_layout",
@@ -24119,11 +24320,11 @@
       "source_file": "maria_cacau/features/auth/data/repository.py",
       "source_location": "L7",
       "weight": 0.8,
-      "_src": "data_repository_rationale_27",
-      "_tgt": "data_apis_connectauthapi",
+      "_src": "data_apis_connectauthapi",
+      "_tgt": "data_repository_rationale_27",
+      "confidence_score": 0.5,
       "source": "data_apis_connectauthapi",
-      "target": "data_repository_rationale_27",
-      "confidence_score": 0.5
+      "target": "data_repository_rationale_27"
     },
     {
       "relation": "uses",
@@ -24131,11 +24332,11 @@
       "source_file": "maria_cacau/features/auth/domain/init_use_case.py",
       "source_location": "L5",
       "weight": 0.8,
-      "_src": "domain_init_use_case_appinitusecase",
-      "_tgt": "data_apis_connectauthapi",
+      "_src": "data_apis_connectauthapi",
+      "_tgt": "domain_init_use_case_appinitusecase",
+      "confidence_score": 0.5,
       "source": "data_apis_connectauthapi",
-      "target": "domain_init_use_case_appinitusecase",
-      "confidence_score": 0.5
+      "target": "domain_init_use_case_appinitusecase"
     },
     {
       "relation": "calls",
@@ -24156,8 +24357,8 @@
       "source_file": "maria_cacau/features/auth/domain/init_use_case.py",
       "source_location": "L24",
       "weight": 1.0,
-      "_src": "domain_init_use_case_appinitusecase_initialize",
-      "_tgt": "data_apis_connectauthapi",
+      "_src": "data_apis_connectauthapi",
+      "_tgt": "domain_init_use_case_appinitusecase_initialize",
       "source": "data_apis_connectauthapi",
       "target": "domain_init_use_case_appinitusecase_initialize"
     },
@@ -24204,8 +24405,8 @@
       "source_file": "maria_cacau/features/auth/domain/init_use_case.py",
       "source_location": "L24",
       "weight": 1.0,
-      "_src": "domain_init_use_case_appinitusecase_initialize",
-      "_tgt": "data_apis_connectauthapi_with_credentials",
+      "_src": "data_apis_connectauthapi_with_credentials",
+      "_tgt": "domain_init_use_case_appinitusecase_initialize",
       "source": "data_apis_connectauthapi_with_credentials",
       "target": "domain_init_use_case_appinitusecase_initialize"
     },
@@ -24263,11 +24464,11 @@
       "source_file": "maria_cacau/features/auth/data/repository.py",
       "source_location": "L7",
       "weight": 0.8,
-      "_src": "data_repository_rationale_27",
-      "_tgt": "data_apis_disconnectauthapi",
+      "_src": "data_apis_disconnectauthapi",
+      "_tgt": "data_repository_rationale_27",
+      "confidence_score": 0.5,
       "source": "data_apis_disconnectauthapi",
-      "target": "data_repository_rationale_27",
-      "confidence_score": 0.5
+      "target": "data_repository_rationale_27"
     },
     {
       "relation": "calls",
@@ -24360,8 +24561,8 @@
       "source_file": "maria_cacau/features/auth/domain/init_use_case.py",
       "source_location": "L10",
       "weight": 1.0,
-      "_src": "domain_init_use_case_appinitusecase_init",
-      "_tgt": "data_repository_authrepository",
+      "_src": "data_repository_authrepository",
+      "_tgt": "domain_init_use_case_appinitusecase_init",
       "source": "data_repository_authrepository",
       "target": "domain_init_use_case_appinitusecase_init"
     },
@@ -24396,8 +24597,8 @@
       "source_file": "maria_cacau/features/auth/domain/init_use_case.py",
       "source_location": "L14",
       "weight": 1.0,
-      "_src": "domain_init_use_case_appinitusecase_initialize",
-      "_tgt": "data_repository_authrepository_read_credentials",
+      "_src": "data_repository_authrepository_read_credentials",
+      "_tgt": "domain_init_use_case_appinitusecase_initialize",
       "source": "data_repository_authrepository_read_credentials",
       "target": "domain_init_use_case_appinitusecase_initialize"
     },
@@ -24887,8 +25088,8 @@
       "source_file": "maria_cacau/features/auth/presentation/controller.py",
       "source_location": "L13",
       "weight": 0.8,
-      "_src": "presentation_controller_rationale_49",
-      "_tgt": "presentation_viewmodel_authviewmodel",
+      "_src": "presentation_viewmodel_authviewmodel",
+      "_tgt": "presentation_controller_rationale_49",
       "confidence_score": 0.5,
       "source": "presentation_viewmodel_authviewmodel",
       "target": "presentation_controller_rationale_49"
@@ -24935,8 +25136,8 @@
       "source_file": "maria_cacau/features/auth/presentation/controller.py",
       "source_location": "L12",
       "weight": 0.8,
-      "_src": "presentation_controller_rationale_49",
-      "_tgt": "presentation_view_authview",
+      "_src": "presentation_view_authview",
+      "_tgt": "presentation_controller_rationale_49",
       "confidence_score": 0.5,
       "source": "presentation_view_authview",
       "target": "presentation_controller_rationale_49"
@@ -30604,6 +30805,30 @@
       "source": "maria_cacau_backend_features_orders_subfeatures_deliveries_models_py",
       "target": "deliveries_models_rationale_1",
       "confidence_score": 1.0
+    },
+    {
+      "relation": "uses",
+      "confidence": "INFERRED",
+      "source_file": "maria_cacau/features/home/sub_features/delivery/data/repository.py",
+      "source_location": "L5",
+      "weight": 0.8,
+      "_src": "data_repository_rationale_12",
+      "_tgt": "deliveries_models_deliveriessummary",
+      "confidence_score": 0.5,
+      "source": "deliveries_models_deliveriessummary",
+      "target": "data_repository_rationale_12"
+    },
+    {
+      "relation": "uses",
+      "confidence": "INFERRED",
+      "source_file": "maria_cacau/features/home/sub_features/delivery/data/repository.py",
+      "source_location": "L5",
+      "weight": 0.8,
+      "_src": "data_repository_rationale_20",
+      "_tgt": "deliveries_models_deliveriessummary",
+      "confidence_score": 0.5,
+      "source": "deliveries_models_deliveriessummary",
+      "target": "data_repository_rationale_20"
     },
     {
       "relation": "contains",

--- a/maria_cacau/core/bus.py
+++ b/maria_cacau/core/bus.py
@@ -1,8 +1,8 @@
-from PyQt6.QtCore import QObject
+from PyQt6.QtCore import QObject, pyqtSignal
 
 
 class _EventBus(QObject):
-    pass
+    cache_cleared = pyqtSignal()
 
 
 bus = _EventBus()

--- a/maria_cacau/features/home/sub_features/delivery/data/repository.py
+++ b/maria_cacau/features/home/sub_features/delivery/data/repository.py
@@ -1,25 +1,45 @@
 """Repository da feature Delivery: chama as APIs e converte erros HTTP em ErrorModel."""
 
+from maria_cacau.core.bus import bus
 from maria_cacau.core.network import HTTPResponseError
+from maria_cacau.core.observability import observability
 
+from ..domain.events import FeatureEvents as ObsEv
 from ..domain.models import DeliveriesSummary, PendentOrder
 from .apis import DeliveriesAPI, PaymentsPendentAPI
 from .mapper import DeliveriesMapper, ErrorMapper, PaymentsMapper
 
 
 class OrdersRepository:
+    def __init__(self) -> None:
+        self._deliveries_cache: dict[str, DeliveriesSummary]  = {}
+        self._payments_cache:   dict[str, list[PendentOrder]] = {}
+        bus.cache_cleared.connect(self._clear_cache)
+
     def get_deliveries(self, date: str) -> DeliveriesSummary:
-        """Busca entregas do dia; converte HTTPResponseError em ErrorModel antes de relançar."""
+        if date in self._deliveries_cache:
+            observability.log(ObsEv.CACHE_HIT)
+            return self._deliveries_cache[date]
         try:
             response = DeliveriesAPI().for_date(date).call()
         except HTTPResponseError as e:
             raise ErrorMapper.from_response(e)
-        return DeliveriesMapper.from_response(response)
+        result = DeliveriesMapper.from_response(response)
+        self._deliveries_cache[date] = result
+        return result
 
     def get_pendent_payments(self, date: str) -> list[PendentOrder]:
-        """Busca pagamentos pendentes do dia; converte HTTPResponseError em ErrorModel antes de relançar."""
+        if date in self._payments_cache:
+            observability.log(ObsEv.CACHE_HIT)
+            return self._payments_cache[date]
         try:
             response = PaymentsPendentAPI().for_date(date).call()
         except HTTPResponseError as e:
             raise ErrorMapper.from_response(e)
-        return PaymentsMapper.from_response(response)
+        result = PaymentsMapper.from_response(response)
+        self._payments_cache[date] = result
+        return result
+
+    def _clear_cache(self) -> None:
+        self._deliveries_cache.clear()
+        self._payments_cache.clear()

--- a/maria_cacau/features/home/sub_features/delivery/domain/events.py
+++ b/maria_cacau/features/home/sub_features/delivery/domain/events.py
@@ -9,4 +9,5 @@ class FeatureEvents(Enum):
     COPY_GRAPH_ACTION = 'Copy graph triggered'
     DOWNLOAD_GRAPH_ACTION = 'Download graph triggered'
 
-    QUERY = 'QUERY  feature=produtos'
+    QUERY     = 'QUERY  feature=entregas'
+    CACHE_HIT = 'CACHE_HIT  feature=entregas'

--- a/maria_cacau/features/home/sub_features/summary/data/repository.py
+++ b/maria_cacau/features/home/sub_features/summary/data/repository.py
@@ -20,11 +20,13 @@ class SummaryRepository:
         if key in self._cache:
             observability.log(ObsEv.CACHE_HIT)
             return self._cache[key]
+        
         try:
             response = OrdersSummaryAPI().for_period(start, end).call()
         except HTTPResponseError as e:
             raise ErrorMapper.from_response(e)
         result = OrdersSummaryMapper.from_response(response)
+        
         self._cache[key] = result
         return result
 

--- a/maria_cacau/features/home/sub_features/summary/data/repository.py
+++ b/maria_cacau/features/home/sub_features/summary/data/repository.py
@@ -1,17 +1,32 @@
 """Repository da feature Summary: chama a API e converte erros HTTP em ErrorModel."""
 
+from maria_cacau.core.bus import bus
 from maria_cacau.core.network import HTTPResponseError
+from maria_cacau.core.observability import observability
 
+from ..domain.events import FeatureEvents as ObsEv
 from ..domain.models import OrderDetail
 from .apis import OrdersSummaryAPI
 from .mapper import ErrorMapper, OrdersSummaryMapper
 
 
 class SummaryRepository:
+    def __init__(self) -> None:
+        self._cache: dict[tuple[str, str], list[OrderDetail]] = {}
+        bus.cache_cleared.connect(self._clear_cache)
+
     def get_by_period(self, start: str, end: str) -> list[OrderDetail]:
-        """Busca pedidos do período; converte HTTPResponseError em ErrorModel antes de relançar."""
+        key = (start, end)
+        if key in self._cache:
+            observability.log(ObsEv.CACHE_HIT)
+            return self._cache[key]
         try:
             response = OrdersSummaryAPI().for_period(start, end).call()
         except HTTPResponseError as e:
             raise ErrorMapper.from_response(e)
-        return OrdersSummaryMapper.from_response(response)
+        result = OrdersSummaryMapper.from_response(response)
+        self._cache[key] = result
+        return result
+
+    def _clear_cache(self) -> None:
+        self._cache.clear()

--- a/maria_cacau/features/home/sub_features/summary/domain/events.py
+++ b/maria_cacau/features/home/sub_features/summary/domain/events.py
@@ -10,4 +10,5 @@ class FeatureEvents(Enum):
     DOWNLOAD_GRAPH_ACTION    = 'Download graph triggered'
     CHANGE_CHART_TYPE_ACTION = 'Change chart type triggered'
 
-    QUERY = 'QUERY  feature=summary'
+    QUERY     = 'QUERY  feature=summary'
+    CACHE_HIT = 'CACHE_HIT  feature=summary'

--- a/maria_cacau/features/sheets/domain/events.py
+++ b/maria_cacau/features/sheets/domain/events.py
@@ -6,3 +6,4 @@ class FeatureEvents(Enum):
     SHEET_SELECTED  = "Planilha selecionada"
     SHEET_RENAMED   = "Planilha renomeada"
     SHEET_ERROR     = "Erro ao conectar planilha"
+    CACHE_CLEAR     = "Cache limpo"

--- a/maria_cacau/features/sheets/presentation/controller.py
+++ b/maria_cacau/features/sheets/presentation/controller.py
@@ -1,6 +1,7 @@
 from PyQt6.QtWidgets import QDialog, QInputDialog, QMessageBox
 
 from maria_cacau.assets import strings
+from maria_cacau.core.bus import bus
 from maria_cacau.core.error import ErrorModel
 from maria_cacau.core.observability import observability
 from maria_cacau.design_system.gui_popup import GuiPopup
@@ -23,6 +24,7 @@ class SheetsController:
     def _setup_actions(self) -> None:
         self.view.connect_triggered.connect(self._on_connect)
         self.view.sheet_selected.connect(self._on_select)
+        self.view.cache_clear_triggered.connect(self._on_clear_cache)
         signals.sheet_connected.connect(self._on_connected)
         signals.sheet_selected.connect(self._on_selected)
         signals.sheet_renamed.connect(self._on_renamed)
@@ -72,6 +74,10 @@ class SheetsController:
             return
         
         return new_name.strip()
+
+    def _on_clear_cache(self) -> None:
+        bus.cache_cleared.emit()
+        observability.log(ObsEv.CACHE_CLEAR)
 
     def _on_select(self, sheet_id: str) -> None:
         self.viewmodel.select(sheet_id)

--- a/maria_cacau/features/sheets/presentation/view/sheets_menu_view.py
+++ b/maria_cacau/features/sheets/presentation/view/sheets_menu_view.py
@@ -6,8 +6,9 @@ from maria_cacau.assets import strings
 
 
 class SheetsMenuView(QMenu):
-    connect_triggered = pyqtSignal()
-    sheet_selected    = pyqtSignal(str)  # emite sheet_id
+    connect_triggered     = pyqtSignal()
+    sheet_selected        = pyqtSignal(str)  # emite sheet_id
+    cache_clear_triggered = pyqtSignal()
 
     def __init__(self) -> None:
         super().__init__(strings.MNU_ARQUIVO)
@@ -30,6 +31,7 @@ class SheetsMenuView(QMenu):
 
         self._act_limpar   = QAction(strings.ACT_LIMPAR_CACHE, self)
         self._act_limpar.setMenuRole(QAction.MenuRole.NoRole)
+        self._act_limpar.triggered.connect(self.cache_clear_triggered)
 
         self._actions: dict[str, QAction] = {}
 

--- a/pocs/architecture/self-study.md
+++ b/pocs/architecture/self-study.md
@@ -142,7 +142,7 @@ Registradas em `overview.md`. Não reabrir sem motivo claro.
 1. ~~**Refatoração home/main**~~ ✅ — `GuiMain` separada em `MainWindow` + `MenuHandler` (`features/main/`) e `HomeController/HomeView/HomeFeaturesModel` (`features/home/source/`)
 2. ~~**Ações de pre-load e `core/session`**~~ ✅ — `AppCoordinator` orquestra inicialização via `AppInitUseCase` (uma única chamada HTTP com credentials + sheet_id); `core/session` singleton com `has_credentials_cached`, `has_sheet_cached`, `is_authenticated`, `active_sheet_id`; `core/bus` como event bus para signals cross-feature
 3. **Feature: status bar** — conectar via `bus` após sinal de sessão ser definido
-4. **Limpeza de cache** — `RemoveSheetAPI` existe mas não está conectada; usar bus quando implementado
+4. ~~**Limpeza de cache**~~ ✅ — cache nos repositories (`OrdersRepository`, `SummaryRepository`); `bus.cache_cleared` dispara via menu Arquivo → "Limpar cache"
 
 ---
 

--- a/pocs/architecture/session-context.md
+++ b/pocs/architecture/session-context.md
@@ -145,8 +145,8 @@ A barra de status existe (`features/home/sub_features/status_bar/`) mas ainda re
 |---|---|
 | Sub-views em pasta | Quando feature tem 2+ views → `presentation/view/` com um arquivo por view |
 | `update_name` separado de `connect` | Renomear planilha existente = só cache; nenhuma chamada ao backend |
-| "Limpar cache" no menu Arquivo | Refere-se ao cache **em memória** dos repositories/services — não à pasta `~/.mariacacau/` |
-| `RemoveSheetAPI` (DELETE /sheet) | Criado, não conectado; será usado quando "Limpar cache" for implementado |
+| "Limpar cache" no menu Arquivo | Limpa o cache em memória dos repositories via `bus.cache_cleared` |
+| `RemoveSheetAPI` (DELETE /sheet) | Criado, não conectado; mantido por hora para uso futuro |
 | Sufixo `Model` em domain models | Ex: `SheetModel` — facilita identificação no uso dentro do código |
 
 ---


### PR DESCRIPTION
## Cache em memória nos repositories

Adiciona cache de resposta em memória nos repositories `OrdersRepository` (delivery) e `SummaryRepository` (summary), com sinal de limpeza via event bus, observabilidade de hit e clear, e conexão ao menu "Arquivo → Limpar cache".

## O que mudou

- **`core/bus.py`** — adicionado `cache_cleared = pyqtSignal()` ao `_EventBus`
- **`delivery/data/repository.py`** — `OrdersRepository` ganha `__init__` com dois dicts de cache (por `date`), subscrição ao `bus.cache_cleared` e log de `CACHE_HIT` em cada hit
- **`summary/data/repository.py`** — `SummaryRepository` ganha `__init__` com cache por `(start, end)`, mesma subscrição e log de `CACHE_HIT`
- **`sheets/domain/events.py`** — novo evento `CACHE_CLEAR`
- **`sheets/presentation/view/sheets_menu_view.py`** — `_act_limpar` conectado ao novo signal `cache_clear_triggered`
- **`sheets/presentation/controller.py`** — `_on_clear_cache()` emite `bus.cache_cleared` e loga `ObsEv.CACHE_CLEAR`
- **`delivery/domain/events.py`** — novo evento `CACHE_HIT`
- **`summary/domain/events.py`** — novo evento `CACHE_HIT`
- **Docs** — `session-context.md`, `self-study.md` e `.ai/architecture.md` atualizados

## Fluxo
Usuário clica "Limpar cache"
  → view.cache_clear_triggered
  → controller._on_clear_cache() → bus.cache_cleared.emit() + log CACHE_CLEAR
  → OrdersRepository._clear_cache() + SummaryRepository._clear_cache()