### PR TITLE
Aumente de observabilidade

### DIFF
--- a/.ai/architecture.md
+++ b/.ai/architecture.md
@@ -22,6 +22,7 @@ Maria-Cacau-Contagem/
 │   │   │   ├── _errors.py                # NetworkError, HTTPRequestError, HTTPResponseError
 │   │   │   ├── _client.py                # HTTPClientContract (Protocol) + LocalClient
 │   │   │   ├── _config.py                # configure() / override() / clear_override() — singleton do client ativo
+│   │   │   ├── _observability.py         # NetworkEvent enum + track() — loga path, method, status, duration_s de toda request
 │   │   │   └── __init__.py               # exports públicos: API, HTTPMethod, HTTPResponse, LocalClient, erros, config
 │   │   ├── storage/
 │   │   │   ├── handler.py                # ABC StorageHandler[T] — contrato único de persistência

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,12 +1,12 @@
-# Graph Report - Maria-Cacau-Contagem  (2026-05-19)
+# Graph Report - Maria-Cacau-Contagem  (2026-05-20)
 
 ## Corpus Check
-- 178 files · ~609,128 words
+- 179 files · ~609,200 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 860 nodes · 1745 edges · 24 communities detected
-- Extraction: 62% EXTRACTED · 38% INFERRED · 0% AMBIGUOUS · INFERRED: 665 edges (avg confidence: 0.65)
+- 866 nodes · 1763 edges · 24 communities detected
+- Extraction: 62% EXTRACTED · 38% INFERRED · 0% AMBIGUOUS · INFERRED: 675 edges (avg confidence: 0.65)
 - Token cost: 0 input · 0 output
 
 ## Community Hubs (Navigation)
@@ -36,7 +36,7 @@
 - [[_COMMUNITY_Community 42|Community 42]]
 
 ## God Nodes (most connected - your core abstractions)
-1. `HTTPResponse` - 21 edges
+1. `HTTPResponse` - 25 edges
 2. `SheetsController` - 20 edges
 3. `DataSourceError` - 20 edges
 4. `connect()` - 20 edges
@@ -48,16 +48,16 @@
 10. `DeliveriesSummary` - 16 edges
 
 ## Surprising Connections (you probably didn't know these)
-- `Backend de armazenamento seguro via arquivo protegido no diretório do usuário.` --uses--> `StorageHandler`  [INFERRED]
-  maria_cacau/core/storage/security.py → maria_cacau/core/storage/handler.py
-- `Backend de cache em arquivo JSON no diretório do usuário.` --uses--> `StorageHandler`  [INFERRED]
-  maria_cacau/core/storage/cache.py → maria_cacau/core/storage/handler.py
-- `Erro genérico para exceções não tratadas.` --uses--> `ErrorModel`  [INFERRED]
-  maria_cacau/core/error/errors.py → maria_cacau/core/error/models.py
-- `AppCoordinator` --uses--> `AppEvent`  [INFERRED]
-  maria_cacau/app/coordinator.py → maria_cacau/core/observability.py
-- `call()` --calls--> `HTTPResponseError`  [INFERRED]
-  maria_cacau/core/network/api.py → maria_cacau/core/network/_errors.py
+- `AppEvent` --uses--> `AppCoordinator`  [INFERRED]
+  maria_cacau/core/observability.py → maria_cacau/app/coordinator.py
+- `HTTPResponseError` --calls--> `call()`  [INFERRED]
+  maria_cacau/core/network/_errors.py → maria_cacau/core/network/api.py
+- `Erros mapeados usados no módulo` --uses--> `HTTPResponse`  [INFERRED]
+  maria_cacau/core/network/_errors.py → maria_cacau/core/network/_response.py
+- `r"""Erro base da camada de network.` --uses--> `HTTPResponse`  [INFERRED]
+  maria_cacau/core/network/_errors.py → maria_cacau/core/network/_response.py
+- `configure() não foi chamado antes de usar a lib.` --uses--> `HTTPResponse`  [INFERRED]
+  maria_cacau/core/network/_errors.py → maria_cacau/core/network/_response.py
 
 ## Communities
 
@@ -66,72 +66,72 @@ Cohesion: 0.04
 Nodes (58): GoogleSheetsDataSource, Implementação de DataSourceProtocol para Google Sheets via gspread., _fix_prod4(), normalize(), Normaliza headers inconsistentes da planilha para os valores canônicos dos enums, Renomeia a coluna que segue prod3 para prod4, independente do header atual., Traduz headers reais da planilha para os nomes canônicos definidos nos enums., _rename_at() (+50 more)
 
 ### Community 1 - "Community 1"
-Cohesion: 0.05
-Nodes (48): Services, DeliveriesAPI, PaymentsPendentAPI, DeliveriesMapper, ErrorMapper, from_response(), OrdersSummaryMapper, PaymentsMapper (+40 more)
+Cohesion: 0.04
+Nodes (24): DSDialog, DSDialogIcon, DSDialogModel, DSComboBox, DSGroupBox, DeliveryViewData, DSDateInput, asset() (+16 more)
 
 ### Community 2 - "Community 2"
-Cohesion: 0.05
-Nodes (25): API, ConnectAuthAPI, DisconnectAuthAPI, OrdersSummaryAPI, path(), Endpoints do backend consumidos pela feature Auth., RemoveSheetAPI, SelectSheetAPI (+17 more)
+Cohesion: 0.04
+Nodes (25): ABC, API, ConnectAuthAPI, DisconnectAuthAPI, RemoveSheetAPI, SelectSheetAPI, AuthRepository, _extract_sheet_id() (+17 more)
 
 ### Community 3 - "Community 3"
-Cohesion: 0.04
-Nodes (20): DSDialog, DSDialogIcon, DSDialogModel, DSComboBox, main(), main(), main(), main() (+12 more)
+Cohesion: 0.07
+Nodes (36): Services, DeliveriesAPI, OrdersSummaryAPI, path(), PaymentsPendentAPI, Endpoints do backend consumidos pela feature Auth., DeliveriesMapper, ErrorMapper (+28 more)
 
 ### Community 4 - "Community 4"
-Cohesion: 0.05
-Nodes (16): AppCoordinator, MenuHandler, MainWindow, connect(), BackendServer, Erro genérico para exceções não tratadas., unexpected_error(), main() (+8 more)
+Cohesion: 0.06
+Nodes (13): AppCoordinator, MenuHandler, MainWindow, connect(), BackendServer, main(), Entry point da aplicação. Execute com: python -m maria_cacau, SheetsController (+5 more)
 
 ### Community 5 - "Community 5"
 Cohesion: 0.07
-Nodes (37): ABC, API, entity(), Comunicação alto nivel para chamadas de api, O tipo precisa aceitar **kwargs (dataclass ou similar)., HTTPClientContract, LocalClient, Realiza as request de fato (+29 more)
+Nodes (39): API, entity(), Comunicação alto nivel para chamadas de api, O tipo precisa aceitar **kwargs (dataclass ou similar)., HTTPClientContract, LocalClient, Realiza as request de fato, Contrato que qualquer client precisa cumprir. (+31 more)
 
 ### Community 6 - "Community 6"
 Cohesion: 0.08
 Nodes (30): Retorna pedidos da data informada (DD/MM/YYYY)., DeliveryTypeCount, Models de domínio da feature de entregas., DeliveriesRepository, Repositório de entregas — busca e prepara dados da planilha para o DeliveriesSer, Retorna todos os pedidos de uma data como DataFrame bruto., Acessa o data source e entrega um DataFrame para o DeliveriesService.      Não f, get_deliveries() (+22 more)
 
 ### Community 7 - "Community 7"
-Cohesion: 0.06
-Nodes (13): _date_field(), DateRangePicker, POC — date picker moderno com QDateEdit + QSS., DSDateInput, DSTextInput, CpfValidationController, CpfValidationView, QDateEdit (+5 more)
+Cohesion: 0.05
+Nodes (20): Rotas de autenticação, AuthService, Service de autenticação — gerencia o estado de conexão do DataSource., DataSourceProtocol, Autentica com o dict da service account e guarda o client em memória., Remove o client autenticado da memória. Mantém o sheet_id., Remove a planilha ativa da memória. Mantém as credenciais., Define a planilha ativa e dispara prewarm em background. (+12 more)
 
 ### Community 8 - "Community 8"
-Cohesion: 0.07
-Nodes (11): DSButton, DSGroupBox, DSLoadingHandler, DSLoadingHandler, Deve ser chamado no __init__ do componente, após o super().__init__()., Implementar no componente: o que fazer com cada frame do spinner., Mixin que adiciona comportamento de loading animado a qualquer componente QObjec, DeliveryView (+3 more)
+Cohesion: 0.09
+Nodes (12): CpfValidationResult, Models utilizados no módulo, CpfValidationSignals, Canal de comunicação entre o ViewModel e o Controller., CpfValidationUseCase, _is_valid_cpf(), Valida um CPF pela regra dos dois dígitos verificadores (algoritmo da Receita Fe, DSTextInput (+4 more)
 
 ### Community 9 - "Community 9"
-Cohesion: 0.1
-Nodes (11): DSButtonState, DSChartType, DSChart, Widget de gráfico reutilizável (barras ou pizza) usando seaborn + matplotlib., _short_label(), AppEvent, _Observability, Observabilidade centralizada do app. (+3 more)
+Cohesion: 0.08
+Nodes (13): DSButton, DSButtonState, AppEvent, _Observability, Observabilidade centralizada do app., FeatureEvents, Eventos de observabilidade da feature CPF Validation., DSLoadingHandler (+5 more)
 
 ### Community 10 - "Community 10"
-Cohesion: 0.1
-Nodes (23): handle_backend_error(), handle_data_source_error(), handle_unexpected_error(), AppError, certificado_limpo(), certificado_ok(), http_error(), planilha_conectada() (+15 more)
+Cohesion: 0.07
+Nodes (13): _EventBus, AppSession, AuthSignals, DeliverySignals, SheetsSignals, SummarySignals, AuthUseCase, Lê o arquivo JSON, salva em storage seguro e autentica o backend. (+5 more)
 
 ### Community 11 - "Community 11"
 Cohesion: 0.11
 Nodes (6): StatusBarState, DSLabel, StatusBarController, StatusBarView, QLabel, QStatusBar
 
 ### Community 12 - "Community 12"
+Cohesion: 0.13
+Nodes (19): AppError, certificado_limpo(), certificado_ok(), http_error(), planilha_conectada(), planilha_ok(), Códigos de erro da aplicação com estrutura AppError., Confirmação de certificado configurado com sucesso. (+11 more)
+
+### Community 13 - "Community 13"
 Cohesion: 0.26
 Nodes (22): _customer(), _customization(), _delivery(), _financial(), OrderMapper, _payments(), _products(), Mapeamento de uma linha do DataFrame para o model Order. (+14 more)
 
-### Community 13 - "Community 13"
-Cohesion: 0.09
-Nodes (12): Rotas de autenticação, AuthService, Service de autenticação — gerencia o estado de conexão do DataSource., DataSourceProtocol, Autentica com o dict da service account e guarda o client em memória., Remove o client autenticado da memória. Mantém o sheet_id., Remove a planilha ativa da memória. Mantém as credenciais., Define a planilha ativa e dispara prewarm em background. (+4 more)
-
 ### Community 14 - "Community 14"
+Cohesion: 0.12
+Nodes (9): _date_field(), DateRangePicker, POC — date picker moderno com QDateEdit + QSS., QDateEdit, QPushButton, QWidget, HomeController, HomeFeaturesModel (+1 more)
+
+### Community 15 - "Community 15"
 Cohesion: 0.15
 Nodes (14): _cast_numeric(), OrdersSummaryRepository, Repositório de pedidos por período — busca e prepara dados da planilha para o Or, Acessa o data source e entrega um DataFrame tipado para o OrdersService.      Ún, Retorna todos os pedidos de um período com colunas numéricas convertidas para fl, _to_dataframe(), get_orders(), Rota de pedidos — GET /orders. (+6 more)
 
-### Community 15 - "Community 15"
-Cohesion: 0.26
-Nodes (8): DeliveryModel, DeliveryViewData, DeliveryUseCase, Busca deliveries e payments em paralelo e retorna o modelo consolidado., Inicia a consulta: trava a view, dispara o ViewModel e registra o timestamp para, Recebe o resultado do ViewModel, atualiza a view e loga a duração da consulta., DeliveryViewModel, Roda o UseCase, monta o ViewData e emite sucesso ou erro — sempre via signal par
-
 ### Community 16 - "Community 16"
-Cohesion: 0.29
-Nodes (3): HomeController, HomeFeaturesModel, HomeView
+Cohesion: 0.22
+Nodes (4): DSChartType, DSChart, Widget de gráfico reutilizável (barras ou pizza) usando seaborn + matplotlib., _short_label()
 
 ### Community 17 - "Community 17"
-Cohesion: 0.33
-Nodes (2): _EventBus, AppSession
+Cohesion: 0.27
+Nodes (7): handle_backend_error(), handle_data_source_error(), handle_unexpected_error(), BackendError, generic_mapper(), translate(), Exception
 
 ### Community 18 - "Community 18"
 Cohesion: 0.4
@@ -160,8 +160,6 @@ Nodes (1): Faz cast numérico de uma coluna se ela existir no DataFrame.
 ## Knowledge Gaps
 - **49 isolated node(s):** `Metadados centralizados do pacote maria-cacau.`, `Resolve um path relativo à pasta assets, funciona em dev e no .exe compilado.`, `Entry point da aplicação. Execute com: python -m maria_cacau`, `Observabilidade centralizada do app.`, `HTTP métodos disponíveis para uso` (+44 more)
   These have ≤1 connection - possible missing edges or undocumented components.
-- **Thin community `Community 17`** (6 nodes): `_EventBus`, `AppSession`, `.__init__()`, `bus.py`, `__init__.py`, `session.py`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 19`** (1 nodes): `r"""Indica se a resposta foi bem sucedida (status code 2xx).`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 38`** (1 nodes): `Converte list[dict] em DataFrame com cast numérico de todas as colunas de valor.`
@@ -176,14 +174,14 @@ Nodes (1): Faz cast numérico de uma coluna se ela existir no DataFrame.
 ## Suggested Questions
 _Questions this graph is uniquely positioned to answer:_
 
-- **Why does `FeatureEvents` connect `Community 9` to `Community 1`, `Community 3`, `Community 4`, `Community 7`, `Community 15`?**
+- **Why does `FeatureEvents` connect `Community 9` to `Community 8`, `Community 1`, `Community 10`, `Community 4`?**
   _High betweenness centrality (0.104) - this node is a cross-community bridge._
-- **Why does `SheetsController` connect `Community 4` to `Community 9`, `Community 2`, `Community 3`, `Community 7`?**
-  _High betweenness centrality (0.084) - this node is a cross-community bridge._
-- **Why does `connect()` connect `Community 4` to `Community 3`, `Community 7`, `Community 8`, `Community 11`, `Community 13`?**
-  _High betweenness centrality (0.080) - this node is a cross-community bridge._
-- **Are the 19 inferred relationships involving `HTTPResponse` (e.g. with `NetworkError` and `NetworkNotConfiguredError`) actually correct?**
-  _`HTTPResponse` has 19 INFERRED edges - model-reasoned connections that need verification._
+- **Why does `SheetsController` connect `Community 4` to `Community 1`, `Community 2`, `Community 7`, `Community 9`, `Community 10`, `Community 12`?**
+  _High betweenness centrality (0.083) - this node is a cross-community bridge._
+- **Why does `connect()` connect `Community 4` to `Community 1`, `Community 7`, `Community 8`, `Community 9`, `Community 10`, `Community 11`, `Community 14`?**
+  _High betweenness centrality (0.079) - this node is a cross-community bridge._
+- **Are the 23 inferred relationships involving `HTTPResponse` (e.g. with `NetworkError` and `NetworkNotConfiguredError`) actually correct?**
+  _`HTTPResponse` has 23 INFERRED edges - model-reasoned connections that need verification._
 - **Are the 4 inferred relationships involving `SheetsController` (e.g. with `FeatureEvents` and `SheetModel`) actually correct?**
   _`SheetsController` has 4 INFERRED edges - model-reasoned connections that need verification._
 - **Are the 19 inferred relationships involving `connect()` (e.g. with `.__init__()` and `._create_features_menu()`) actually correct?**

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -9,7 +9,7 @@
       "source_file": "maria_cacau/__init__.py",
       "source_location": "L1",
       "id": "maria_cacau_init_py",
-      "community": 3,
+      "community": 1,
       "norm_label": "__init__.py"
     },
     {
@@ -18,7 +18,7 @@
       "source_file": "maria_cacau/__init__.py",
       "source_location": "L17",
       "id": "maria_cacau_init_asset",
-      "community": 3,
+      "community": 1,
       "norm_label": "asset()"
     },
     {
@@ -26,18 +26,18 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/__init__.py",
       "source_location": "L1",
-      "id": "maria_cacau_init_rationale_1",
-      "community": 3,
-      "norm_label": "metadados centralizados do pacote maria-cacau."
+      "community": 1,
+      "norm_label": "metadados centralizados do pacote maria-cacau.",
+      "id": "maria_cacau_init_rationale_1"
     },
     {
       "label": "Resolve um path relativo \u00e0 pasta assets, funciona em dev e no .exe compilado.",
       "file_type": "rationale",
       "source_file": "maria_cacau/__init__.py",
       "source_location": "L18",
-      "id": "maria_cacau_init_rationale_18",
-      "community": 3,
-      "norm_label": "resolve um path relativo a pasta assets, funciona em dev e no .exe compilado."
+      "community": 1,
+      "norm_label": "resolve um path relativo a pasta assets, funciona em dev e no .exe compilado.",
+      "id": "maria_cacau_init_rationale_18"
     },
     {
       "label": "__main__.py",
@@ -62,9 +62,9 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/__main__.py",
       "source_location": "L1",
-      "id": "maria_cacau_main_rationale_1",
       "community": 4,
-      "norm_label": "entry point da aplicacao. execute com: python -m maria_cacau"
+      "norm_label": "entry point da aplicacao. execute com: python -m maria_cacau",
+      "id": "maria_cacau_main_rationale_1"
     },
     {
       "label": "services.py",
@@ -81,7 +81,7 @@
       "source_file": "maria_cacau/core/services.py",
       "source_location": "L4",
       "id": "core_services_services",
-      "community": 1,
+      "community": 3,
       "norm_label": "services"
     },
     {
@@ -99,7 +99,7 @@
       "source_file": "maria_cacau/core/session.py",
       "source_location": "L1",
       "id": "maria_cacau_core_session_py",
-      "community": 17,
+      "community": 10,
       "norm_label": "session.py"
     },
     {
@@ -108,7 +108,7 @@
       "source_file": "maria_cacau/core/session.py",
       "source_location": "L1",
       "id": "core_session_appsession",
-      "community": 17,
+      "community": 10,
       "norm_label": "appsession"
     },
     {
@@ -117,7 +117,7 @@
       "source_file": "maria_cacau/core/session.py",
       "source_location": "L2",
       "id": "core_session_appsession_init",
-      "community": 17,
+      "community": 10,
       "norm_label": ".__init__()"
     },
     {
@@ -126,7 +126,7 @@
       "source_file": "maria_cacau/core/__init__.py",
       "source_location": "L1",
       "id": "maria_cacau_core_init_py",
-      "community": 17,
+      "community": 10,
       "norm_label": "__init__.py"
     },
     {
@@ -151,7 +151,7 @@
       "label": "_Observability",
       "file_type": "code",
       "source_file": "maria_cacau/core/observability.py",
-      "source_location": "L28",
+      "source_location": "L18",
       "id": "core_observability_observability",
       "community": 9,
       "norm_label": "_observability"
@@ -160,7 +160,7 @@
       "label": ".__init__()",
       "file_type": "code",
       "source_file": "maria_cacau/core/observability.py",
-      "source_location": "L29",
+      "source_location": "L19",
       "id": "core_observability_observability_init",
       "community": 9,
       "norm_label": ".__init__()"
@@ -169,9 +169,9 @@
       "label": ".log()",
       "file_type": "code",
       "source_file": "maria_cacau/core/observability.py",
-      "source_location": "L38",
+      "source_location": "L28",
       "id": "core_observability_observability_log",
-      "community": 3,
+      "community": 1,
       "norm_label": ".log()"
     },
     {
@@ -179,9 +179,9 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/core/observability.py",
       "source_location": "L1",
-      "id": "core_observability_rationale_1",
       "community": 9,
-      "norm_label": "observabilidade centralizada do app."
+      "norm_label": "observabilidade centralizada do app.",
+      "id": "core_observability_rationale_1"
     },
     {
       "label": "bus.py",
@@ -189,7 +189,7 @@
       "source_file": "maria_cacau/core/bus.py",
       "source_location": "L1",
       "id": "maria_cacau_core_bus_py",
-      "community": 17,
+      "community": 10,
       "norm_label": "bus.py"
     },
     {
@@ -198,7 +198,7 @@
       "source_file": "maria_cacau/core/bus.py",
       "source_location": "L4",
       "id": "core_bus_eventbus",
-      "community": 17,
+      "community": 10,
       "norm_label": "_eventbus"
     },
     {
@@ -207,7 +207,7 @@
       "source_file": "",
       "source_location": "",
       "id": "qobject",
-      "community": 1,
+      "community": 10,
       "norm_label": "qobject"
     },
     {
@@ -234,7 +234,7 @@
       "source_file": "",
       "source_location": "",
       "id": "exception",
-      "community": 10,
+      "community": 17,
       "norm_label": "exception"
     },
     {
@@ -314,45 +314,45 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/core/network/_errors.py",
       "source_location": "L1",
-      "id": "network_errors_rationale_1",
       "community": 5,
-      "norm_label": "erros mapeados usados no modulo"
+      "norm_label": "erros mapeados usados no modulo",
+      "id": "network_errors_rationale_1"
     },
     {
       "label": "r\"\"\"Erro base da camada de network.",
       "file_type": "rationale",
       "source_file": "maria_cacau/core/network/_errors.py",
       "source_location": "L10",
-      "id": "network_errors_rationale_10",
       "community": 5,
-      "norm_label": "r\"\"\"erro base da camada de network."
+      "norm_label": "r\"\"\"erro base da camada de network.",
+      "id": "network_errors_rationale_10"
     },
     {
       "label": "configure() n\u00e3o foi chamado antes de usar a lib.",
       "file_type": "rationale",
       "source_file": "maria_cacau/core/network/_errors.py",
       "source_location": "L15",
-      "id": "network_errors_rationale_15",
       "community": 5,
-      "norm_label": "configure() nao foi chamado antes de usar a lib."
+      "norm_label": "configure() nao foi chamado antes de usar a lib.",
+      "id": "network_errors_rationale_15"
     },
     {
       "label": "Erro antes de receber resposta (conectividade, timeout, URL inv\u00e1lida).",
       "file_type": "rationale",
       "source_file": "maria_cacau/core/network/_errors.py",
       "source_location": "L20",
-      "id": "network_errors_rationale_20",
       "community": 5,
-      "norm_label": "erro antes de receber resposta (conectividade, timeout, url invalida)."
+      "norm_label": "erro antes de receber resposta (conectividade, timeout, url invalida).",
+      "id": "network_errors_rationale_20"
     },
     {
       "label": "Resposta recebida com status de erro (4xx, 5xx).",
       "file_type": "rationale",
       "source_file": "maria_cacau/core/network/_errors.py",
       "source_location": "L26",
-      "id": "network_errors_rationale_26",
       "community": 5,
-      "norm_label": "resposta recebida com status de erro (4xx, 5xx)."
+      "norm_label": "resposta recebida com status de erro (4xx, 5xx).",
+      "id": "network_errors_rationale_26"
     },
     {
       "label": "_method.py",
@@ -377,9 +377,9 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/core/network/_method.py",
       "source_location": "L1",
-      "id": "network_method_rationale_1",
       "community": 5,
-      "norm_label": "http metodos disponiveis para uso"
+      "norm_label": "http metodos disponiveis para uso",
+      "id": "network_method_rationale_1"
     },
     {
       "label": "_response.py",
@@ -422,18 +422,18 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/core/network/_response.py",
       "source_location": "L12",
-      "id": "network_response_rationale_12",
       "community": 5,
-      "norm_label": "r\"\"\"decodifica o body para um objeto."
+      "norm_label": "r\"\"\"decodifica o body para um objeto.",
+      "id": "network_response_rationale_12"
     },
     {
       "label": "r\"\"\"Indica se a resposta foi bem sucedida (status code 2xx).",
       "file_type": "rationale",
       "source_file": "maria_cacau/core/network/_response.py",
       "source_location": "L17",
-      "id": "network_response_rationale_17",
       "community": 19,
-      "norm_label": "r\"\"\"indica se a resposta foi bem sucedida (status code 2xx)."
+      "norm_label": "r\"\"\"indica se a resposta foi bem sucedida (status code 2xx).",
+      "id": "network_response_rationale_17"
     },
     {
       "label": "__init__.py",
@@ -467,9 +467,9 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/core/network/_request.py",
       "source_location": "L1",
-      "id": "network_request_rationale_1",
       "community": 5,
-      "norm_label": "dados e parametros de uma request"
+      "norm_label": "dados e parametros de uma request",
+      "id": "network_request_rationale_1"
     },
     {
       "label": "api.py",
@@ -495,7 +495,7 @@
       "source_file": "",
       "source_location": "",
       "id": "abc",
-      "community": 5,
+      "community": 2,
       "norm_label": "abc"
     },
     {
@@ -539,18 +539,18 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/core/network/api.py",
       "source_location": "L1",
-      "id": "network_api_rationale_1",
       "community": 5,
-      "norm_label": "comunicacao alto nivel para chamadas de api"
+      "norm_label": "comunicacao alto nivel para chamadas de api",
+      "id": "network_api_rationale_1"
     },
     {
       "label": "O tipo precisa aceitar **kwargs (dataclass ou similar).",
       "file_type": "rationale",
       "source_file": "maria_cacau/core/network/api.py",
       "source_location": "L34",
-      "id": "network_api_rationale_34",
       "community": 5,
-      "norm_label": "o tipo precisa aceitar **kwargs (dataclass ou similar)."
+      "norm_label": "o tipo precisa aceitar **kwargs (dataclass ou similar).",
+      "id": "network_api_rationale_34"
     },
     {
       "label": "_client.py",
@@ -565,7 +565,7 @@
       "label": "HTTPClientContract",
       "file_type": "code",
       "source_file": "maria_cacau/core/network/_client.py",
-      "source_location": "L11",
+      "source_location": "L13",
       "id": "network_client_httpclientcontract",
       "community": 5,
       "norm_label": "httpclientcontract"
@@ -576,14 +576,14 @@
       "source_file": "",
       "source_location": "",
       "id": "protocol",
-      "community": 13,
+      "community": 7,
       "norm_label": "protocol"
     },
     {
       "label": ".execute()",
       "file_type": "code",
       "source_file": "maria_cacau/core/network/_client.py",
-      "source_location": "L13",
+      "source_location": "L15",
       "id": "network_client_httpclientcontract_execute",
       "community": 5,
       "norm_label": ".execute()"
@@ -592,7 +592,7 @@
       "label": "LocalClient",
       "file_type": "code",
       "source_file": "maria_cacau/core/network/_client.py",
-      "source_location": "L18",
+      "source_location": "L20",
       "id": "network_client_localclient",
       "community": 5,
       "norm_label": "localclient"
@@ -601,7 +601,7 @@
       "label": ".__init__()",
       "file_type": "code",
       "source_file": "maria_cacau/core/network/_client.py",
-      "source_location": "L23",
+      "source_location": "L25",
       "id": "network_client_localclient_init",
       "community": 5,
       "norm_label": ".__init__()"
@@ -610,7 +610,7 @@
       "label": ".execute()",
       "file_type": "code",
       "source_file": "maria_cacau/core/network/_client.py",
-      "source_location": "L26",
+      "source_location": "L28",
       "id": "network_client_localclient_execute",
       "community": 5,
       "norm_label": ".execute()"
@@ -620,16 +620,16 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/core/network/_client.py",
       "source_location": "L1",
-      "id": "network_client_rationale_1",
       "community": 5,
-      "norm_label": "realiza as request de fato"
+      "norm_label": "realiza as request de fato",
+      "id": "network_client_rationale_1"
     },
     {
       "label": "Contrato que qualquer client precisa cumprir.",
       "file_type": "rationale",
       "source_file": "maria_cacau/core/network/_client.py",
-      "source_location": "L12",
-      "id": "network_client_rationale_12",
+      "source_location": "L14",
+      "id": "network_client_rationale_14",
       "community": 5,
       "norm_label": "contrato que qualquer client precisa cumprir."
     },
@@ -637,10 +637,46 @@
       "label": "Roteia requests para o backend local (in-process).     Nenhuma rede envolvida \u2014",
       "file_type": "rationale",
       "source_file": "maria_cacau/core/network/_client.py",
-      "source_location": "L19",
-      "id": "network_client_rationale_19",
+      "source_location": "L21",
+      "id": "network_client_rationale_21",
       "community": 5,
       "norm_label": "roteia requests para o backend local (in-process).     nenhuma rede envolvida \u2014"
+    },
+    {
+      "label": "_observability.py",
+      "file_type": "code",
+      "source_file": "maria_cacau/core/network/_observability.py",
+      "source_location": "L1",
+      "id": "maria_cacau_core_network_observability_py",
+      "community": 5,
+      "norm_label": "_observability.py"
+    },
+    {
+      "label": "NetworkEvent",
+      "file_type": "code",
+      "source_file": "maria_cacau/core/network/_observability.py",
+      "source_location": "L12",
+      "id": "network_observability_networkevent",
+      "community": 5,
+      "norm_label": "networkevent"
+    },
+    {
+      "label": "track()",
+      "file_type": "code",
+      "source_file": "maria_cacau/core/network/_observability.py",
+      "source_location": "L19",
+      "id": "network_observability_track",
+      "community": 5,
+      "norm_label": "track()"
+    },
+    {
+      "label": "Observabilidade da camada de network.",
+      "file_type": "rationale",
+      "source_file": "maria_cacau/core/network/_observability.py",
+      "source_location": "L1",
+      "id": "network_observability_rationale_1",
+      "community": 5,
+      "norm_label": "observabilidade da camada de network."
     },
     {
       "label": "_config.py",
@@ -692,45 +728,45 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/core/network/_config.py",
       "source_location": "L1",
-      "id": "network_config_rationale_1",
       "community": 5,
-      "norm_label": "configuracoes globais para uso do modulo"
+      "norm_label": "configuracoes globais para uso do modulo",
+      "id": "network_config_rationale_1"
     },
     {
       "label": "Configura o client ativo.",
       "file_type": "rationale",
       "source_file": "maria_cacau/core/network/_config.py",
       "source_location": "L16",
-      "id": "network_config_rationale_16",
       "community": 5,
-      "norm_label": "configura o client ativo."
+      "norm_label": "configura o client ativo.",
+      "id": "network_config_rationale_16"
     },
     {
       "label": "Substitui o client \u2014 \u00fatil para testes ou WireMock.",
       "file_type": "rationale",
       "source_file": "maria_cacau/core/network/_config.py",
       "source_location": "L21",
-      "id": "network_config_rationale_21",
       "community": 5,
-      "norm_label": "substitui o client \u2014 util para testes ou wiremock."
+      "norm_label": "substitui o client \u2014 util para testes ou wiremock.",
+      "id": "network_config_rationale_21"
     },
     {
       "label": "Remove o override. Volta ao client padr\u00e3o.",
       "file_type": "rationale",
       "source_file": "maria_cacau/core/network/_config.py",
       "source_location": "L26",
-      "id": "network_config_rationale_26",
       "community": 5,
-      "norm_label": "remove o override. volta ao client padrao."
+      "norm_label": "remove o override. volta ao client padrao.",
+      "id": "network_config_rationale_26"
     },
     {
       "label": "Retorna o client ativo (override se existir, padr\u00e3o caso contr\u00e1rio).",
       "file_type": "rationale",
       "source_file": "maria_cacau/core/network/_config.py",
       "source_location": "L31",
-      "id": "network_config_rationale_31",
       "community": 5,
-      "norm_label": "retorna o client ativo (override se existir, padrao caso contrario)."
+      "norm_label": "retorna o client ativo (override se existir, padrao caso contrario).",
+      "id": "network_config_rationale_31"
     },
     {
       "label": "handler.py",
@@ -738,7 +774,7 @@
       "source_file": "maria_cacau/core/storage/handler.py",
       "source_location": "L1",
       "id": "maria_cacau_core_storage_handler_py",
-      "community": 5,
+      "community": 2,
       "norm_label": "handler.py"
     },
     {
@@ -747,7 +783,7 @@
       "source_file": "maria_cacau/core/storage/handler.py",
       "source_location": "L9",
       "id": "storage_handler_storagehandler",
-      "community": 5,
+      "community": 2,
       "norm_label": "storagehandler"
     },
     {
@@ -756,7 +792,7 @@
       "source_file": "maria_cacau/core/storage/handler.py",
       "source_location": "L11",
       "id": "storage_handler_save",
-      "community": 5,
+      "community": 2,
       "norm_label": "save()"
     },
     {
@@ -765,7 +801,7 @@
       "source_file": "maria_cacau/core/storage/handler.py",
       "source_location": "L14",
       "id": "storage_handler_retrieve",
-      "community": 5,
+      "community": 2,
       "norm_label": "retrieve()"
     },
     {
@@ -774,7 +810,7 @@
       "source_file": "maria_cacau/core/storage/handler.py",
       "source_location": "L17",
       "id": "storage_handler_delete",
-      "community": 5,
+      "community": 2,
       "norm_label": "delete()"
     },
     {
@@ -783,7 +819,7 @@
       "source_file": "maria_cacau/core/storage/handler.py",
       "source_location": "L20",
       "id": "storage_handler_clean_all",
-      "community": 5,
+      "community": 2,
       "norm_label": "clean_all()"
     },
     {
@@ -791,9 +827,9 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/core/storage/handler.py",
       "source_location": "L1",
-      "id": "storage_handler_rationale_1",
-      "community": 5,
-      "norm_label": "contrato base para todos os backends de armazenamento."
+      "community": 2,
+      "norm_label": "contrato base para todos os backends de armazenamento.",
+      "id": "storage_handler_rationale_1"
     },
     {
       "label": "security.py",
@@ -872,9 +908,9 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/core/storage/security.py",
       "source_location": "L1",
-      "id": "storage_security_rationale_1",
       "community": 2,
-      "norm_label": "backend de armazenamento seguro via arquivo protegido no diretorio do usuario."
+      "norm_label": "backend de armazenamento seguro via arquivo protegido no diretorio do usuario.",
+      "id": "storage_security_rationale_1"
     },
     {
       "label": "cache.py",
@@ -953,9 +989,9 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/core/storage/cache.py",
       "source_location": "L1",
-      "id": "storage_cache_rationale_1",
       "community": 2,
-      "norm_label": "backend de cache em arquivo json no diretorio do usuario."
+      "norm_label": "backend de cache em arquivo json no diretorio do usuario.",
+      "id": "storage_cache_rationale_1"
     },
     {
       "label": "__init__.py",
@@ -972,7 +1008,7 @@
       "source_file": "maria_cacau/core/error/models.py",
       "source_location": "L1",
       "id": "maria_cacau_core_error_models_py",
-      "community": 10,
+      "community": 12,
       "norm_label": "models.py"
     },
     {
@@ -981,7 +1017,7 @@
       "source_file": "maria_cacau/core/error/models.py",
       "source_location": "L7",
       "id": "error_models_errormodel",
-      "community": 10,
+      "community": 12,
       "norm_label": "errormodel"
     },
     {
@@ -990,7 +1026,7 @@
       "source_file": "maria_cacau/core/error/models.py",
       "source_location": "L12",
       "id": "error_models_errormodel_post_init",
-      "community": 7,
+      "community": 14,
       "norm_label": ".__post_init__()"
     },
     {
@@ -999,7 +1035,7 @@
       "source_file": "maria_cacau/core/error/models.py",
       "source_location": "L16",
       "id": "error_models_from_error",
-      "community": 10,
+      "community": 12,
       "norm_label": "from_error()"
     },
     {
@@ -1008,7 +1044,7 @@
       "source_file": "maria_cacau/core/error/models.py",
       "source_location": "L23",
       "id": "error_models_errormodel_to_popup",
-      "community": 3,
+      "community": 1,
       "norm_label": ".to_popup()"
     },
     {
@@ -1017,7 +1053,7 @@
       "source_file": "maria_cacau/core/error/__init__.py",
       "source_location": "L1",
       "id": "maria_cacau_core_error_init_py",
-      "community": 10,
+      "community": 12,
       "norm_label": "__init__.py"
     },
     {
@@ -1026,7 +1062,7 @@
       "source_file": "maria_cacau/core/error/errors.py",
       "source_location": "L1",
       "id": "maria_cacau_core_error_errors_py",
-      "community": 10,
+      "community": 12,
       "norm_label": "errors.py"
     },
     {
@@ -1035,7 +1071,7 @@
       "source_file": "maria_cacau/core/error/errors.py",
       "source_location": "L8",
       "id": "error_errors_apperror",
-      "community": 10,
+      "community": 12,
       "norm_label": "apperror"
     },
     {
@@ -1044,7 +1080,7 @@
       "source_file": "",
       "source_location": "",
       "id": "namedtuple",
-      "community": 10,
+      "community": 12,
       "norm_label": "namedtuple"
     },
     {
@@ -1053,7 +1089,7 @@
       "source_file": "maria_cacau/core/error/errors.py",
       "source_location": "L104",
       "id": "error_errors_certificado_ok",
-      "community": 10,
+      "community": 12,
       "norm_label": "certificado_ok()"
     },
     {
@@ -1062,7 +1098,7 @@
       "source_file": "maria_cacau/core/error/errors.py",
       "source_location": "L113",
       "id": "error_errors_certificado_limpo",
-      "community": 10,
+      "community": 12,
       "norm_label": "certificado_limpo()"
     },
     {
@@ -1071,7 +1107,7 @@
       "source_file": "maria_cacau/core/error/errors.py",
       "source_location": "L122",
       "id": "error_errors_planilha_conectada",
-      "community": 10,
+      "community": 12,
       "norm_label": "planilha_conectada()"
     },
     {
@@ -1080,7 +1116,7 @@
       "source_file": "maria_cacau/core/error/errors.py",
       "source_location": "L131",
       "id": "error_errors_unexpected_error",
-      "community": 4,
+      "community": 12,
       "norm_label": "unexpected_error()"
     },
     {
@@ -1089,7 +1125,7 @@
       "source_file": "maria_cacau/core/error/errors.py",
       "source_location": "L140",
       "id": "error_errors_http_error",
-      "community": 10,
+      "community": 12,
       "norm_label": "http_error()"
     },
     {
@@ -1098,7 +1134,7 @@
       "source_file": "maria_cacau/core/error/errors.py",
       "source_location": "L149",
       "id": "error_errors_planilha_ok",
-      "community": 10,
+      "community": 12,
       "norm_label": "planilha_ok()"
     },
     {
@@ -1106,72 +1142,72 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/core/error/errors.py",
       "source_location": "L1",
-      "id": "error_errors_rationale_1",
-      "community": 10,
-      "norm_label": "codigos de erro da aplicacao com estrutura apperror."
+      "community": 12,
+      "norm_label": "codigos de erro da aplicacao com estrutura apperror.",
+      "id": "error_errors_rationale_1"
     },
     {
       "label": "Estrutura de uma mensagem de erro/info para exibi\u00e7\u00e3o no PopUp.",
       "file_type": "rationale",
       "source_file": "maria_cacau/core/error/errors.py",
       "source_location": "L9",
-      "id": "error_errors_rationale_9",
-      "community": 10,
-      "norm_label": "estrutura de uma mensagem de erro/info para exibicao no popup."
+      "community": 12,
+      "norm_label": "estrutura de uma mensagem de erro/info para exibicao no popup.",
+      "id": "error_errors_rationale_9"
     },
     {
       "label": "Confirma\u00e7\u00e3o de certificado configurado com sucesso.",
       "file_type": "rationale",
       "source_file": "maria_cacau/core/error/errors.py",
       "source_location": "L105",
-      "id": "error_errors_rationale_105",
-      "community": 10,
-      "norm_label": "confirmacao de certificado configurado com sucesso."
+      "community": 12,
+      "norm_label": "confirmacao de certificado configurado com sucesso.",
+      "id": "error_errors_rationale_105"
     },
     {
       "label": "Confirma\u00e7\u00e3o de credenciais removidas com sucesso.",
       "file_type": "rationale",
       "source_file": "maria_cacau/core/error/errors.py",
       "source_location": "L114",
-      "id": "error_errors_rationale_114",
-      "community": 10,
-      "norm_label": "confirmacao de credenciais removidas com sucesso."
+      "community": 12,
+      "norm_label": "confirmacao de credenciais removidas com sucesso.",
+      "id": "error_errors_rationale_114"
     },
     {
       "label": "Confirma\u00e7\u00e3o de planilha selecionada com sucesso.",
       "file_type": "rationale",
       "source_file": "maria_cacau/core/error/errors.py",
       "source_location": "L123",
-      "id": "error_errors_rationale_123",
-      "community": 10,
-      "norm_label": "confirmacao de planilha selecionada com sucesso."
+      "community": 12,
+      "norm_label": "confirmacao de planilha selecionada com sucesso.",
+      "id": "error_errors_rationale_123"
     },
     {
       "label": "Erro gen\u00e9rico para exce\u00e7\u00f5es n\u00e3o tratadas.",
       "file_type": "rationale",
       "source_file": "maria_cacau/core/error/errors.py",
       "source_location": "L132",
-      "id": "error_errors_rationale_132",
-      "community": 4,
-      "norm_label": "erro generico para excecoes nao tratadas."
+      "community": 12,
+      "norm_label": "erro generico para excecoes nao tratadas.",
+      "id": "error_errors_rationale_132"
     },
     {
       "label": "Erro HTTP sem body JSON \u2014 resposta de erro n\u00e3o estruturada do servidor.",
       "file_type": "rationale",
       "source_file": "maria_cacau/core/error/errors.py",
       "source_location": "L141",
-      "id": "error_errors_rationale_141",
-      "community": 10,
-      "norm_label": "erro http sem body json \u2014 resposta de erro nao estruturada do servidor."
+      "community": 12,
+      "norm_label": "erro http sem body json \u2014 resposta de erro nao estruturada do servidor.",
+      "id": "error_errors_rationale_141"
     },
     {
       "label": "Confirma\u00e7\u00e3o de leitura bem-sucedida da planilha.",
       "file_type": "rationale",
       "source_file": "maria_cacau/core/error/errors.py",
       "source_location": "L150",
-      "id": "error_errors_rationale_150",
-      "community": 10,
-      "norm_label": "confirmacao de leitura bem-sucedida da planilha."
+      "community": 12,
+      "norm_label": "confirmacao de leitura bem-sucedida da planilha.",
+      "id": "error_errors_rationale_150"
     },
     {
       "label": "coordinator.py",
@@ -1269,7 +1305,7 @@
       "source_file": "maria_cacau/app/handler.py",
       "source_location": "L11",
       "id": "app_handler_menuhandler_init",
-      "community": 7,
+      "community": 10,
       "norm_label": ".__init__()"
     },
     {
@@ -1413,7 +1449,7 @@
       "source_file": "maria_cacau/design_system/components/buttons/button.py",
       "source_location": "L9",
       "id": "buttons_button_dsbutton",
-      "community": 8,
+      "community": 9,
       "norm_label": "dsbutton"
     },
     {
@@ -1422,7 +1458,7 @@
       "source_file": "",
       "source_location": "",
       "id": "qpushbutton",
-      "community": 7,
+      "community": 14,
       "norm_label": "qpushbutton"
     },
     {
@@ -1431,7 +1467,7 @@
       "source_file": "",
       "source_location": "",
       "id": "dsloadinghandler",
-      "community": 8,
+      "community": 9,
       "norm_label": "dsloadinghandler"
     },
     {
@@ -1440,7 +1476,7 @@
       "source_file": "maria_cacau/design_system/components/buttons/button.py",
       "source_location": "L11",
       "id": "buttons_button_dsbutton_init",
-      "community": 8,
+      "community": 9,
       "norm_label": ".__init__()"
     },
     {
@@ -1449,7 +1485,7 @@
       "source_file": "maria_cacau/design_system/components/buttons/button.py",
       "source_location": "L22",
       "id": "buttons_button_dsbutton_update_state",
-      "community": 8,
+      "community": 9,
       "norm_label": ".update_state()"
     },
     {
@@ -1458,7 +1494,7 @@
       "source_file": "maria_cacau/design_system/components/buttons/button.py",
       "source_location": "L40",
       "id": "buttons_button_dsbutton_on_loading_tick",
-      "community": 8,
+      "community": 9,
       "norm_label": "._on_loading_tick()"
     },
     {
@@ -1467,7 +1503,7 @@
       "source_file": "maria_cacau/design_system/components/buttons/button.py",
       "source_location": "L45",
       "id": "buttons_button_dsbutton_mousepressevent",
-      "community": 8,
+      "community": 9,
       "norm_label": ".mousepressevent()"
     },
     {
@@ -1494,7 +1530,7 @@
       "source_file": "maria_cacau/design_system/components/chart/chart_type.py",
       "source_location": "L1",
       "id": "maria_cacau_design_system_components_chart_chart_type_py",
-      "community": 9,
+      "community": 16,
       "norm_label": "chart_type.py"
     },
     {
@@ -1503,7 +1539,7 @@
       "source_file": "maria_cacau/design_system/components/chart/chart_type.py",
       "source_location": "L4",
       "id": "chart_chart_type_dscharttype",
-      "community": 9,
+      "community": 16,
       "norm_label": "dscharttype"
     },
     {
@@ -1512,7 +1548,7 @@
       "source_file": "maria_cacau/design_system/components/chart/__init__.py",
       "source_location": "L1",
       "id": "maria_cacau_design_system_components_chart_init_py",
-      "community": 9,
+      "community": 16,
       "norm_label": "__init__.py"
     },
     {
@@ -1521,7 +1557,7 @@
       "source_file": "maria_cacau/design_system/components/chart/chart_widget.py",
       "source_location": "L1",
       "id": "maria_cacau_design_system_components_chart_chart_widget_py",
-      "community": 9,
+      "community": 16,
       "norm_label": "chart_widget.py"
     },
     {
@@ -1530,7 +1566,7 @@
       "source_file": "maria_cacau/design_system/components/chart/chart_widget.py",
       "source_location": "L18",
       "id": "chart_chart_widget_short_label",
-      "community": 9,
+      "community": 16,
       "norm_label": "_short_label()"
     },
     {
@@ -1539,7 +1575,7 @@
       "source_file": "maria_cacau/design_system/components/chart/chart_widget.py",
       "source_location": "L26",
       "id": "chart_chart_widget_dschart",
-      "community": 9,
+      "community": 16,
       "norm_label": "dschart"
     },
     {
@@ -1548,7 +1584,7 @@
       "source_file": "",
       "source_location": "",
       "id": "qwidget",
-      "community": 7,
+      "community": 14,
       "norm_label": "qwidget"
     },
     {
@@ -1557,7 +1593,7 @@
       "source_file": "maria_cacau/design_system/components/chart/chart_widget.py",
       "source_location": "L27",
       "id": "chart_chart_widget_dschart_init",
-      "community": 9,
+      "community": 16,
       "norm_label": ".__init__()"
     },
     {
@@ -1566,7 +1602,7 @@
       "source_file": "maria_cacau/design_system/components/chart/chart_widget.py",
       "source_location": "L64",
       "id": "chart_chart_widget_dschart_update_data",
-      "community": 9,
+      "community": 16,
       "norm_label": ".update_data()"
     },
     {
@@ -1575,7 +1611,7 @@
       "source_file": "maria_cacau/design_system/components/chart/chart_widget.py",
       "source_location": "L69",
       "id": "chart_chart_widget_dschart_clear",
-      "community": 9,
+      "community": 16,
       "norm_label": ".clear()"
     },
     {
@@ -1584,7 +1620,7 @@
       "source_file": "maria_cacau/design_system/components/chart/chart_widget.py",
       "source_location": "L76",
       "id": "chart_chart_widget_dschart_set_type",
-      "community": 9,
+      "community": 16,
       "norm_label": ".set_type()"
     },
     {
@@ -1593,7 +1629,7 @@
       "source_file": "maria_cacau/design_system/components/chart/chart_widget.py",
       "source_location": "L81",
       "id": "chart_chart_widget_dschart_copy_to_clipboard",
-      "community": 9,
+      "community": 16,
       "norm_label": ".copy_to_clipboard()"
     },
     {
@@ -1602,7 +1638,7 @@
       "source_file": "maria_cacau/design_system/components/chart/chart_widget.py",
       "source_location": "L91",
       "id": "chart_chart_widget_dschart_save_to_file",
-      "community": 9,
+      "community": 16,
       "norm_label": ".save_to_file()"
     },
     {
@@ -1611,7 +1647,7 @@
       "source_file": "maria_cacau/design_system/components/chart/chart_widget.py",
       "source_location": "L101",
       "id": "chart_chart_widget_dschart_canvas_dims",
-      "community": 9,
+      "community": 16,
       "norm_label": "._canvas_dims()"
     },
     {
@@ -1620,7 +1656,7 @@
       "source_file": "maria_cacau/design_system/components/chart/chart_widget.py",
       "source_location": "L109",
       "id": "chart_chart_widget_dschart_render",
-      "community": 9,
+      "community": 16,
       "norm_label": "._render()"
     },
     {
@@ -1629,7 +1665,7 @@
       "source_file": "maria_cacau/design_system/components/chart/chart_widget.py",
       "source_location": "L115",
       "id": "chart_chart_widget_dschart_render_bar",
-      "community": 9,
+      "community": 16,
       "norm_label": "._render_bar()"
     },
     {
@@ -1638,7 +1674,7 @@
       "source_file": "maria_cacau/design_system/components/chart/chart_widget.py",
       "source_location": "L153",
       "id": "chart_chart_widget_dschart_render_pie",
-      "community": 9,
+      "community": 16,
       "norm_label": "._render_pie()"
     },
     {
@@ -1647,7 +1683,7 @@
       "source_file": "maria_cacau/design_system/components/chart/chart_widget.py",
       "source_location": "L196",
       "id": "chart_chart_widget_dschart_empty",
-      "community": 9,
+      "community": 16,
       "norm_label": "._empty()"
     },
     {
@@ -1655,9 +1691,9 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/design_system/components/chart/chart_widget.py",
       "source_location": "L1",
-      "id": "chart_chart_widget_rationale_1",
-      "community": 9,
-      "norm_label": "widget de grafico reutilizavel (barras ou pizza) usando seaborn + matplotlib."
+      "community": 16,
+      "norm_label": "widget de grafico reutilizavel (barras ou pizza) usando seaborn + matplotlib.",
+      "id": "chart_chart_widget_rationale_1"
     },
     {
       "label": "__init__.py",
@@ -1710,7 +1746,7 @@
       "source_file": "maria_cacau/design_system/components/alerts/dialog.py",
       "source_location": "L1",
       "id": "maria_cacau_design_system_components_alerts_dialog_py",
-      "community": 3,
+      "community": 1,
       "norm_label": "dialog.py"
     },
     {
@@ -1719,7 +1755,7 @@
       "source_file": "maria_cacau/design_system/components/alerts/dialog.py",
       "source_location": "L11",
       "id": "alerts_dialog_dsdialogicon",
-      "community": 3,
+      "community": 1,
       "norm_label": "dsdialogicon"
     },
     {
@@ -1728,7 +1764,7 @@
       "source_file": "maria_cacau/design_system/components/alerts/dialog.py",
       "source_location": "L18",
       "id": "alerts_dialog_dsdialogmodel",
-      "community": 3,
+      "community": 1,
       "norm_label": "dsdialogmodel"
     },
     {
@@ -1737,7 +1773,7 @@
       "source_file": "maria_cacau/design_system/components/alerts/dialog.py",
       "source_location": "L25",
       "id": "alerts_dialog_dsdialog",
-      "community": 3,
+      "community": 1,
       "norm_label": "dsdialog"
     },
     {
@@ -1746,7 +1782,7 @@
       "source_file": "",
       "source_location": "",
       "id": "qmessagebox",
-      "community": 3,
+      "community": 1,
       "norm_label": "qmessagebox"
     },
     {
@@ -1755,7 +1791,7 @@
       "source_file": "maria_cacau/design_system/components/alerts/dialog.py",
       "source_location": "L27",
       "id": "alerts_dialog_dsdialog_init",
-      "community": 3,
+      "community": 1,
       "norm_label": ".__init__()"
     },
     {
@@ -1764,7 +1800,7 @@
       "source_file": "maria_cacau/design_system/components/alerts/dialog.py",
       "source_location": "L31",
       "id": "alerts_dialog_dsdialog_setup_ui",
-      "community": 3,
+      "community": 1,
       "norm_label": "._setup_ui()"
     },
     {
@@ -1773,7 +1809,7 @@
       "source_file": "maria_cacau/design_system/components/alerts/dialog.py",
       "source_location": "L42",
       "id": "alerts_dialog_dsdialog_show",
-      "community": 3,
+      "community": 1,
       "norm_label": ".show()"
     },
     {
@@ -1782,7 +1818,7 @@
       "source_file": "maria_cacau/design_system/components/alerts/dialog.py",
       "source_location": "L50",
       "id": "alerts_dialog_dsdialog_apply_min_width",
-      "community": 3,
+      "community": 1,
       "norm_label": "._apply_min_width()"
     },
     {
@@ -1791,7 +1827,7 @@
       "source_file": "maria_cacau/design_system/components/alerts/__init__.py",
       "source_location": "L1",
       "id": "maria_cacau_design_system_components_alerts_init_py",
-      "community": 3,
+      "community": 1,
       "norm_label": "__init__.py"
     },
     {
@@ -1800,7 +1836,7 @@
       "source_file": "maria_cacau/design_system/components/combo_box/combo_box.py",
       "source_location": "L1",
       "id": "maria_cacau_design_system_components_combo_box_combo_box_py",
-      "community": 3,
+      "community": 1,
       "norm_label": "combo_box.py"
     },
     {
@@ -1809,7 +1845,7 @@
       "source_file": "maria_cacau/design_system/components/combo_box/combo_box.py",
       "source_location": "L5",
       "id": "combo_box_combo_box_dscombobox",
-      "community": 3,
+      "community": 1,
       "norm_label": "dscombobox"
     },
     {
@@ -1818,7 +1854,7 @@
       "source_file": "",
       "source_location": "",
       "id": "qcombobox",
-      "community": 3,
+      "community": 1,
       "norm_label": "qcombobox"
     },
     {
@@ -1827,7 +1863,7 @@
       "source_file": "maria_cacau/design_system/components/combo_box/combo_box.py",
       "source_location": "L7",
       "id": "combo_box_combo_box_dscombobox_init",
-      "community": 3,
+      "community": 1,
       "norm_label": ".__init__()"
     },
     {
@@ -1836,7 +1872,7 @@
       "source_file": "maria_cacau/design_system/components/combo_box/__init__.py",
       "source_location": "L1",
       "id": "maria_cacau_design_system_components_combo_box_init_py",
-      "community": 3,
+      "community": 1,
       "norm_label": "__init__.py"
     },
     {
@@ -1845,7 +1881,7 @@
       "source_file": "maria_cacau/design_system/components/text_view/__init__.py",
       "source_location": "L1",
       "id": "maria_cacau_design_system_components_text_view_init_py",
-      "community": 8,
+      "community": 1,
       "norm_label": "__init__.py"
     },
     {
@@ -1854,7 +1890,7 @@
       "source_file": "maria_cacau/design_system/components/text_view/text_view.py",
       "source_location": "L1",
       "id": "maria_cacau_design_system_components_text_view_text_view_py",
-      "community": 8,
+      "community": 1,
       "norm_label": "text_view.py"
     },
     {
@@ -1863,7 +1899,7 @@
       "source_file": "maria_cacau/design_system/components/text_view/text_view.py",
       "source_location": "L5",
       "id": "text_view_text_view_dstextview",
-      "community": 8,
+      "community": 1,
       "norm_label": "dstextview"
     },
     {
@@ -1872,7 +1908,7 @@
       "source_file": "",
       "source_location": "",
       "id": "qtextbrowser",
-      "community": 8,
+      "community": 1,
       "norm_label": "qtextbrowser"
     },
     {
@@ -1881,7 +1917,7 @@
       "source_file": "maria_cacau/design_system/components/text_view/text_view.py",
       "source_location": "L7",
       "id": "text_view_text_view_dstextview_init",
-      "community": 8,
+      "community": 1,
       "norm_label": ".__init__()"
     },
     {
@@ -1890,7 +1926,7 @@
       "source_file": "maria_cacau/design_system/components/text_view/text_view.py",
       "source_location": "L11",
       "id": "text_view_text_view_dstextview_copy_to_clipboard",
-      "community": 8,
+      "community": 1,
       "norm_label": ".copy_to_clipboard()"
     },
     {
@@ -1899,7 +1935,7 @@
       "source_file": "maria_cacau/design_system/components/containers/group_box.py",
       "source_location": "L1",
       "id": "maria_cacau_design_system_components_containers_group_box_py",
-      "community": 8,
+      "community": 1,
       "norm_label": "group_box.py"
     },
     {
@@ -1908,7 +1944,7 @@
       "source_file": "maria_cacau/design_system/components/containers/group_box.py",
       "source_location": "L5",
       "id": "containers_group_box_dsgroupbox",
-      "community": 8,
+      "community": 1,
       "norm_label": "dsgroupbox"
     },
     {
@@ -1917,7 +1953,7 @@
       "source_file": "",
       "source_location": "",
       "id": "qgroupbox",
-      "community": 8,
+      "community": 1,
       "norm_label": "qgroupbox"
     },
     {
@@ -1926,7 +1962,7 @@
       "source_file": "maria_cacau/design_system/components/containers/group_box.py",
       "source_location": "L7",
       "id": "containers_group_box_dsgroupbox_init",
-      "community": 8,
+      "community": 1,
       "norm_label": ".__init__()"
     },
     {
@@ -1935,7 +1971,7 @@
       "source_file": "maria_cacau/design_system/components/containers/__init__.py",
       "source_location": "L1",
       "id": "maria_cacau_design_system_components_containers_init_py",
-      "community": 8,
+      "community": 1,
       "norm_label": "__init__.py"
     },
     {
@@ -1944,7 +1980,7 @@
       "source_file": "maria_cacau/design_system/components/inputs/text_input.py",
       "source_location": "L1",
       "id": "maria_cacau_design_system_components_inputs_text_input_py",
-      "community": 7,
+      "community": 8,
       "norm_label": "text_input.py"
     },
     {
@@ -1953,7 +1989,7 @@
       "source_file": "maria_cacau/design_system/components/inputs/text_input.py",
       "source_location": "L5",
       "id": "inputs_text_input_dstextinput",
-      "community": 7,
+      "community": 8,
       "norm_label": "dstextinput"
     },
     {
@@ -1962,7 +1998,7 @@
       "source_file": "",
       "source_location": "",
       "id": "qlineedit",
-      "community": 7,
+      "community": 8,
       "norm_label": "qlineedit"
     },
     {
@@ -1971,7 +2007,7 @@
       "source_file": "maria_cacau/design_system/components/inputs/text_input.py",
       "source_location": "L7",
       "id": "inputs_text_input_dstextinput_init",
-      "community": 7,
+      "community": 8,
       "norm_label": ".__init__()"
     },
     {
@@ -1980,7 +2016,7 @@
       "source_file": "maria_cacau/design_system/components/inputs/__init__.py",
       "source_location": "L1",
       "id": "maria_cacau_design_system_components_inputs_init_py",
-      "community": 7,
+      "community": 8,
       "norm_label": "__init__.py"
     },
     {
@@ -1989,7 +2025,7 @@
       "source_file": "maria_cacau/design_system/components/inputs/date_input.py",
       "source_location": "L1",
       "id": "maria_cacau_design_system_components_inputs_date_input_py",
-      "community": 7,
+      "community": 8,
       "norm_label": "date_input.py"
     },
     {
@@ -1998,7 +2034,7 @@
       "source_file": "maria_cacau/design_system/components/inputs/date_input.py",
       "source_location": "L5",
       "id": "inputs_date_input_dsdateinput",
-      "community": 7,
+      "community": 1,
       "norm_label": "dsdateinput"
     },
     {
@@ -2007,7 +2043,7 @@
       "source_file": "",
       "source_location": "",
       "id": "qdateedit",
-      "community": 7,
+      "community": 14,
       "norm_label": "qdateedit"
     },
     {
@@ -2016,7 +2052,7 @@
       "source_file": "maria_cacau/design_system/components/inputs/date_input.py",
       "source_location": "L7",
       "id": "inputs_date_input_dsdateinput_init",
-      "community": 7,
+      "community": 1,
       "norm_label": ".__init__()"
     },
     {
@@ -2025,7 +2061,7 @@
       "source_file": "maria_cacau/design_system/handlers/__init__.py",
       "source_location": "L1",
       "id": "maria_cacau_design_system_handlers_init_py",
-      "community": 8,
+      "community": 9,
       "norm_label": "__init__.py"
     },
     {
@@ -2034,7 +2070,7 @@
       "source_file": "maria_cacau/design_system/handlers/loading_handler.py",
       "source_location": "L1",
       "id": "maria_cacau_design_system_handlers_loading_handler_py",
-      "community": 8,
+      "community": 9,
       "norm_label": "loading_handler.py"
     },
     {
@@ -2043,7 +2079,7 @@
       "source_file": "maria_cacau/design_system/handlers/loading_handler.py",
       "source_location": "L4",
       "id": "handlers_loading_handler_dsloadinghandler",
-      "community": 8,
+      "community": 9,
       "norm_label": "dsloadinghandler"
     },
     {
@@ -2052,7 +2088,7 @@
       "source_file": "maria_cacau/design_system/handlers/loading_handler.py",
       "source_location": "L9",
       "id": "handlers_loading_handler_dsloadinghandler_setup_loading",
-      "community": 8,
+      "community": 9,
       "norm_label": "._setup_loading()"
     },
     {
@@ -2061,7 +2097,7 @@
       "source_file": "maria_cacau/design_system/handlers/loading_handler.py",
       "source_location": "L16",
       "id": "handlers_loading_handler_dsloadinghandler_start_loading",
-      "community": 8,
+      "community": 9,
       "norm_label": "._start_loading()"
     },
     {
@@ -2070,7 +2106,7 @@
       "source_file": "maria_cacau/design_system/handlers/loading_handler.py",
       "source_location": "L20",
       "id": "handlers_loading_handler_dsloadinghandler_stop_loading",
-      "community": 8,
+      "community": 9,
       "norm_label": "._stop_loading()"
     },
     {
@@ -2079,7 +2115,7 @@
       "source_file": "maria_cacau/design_system/handlers/loading_handler.py",
       "source_location": "L23",
       "id": "handlers_loading_handler_dsloadinghandler_loading_tick",
-      "community": 8,
+      "community": 9,
       "norm_label": "._loading_tick()"
     },
     {
@@ -2088,7 +2124,7 @@
       "source_file": "maria_cacau/design_system/handlers/loading_handler.py",
       "source_location": "L28",
       "id": "handlers_loading_handler_dsloadinghandler_on_loading_tick",
-      "community": 8,
+      "community": 9,
       "norm_label": "._on_loading_tick()"
     },
     {
@@ -2096,27 +2132,27 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/design_system/handlers/loading_handler.py",
       "source_location": "L5",
-      "id": "handlers_loading_handler_rationale_5",
-      "community": 8,
-      "norm_label": "mixin que adiciona comportamento de loading animado a qualquer componente qobjec"
+      "community": 9,
+      "norm_label": "mixin que adiciona comportamento de loading animado a qualquer componente qobjec",
+      "id": "handlers_loading_handler_rationale_5"
     },
     {
       "label": "Deve ser chamado no __init__ do componente, ap\u00f3s o super().__init__().",
       "file_type": "rationale",
       "source_file": "maria_cacau/design_system/handlers/loading_handler.py",
       "source_location": "L10",
-      "id": "handlers_loading_handler_rationale_10",
-      "community": 8,
-      "norm_label": "deve ser chamado no __init__ do componente, apos o super().__init__()."
+      "community": 9,
+      "norm_label": "deve ser chamado no __init__ do componente, apos o super().__init__().",
+      "id": "handlers_loading_handler_rationale_10"
     },
     {
       "label": "Implementar no componente: o que fazer com cada frame do spinner.",
       "file_type": "rationale",
       "source_file": "maria_cacau/design_system/handlers/loading_handler.py",
       "source_location": "L29",
-      "id": "handlers_loading_handler_rationale_29",
-      "community": 8,
-      "norm_label": "implementar no componente: o que fazer com cada frame do spinner."
+      "community": 9,
+      "norm_label": "implementar no componente: o que fazer com cada frame do spinner.",
+      "id": "handlers_loading_handler_rationale_29"
     },
     {
       "label": "__init__.py",
@@ -2142,7 +2178,7 @@
       "source_file": "maria_cacau/features/home/source/controller.py",
       "source_location": "L1",
       "id": "maria_cacau_features_home_source_controller_py",
-      "community": 16,
+      "community": 14,
       "norm_label": "controller.py"
     },
     {
@@ -2151,7 +2187,7 @@
       "source_file": "maria_cacau/features/home/source/controller.py",
       "source_location": "L8",
       "id": "source_controller_homecontroller",
-      "community": 16,
+      "community": 14,
       "norm_label": "homecontroller"
     },
     {
@@ -2160,7 +2196,7 @@
       "source_file": "maria_cacau/features/home/source/controller.py",
       "source_location": "L9",
       "id": "source_controller_homecontroller_init",
-      "community": 16,
+      "community": 14,
       "norm_label": ".__init__()"
     },
     {
@@ -2169,7 +2205,7 @@
       "source_file": "maria_cacau/features/home/source/controller.py",
       "source_location": "L16",
       "id": "source_controller_homecontroller_setup_view",
-      "community": 16,
+      "community": 14,
       "norm_label": ".setup_view()"
     },
     {
@@ -2178,7 +2214,7 @@
       "source_file": "maria_cacau/features/home/source/models.py",
       "source_location": "L1",
       "id": "maria_cacau_features_home_source_models_py",
-      "community": 16,
+      "community": 14,
       "norm_label": "models.py"
     },
     {
@@ -2187,7 +2223,7 @@
       "source_file": "maria_cacau/features/home/source/models.py",
       "source_location": "L7",
       "id": "source_models_homefeaturesmodel",
-      "community": 16,
+      "community": 14,
       "norm_label": "homefeaturesmodel"
     },
     {
@@ -2196,7 +2232,7 @@
       "source_file": "maria_cacau/features/home/source/__init__.py",
       "source_location": "L1",
       "id": "maria_cacau_features_home_source_init_py",
-      "community": 16,
+      "community": 14,
       "norm_label": "__init__.py"
     },
     {
@@ -2205,7 +2241,7 @@
       "source_file": "maria_cacau/features/home/source/view.py",
       "source_location": "L1",
       "id": "maria_cacau_features_home_source_view_py",
-      "community": 16,
+      "community": 14,
       "norm_label": "view.py"
     },
     {
@@ -2214,7 +2250,7 @@
       "source_file": "maria_cacau/features/home/source/view.py",
       "source_location": "L7",
       "id": "source_view_homeview",
-      "community": 16,
+      "community": 14,
       "norm_label": "homeview"
     },
     {
@@ -2223,7 +2259,7 @@
       "source_file": "maria_cacau/features/home/source/view.py",
       "source_location": "L8",
       "id": "source_view_homeview_init",
-      "community": 16,
+      "community": 14,
       "norm_label": ".__init__()"
     },
     {
@@ -2232,7 +2268,7 @@
       "source_file": "maria_cacau/features/home/source/view.py",
       "source_location": "L12",
       "id": "source_view_homeview_paintevent",
-      "community": 16,
+      "community": 14,
       "norm_label": ".paintevent()"
     },
     {
@@ -2241,7 +2277,7 @@
       "source_file": "maria_cacau/features/home/source/view.py",
       "source_location": "L16",
       "id": "source_view_homeview_setup_layout",
-      "community": 16,
+      "community": 14,
       "norm_label": ".setup_layout()"
     },
     {
@@ -2268,7 +2304,7 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/data/mapper.py",
       "source_location": "L1",
       "id": "maria_cacau_features_home_sub_features_delivery_data_mapper_py",
-      "community": 1,
+      "community": 3,
       "norm_label": "mapper.py"
     },
     {
@@ -2277,7 +2313,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/data/mapper.py",
       "source_location": "L9",
       "id": "data_mapper_errormapper",
-      "community": 1,
+      "community": 3,
       "norm_label": "errormapper"
     },
     {
@@ -2286,7 +2322,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/data/mapper.py",
       "source_location": "L11",
       "id": "data_mapper_from_response",
-      "community": 1,
+      "community": 3,
       "norm_label": "from_response()"
     },
     {
@@ -2295,7 +2331,7 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/data/mapper.py",
       "source_location": "L24",
       "id": "data_mapper_deliveriesmapper",
-      "community": 1,
+      "community": 3,
       "norm_label": "deliveriesmapper"
     },
     {
@@ -2304,7 +2340,7 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/data/mapper.py",
       "source_location": "L36",
       "id": "data_mapper_paymentsmapper",
-      "community": 1,
+      "community": 3,
       "norm_label": "paymentsmapper"
     },
     {
@@ -2312,18 +2348,18 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/features/home/sub_features/summary/data/mapper.py",
       "source_location": "L1",
-      "id": "data_mapper_rationale_1",
-      "community": 1,
-      "norm_label": "mappers de httpresponse para domain models e de httpresponseerror para errormode"
+      "community": 3,
+      "norm_label": "mappers de httpresponse para domain models e de httpresponseerror para errormode",
+      "id": "data_mapper_rationale_1"
     },
     {
       "label": "L\u00ea o JSON do backend; cai em http_error gen\u00e9rico se o corpo n\u00e3o for JSON v\u00e1lido.",
       "file_type": "rationale",
       "source_file": "maria_cacau/features/home/sub_features/delivery/data/mapper.py",
       "source_location": "L12",
-      "id": "data_mapper_rationale_12",
-      "community": 1,
-      "norm_label": "le o json do backend; cai em http_error generico se o corpo nao for json valido."
+      "community": 3,
+      "norm_label": "le o json do backend; cai em http_error generico se o corpo nao for json valido.",
+      "id": "data_mapper_rationale_12"
     },
     {
       "label": "__init__.py",
@@ -2331,7 +2367,7 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/data/__init__.py",
       "source_location": "L1",
       "id": "maria_cacau_features_home_sub_features_delivery_data_init_py",
-      "community": 1,
+      "community": 3,
       "norm_label": "__init__.py"
     },
     {
@@ -2340,7 +2376,7 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/data/apis.py",
       "source_location": "L1",
       "id": "maria_cacau_features_home_sub_features_delivery_data_apis_py",
-      "community": 1,
+      "community": 3,
       "norm_label": "apis.py"
     },
     {
@@ -2349,7 +2385,7 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/data/apis.py",
       "source_location": "L6",
       "id": "data_apis_deliveriesapi",
-      "community": 1,
+      "community": 3,
       "norm_label": "deliveriesapi"
     },
     {
@@ -2367,7 +2403,7 @@
       "source_file": "maria_cacau/features/auth/data/apis.py",
       "source_location": "L13",
       "id": "data_apis_path",
-      "community": 2,
+      "community": 3,
       "norm_label": "path()"
     },
     {
@@ -2376,7 +2412,7 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/data/apis.py",
       "source_location": "L11",
       "id": "data_apis_deliveriesapi_for_date",
-      "community": 1,
+      "community": 3,
       "norm_label": ".for_date()"
     },
     {
@@ -2385,7 +2421,7 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/data/apis.py",
       "source_location": "L16",
       "id": "data_apis_paymentspendentapi",
-      "community": 1,
+      "community": 3,
       "norm_label": "paymentspendentapi"
     },
     {
@@ -2394,7 +2430,7 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/data/apis.py",
       "source_location": "L21",
       "id": "data_apis_paymentspendentapi_for_date",
-      "community": 1,
+      "community": 3,
       "norm_label": ".for_date()"
     },
     {
@@ -2402,9 +2438,9 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/features/auth/data/apis.py",
       "source_location": "L1",
-      "id": "data_apis_rationale_1",
-      "community": 2,
-      "norm_label": "endpoints do backend consumidos pela feature auth."
+      "community": 3,
+      "norm_label": "endpoints do backend consumidos pela feature auth.",
+      "id": "data_apis_rationale_1"
     },
     {
       "label": "repository.py",
@@ -2412,7 +2448,7 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/data/repository.py",
       "source_location": "L1",
       "id": "maria_cacau_features_home_sub_features_delivery_data_repository_py",
-      "community": 1,
+      "community": 3,
       "norm_label": "repository.py"
     },
     {
@@ -2421,7 +2457,7 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/data/repository.py",
       "source_location": "L12",
       "id": "data_repository_ordersrepository",
-      "community": 1,
+      "community": 3,
       "norm_label": "ordersrepository"
     },
     {
@@ -2430,7 +2466,7 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/data/repository.py",
       "source_location": "L13",
       "id": "data_repository_ordersrepository_get_deliveries",
-      "community": 1,
+      "community": 3,
       "norm_label": ".get_deliveries()"
     },
     {
@@ -2439,7 +2475,7 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/data/repository.py",
       "source_location": "L23",
       "id": "data_repository_ordersrepository_get_pendent_payments",
-      "community": 1,
+      "community": 3,
       "norm_label": ".get_pendent_payments()"
     },
     {
@@ -2447,9 +2483,9 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/features/auth/data/repository.py",
       "source_location": "L1",
-      "id": "data_repository_rationale_1",
-      "community": 1,
-      "norm_label": "repository da feature auth: gerencia storage seguro e chamadas ao backend."
+      "community": 3,
+      "norm_label": "repository da feature auth: gerencia storage seguro e chamadas ao backend.",
+      "id": "data_repository_rationale_1"
     },
     {
       "label": "use_case.py",
@@ -2457,7 +2493,7 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/domain/use_case.py",
       "source_location": "L1",
       "id": "maria_cacau_features_home_sub_features_delivery_domain_use_case_py",
-      "community": 1,
+      "community": 3,
       "norm_label": "use_case.py"
     },
     {
@@ -2466,7 +2502,7 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/domain/use_case.py",
       "source_location": "L9",
       "id": "domain_use_case_deliveryusecase",
-      "community": 15,
+      "community": 3,
       "norm_label": "deliveryusecase"
     },
     {
@@ -2475,7 +2511,7 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/domain/use_case.py",
       "source_location": "L10",
       "id": "domain_use_case_deliveryusecase_init",
-      "community": 15,
+      "community": 3,
       "norm_label": ".__init__()"
     },
     {
@@ -2484,7 +2520,7 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/domain/use_case.py",
       "source_location": "L13",
       "id": "domain_use_case_deliveryusecase_get_orders",
-      "community": 15,
+      "community": 3,
       "norm_label": ".get_orders()"
     },
     {
@@ -2492,18 +2528,18 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/features/cpf_validation/domain/use_case.py",
       "source_location": "L1",
-      "id": "domain_use_case_rationale_1",
-      "community": 1,
-      "norm_label": "regra de negocios: validacao matematica de cpf."
+      "community": 3,
+      "norm_label": "regra de negocios: validacao matematica de cpf.",
+      "id": "domain_use_case_rationale_1"
     },
     {
       "label": "Busca deliveries e payments em paralelo e retorna o modelo consolidado.",
       "file_type": "rationale",
       "source_file": "maria_cacau/features/home/sub_features/delivery/domain/use_case.py",
       "source_location": "L14",
-      "id": "domain_use_case_rationale_14",
-      "community": 15,
-      "norm_label": "busca deliveries e payments em paralelo e retorna o modelo consolidado."
+      "community": 3,
+      "norm_label": "busca deliveries e payments em paralelo e retorna o modelo consolidado.",
+      "id": "domain_use_case_rationale_14"
     },
     {
       "label": "signals.py",
@@ -2511,7 +2547,7 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/domain/signals.py",
       "source_location": "L1",
       "id": "maria_cacau_features_home_sub_features_delivery_domain_signals_py",
-      "community": 1,
+      "community": 3,
       "norm_label": "signals.py"
     },
     {
@@ -2520,7 +2556,7 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/domain/signals.py",
       "source_location": "L8",
       "id": "domain_signals_deliverysignals",
-      "community": 1,
+      "community": 10,
       "norm_label": "deliverysignals"
     },
     {
@@ -2528,9 +2564,9 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/features/cpf_validation/domain/signals.py",
       "source_location": "L1",
-      "id": "domain_signals_rationale_1",
-      "community": 1,
-      "norm_label": "canal de comunicacao entre o viewmodel e o controller."
+      "community": 8,
+      "norm_label": "canal de comunicacao entre o viewmodel e o controller.",
+      "id": "domain_signals_rationale_1"
     },
     {
       "label": "models.py",
@@ -2538,7 +2574,7 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/domain/models.py",
       "source_location": "L1",
       "id": "maria_cacau_features_home_sub_features_delivery_domain_models_py",
-      "community": 1,
+      "community": 3,
       "norm_label": "models.py"
     },
     {
@@ -2547,7 +2583,7 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/domain/models.py",
       "source_location": "L7",
       "id": "domain_models_deliverycount",
-      "community": 1,
+      "community": 3,
       "norm_label": "deliverycount"
     },
     {
@@ -2556,7 +2592,7 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/domain/models.py",
       "source_location": "L13",
       "id": "domain_models_deliveriessummary",
-      "community": 1,
+      "community": 3,
       "norm_label": "deliveriessummary"
     },
     {
@@ -2565,7 +2601,7 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/domain/models.py",
       "source_location": "L20",
       "id": "domain_models_pendentorder",
-      "community": 1,
+      "community": 3,
       "norm_label": "pendentorder"
     },
     {
@@ -2574,7 +2610,7 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/domain/models.py",
       "source_location": "L29",
       "id": "domain_models_deliverymodel",
-      "community": 15,
+      "community": 3,
       "norm_label": "deliverymodel"
     },
     {
@@ -2583,7 +2619,7 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/domain/models.py",
       "source_location": "L35",
       "id": "domain_models_deliveryviewdata",
-      "community": 15,
+      "community": 1,
       "norm_label": "deliveryviewdata"
     },
     {
@@ -2591,9 +2627,9 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/features/cpf_validation/domain/models.py",
       "source_location": "L1",
-      "id": "domain_models_rationale_1",
-      "community": 1,
-      "norm_label": "models utilizados no modulo"
+      "community": 8,
+      "norm_label": "models utilizados no modulo",
+      "id": "domain_models_rationale_1"
     },
     {
       "label": "events.py",
@@ -2618,9 +2654,9 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/features/cpf_validation/domain/events.py",
       "source_location": "L1",
-      "id": "domain_events_rationale_1",
       "community": 9,
-      "norm_label": "eventos de observabilidade da feature cpf validation."
+      "norm_label": "eventos de observabilidade da feature cpf validation.",
+      "id": "domain_events_rationale_1"
     },
     {
       "label": "__init__.py",
@@ -2628,7 +2664,7 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/domain/__init__.py",
       "source_location": "L1",
       "id": "maria_cacau_features_home_sub_features_delivery_domain_init_py",
-      "community": 1,
+      "community": 3,
       "norm_label": "__init__.py"
     },
     {
@@ -2637,7 +2673,7 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/presentation/controller.py",
       "source_location": "L1",
       "id": "maria_cacau_features_home_sub_features_delivery_presentation_controller_py",
-      "community": 1,
+      "community": 3,
       "norm_label": "controller.py"
     },
     {
@@ -2646,7 +2682,7 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/presentation/controller.py",
       "source_location": "L15",
       "id": "presentation_controller_deliverycontroller",
-      "community": 3,
+      "community": 1,
       "norm_label": "deliverycontroller"
     },
     {
@@ -2655,7 +2691,7 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/presentation/controller.py",
       "source_location": "L16",
       "id": "presentation_controller_deliverycontroller_init",
-      "community": 3,
+      "community": 1,
       "norm_label": ".__init__()"
     },
     {
@@ -2664,7 +2700,7 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/presentation/controller.py",
       "source_location": "L22",
       "id": "presentation_controller_deliverycontroller_setupactions",
-      "community": 3,
+      "community": 1,
       "norm_label": "._setupactions()"
     },
     {
@@ -2673,7 +2709,7 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/presentation/controller.py",
       "source_location": "L33",
       "id": "presentation_controller_deliverycontroller_on_generate_report",
-      "community": 3,
+      "community": 1,
       "norm_label": ".on_generate_report()"
     },
     {
@@ -2682,7 +2718,7 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/presentation/controller.py",
       "source_location": "L42",
       "id": "presentation_controller_deliverycontroller_on_copy_report",
-      "community": 3,
+      "community": 1,
       "norm_label": ".on_copy_report()"
     },
     {
@@ -2691,7 +2727,7 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/presentation/controller.py",
       "source_location": "L45",
       "id": "presentation_controller_deliverycontroller_on_copy_graph",
-      "community": 3,
+      "community": 1,
       "norm_label": ".on_copy_graph()"
     },
     {
@@ -2700,7 +2736,7 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/presentation/controller.py",
       "source_location": "L48",
       "id": "presentation_controller_deliverycontroller_on_download_graph",
-      "community": 3,
+      "community": 1,
       "norm_label": ".on_download_graph()"
     },
     {
@@ -2709,7 +2745,7 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/presentation/controller.py",
       "source_location": "L53",
       "id": "presentation_controller_deliverycontroller_handle_error",
-      "community": 3,
+      "community": 1,
       "norm_label": ".handle_error()"
     },
     {
@@ -2718,7 +2754,7 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/presentation/controller.py",
       "source_location": "L57",
       "id": "presentation_controller_deliverycontroller_handle_report_generated",
-      "community": 3,
+      "community": 1,
       "norm_label": ".handle_report_generated()"
     },
     {
@@ -2726,27 +2762,27 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/features/cpf_validation/presentation/controller.py",
       "source_location": "L1",
-      "id": "presentation_controller_rationale_1",
       "community": 1,
-      "norm_label": "controller da feature cpf validation: conecta signals da view ao viewmodel e tra"
+      "norm_label": "controller da feature cpf validation: conecta signals da view ao viewmodel e tra",
+      "id": "presentation_controller_rationale_1"
     },
     {
       "label": "Inicia a consulta: trava a view, dispara o ViewModel e registra o timestamp para",
       "file_type": "rationale",
       "source_file": "maria_cacau/features/home/sub_features/delivery/presentation/controller.py",
       "source_location": "L34",
-      "id": "presentation_controller_rationale_34",
-      "community": 15,
-      "norm_label": "inicia a consulta: trava a view, dispara o viewmodel e registra o timestamp para"
+      "community": 1,
+      "norm_label": "inicia a consulta: trava a view, dispara o viewmodel e registra o timestamp para",
+      "id": "presentation_controller_rationale_34"
     },
     {
       "label": "Recebe o resultado do ViewModel, atualiza a view e loga a dura\u00e7\u00e3o da consulta.",
       "file_type": "rationale",
       "source_file": "maria_cacau/features/home/sub_features/delivery/presentation/controller.py",
       "source_location": "L58",
-      "id": "presentation_controller_rationale_58",
-      "community": 15,
-      "norm_label": "recebe o resultado do viewmodel, atualiza a view e loga a duracao da consulta."
+      "community": 1,
+      "norm_label": "recebe o resultado do viewmodel, atualiza a view e loga a duracao da consulta.",
+      "id": "presentation_controller_rationale_58"
     },
     {
       "label": "__init__.py",
@@ -2754,7 +2790,7 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/presentation/__init__.py",
       "source_location": "L1",
       "id": "maria_cacau_features_home_sub_features_delivery_presentation_init_py",
-      "community": 1,
+      "community": 3,
       "norm_label": "__init__.py"
     },
     {
@@ -2763,7 +2799,7 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/presentation/viewmodel.py",
       "source_location": "L1",
       "id": "maria_cacau_features_home_sub_features_delivery_presentation_viewmodel_py",
-      "community": 1,
+      "community": 3,
       "norm_label": "viewmodel.py"
     },
     {
@@ -2772,7 +2808,7 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/presentation/viewmodel.py",
       "source_location": "L12",
       "id": "presentation_viewmodel_deliveryviewmodel",
-      "community": 15,
+      "community": 1,
       "norm_label": "deliveryviewmodel"
     },
     {
@@ -2781,7 +2817,7 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/presentation/viewmodel.py",
       "source_location": "L13",
       "id": "presentation_viewmodel_deliveryviewmodel_init",
-      "community": 15,
+      "community": 3,
       "norm_label": ".__init__()"
     },
     {
@@ -2790,7 +2826,7 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/presentation/viewmodel.py",
       "source_location": "L17",
       "id": "presentation_viewmodel_deliveryviewmodel_on_generate",
-      "community": 15,
+      "community": 1,
       "norm_label": ".on_generate()"
     },
     {
@@ -2799,7 +2835,7 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/presentation/viewmodel.py",
       "source_location": "L20",
       "id": "presentation_viewmodel_deliveryviewmodel_fetch",
-      "community": 15,
+      "community": 1,
       "norm_label": "._fetch()"
     },
     {
@@ -2808,7 +2844,7 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/presentation/viewmodel.py",
       "source_location": "L31",
       "id": "presentation_viewmodel_deliveryviewmodel_build_view_data",
-      "community": 15,
+      "community": 1,
       "norm_label": "._build_view_data()"
     },
     {
@@ -2817,7 +2853,7 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/presentation/viewmodel.py",
       "source_location": "L37",
       "id": "presentation_viewmodel_deliveryviewmodel_build_report",
-      "community": 15,
+      "community": 1,
       "norm_label": "._build_report()"
     },
     {
@@ -2825,18 +2861,18 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/features/cpf_validation/presentation/viewmodel.py",
       "source_location": "L1",
-      "id": "presentation_viewmodel_rationale_1",
-      "community": 1,
-      "norm_label": "viewmodel da feature cpf validation: executa o usecase e emite resultado via sig"
+      "community": 3,
+      "norm_label": "viewmodel da feature cpf validation: executa o usecase e emite resultado via sig",
+      "id": "presentation_viewmodel_rationale_1"
     },
     {
       "label": "Roda o UseCase, monta o ViewData e emite sucesso ou erro \u2014 sempre via signal par",
       "file_type": "rationale",
       "source_file": "maria_cacau/features/home/sub_features/delivery/presentation/viewmodel.py",
       "source_location": "L21",
-      "id": "presentation_viewmodel_rationale_21",
-      "community": 15,
-      "norm_label": "roda o usecase, monta o viewdata e emite sucesso ou erro \u2014 sempre via signal par"
+      "community": 1,
+      "norm_label": "roda o usecase, monta o viewdata e emite sucesso ou erro \u2014 sempre via signal par",
+      "id": "presentation_viewmodel_rationale_21"
     },
     {
       "label": "view.py",
@@ -2844,7 +2880,7 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/presentation/view.py",
       "source_location": "L1",
       "id": "maria_cacau_features_home_sub_features_delivery_presentation_view_py",
-      "community": 1,
+      "community": 3,
       "norm_label": "view.py"
     },
     {
@@ -2853,7 +2889,7 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/presentation/view.py",
       "source_location": "L15",
       "id": "presentation_view_deliveryview",
-      "community": 8,
+      "community": 1,
       "norm_label": "deliveryview"
     },
     {
@@ -2862,7 +2898,7 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/presentation/view.py",
       "source_location": "L21",
       "id": "presentation_view_deliveryview_init",
-      "community": 8,
+      "community": 1,
       "norm_label": ".__init__()"
     },
     {
@@ -2871,7 +2907,7 @@
       "source_file": "maria_cacau/features/auth/presentation/view.py",
       "source_location": "L19",
       "id": "presentation_view_view_title",
-      "community": 1,
+      "community": 3,
       "norm_label": "view_title()"
     },
     {
@@ -2880,7 +2916,7 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/presentation/view.py",
       "source_location": "L31",
       "id": "presentation_view_deliveryview_setup_ui",
-      "community": 8,
+      "community": 1,
       "norm_label": "._setup_ui()"
     },
     {
@@ -2889,7 +2925,7 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/presentation/view.py",
       "source_location": "L36",
       "id": "presentation_view_deliveryview_setup_components",
-      "community": 8,
+      "community": 1,
       "norm_label": "._setup_components()"
     },
     {
@@ -2898,7 +2934,7 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/presentation/view.py",
       "source_location": "L61",
       "id": "presentation_view_deliveryview_setup_layout",
-      "community": 8,
+      "community": 1,
       "norm_label": "._setup_layout()"
     },
     {
@@ -2907,7 +2943,7 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/presentation/view.py",
       "source_location": "L84",
       "id": "presentation_view_deliveryview_update_buttons_state",
-      "community": 8,
+      "community": 1,
       "norm_label": "._update_buttons_state()"
     },
     {
@@ -2916,7 +2952,7 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/presentation/view.py",
       "source_location": "L91",
       "id": "presentation_view_deliveryview_get_date",
-      "community": 3,
+      "community": 1,
       "norm_label": ".get_date()"
     },
     {
@@ -2925,7 +2961,7 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/presentation/view.py",
       "source_location": "L94",
       "id": "presentation_view_deliveryview_update_data",
-      "community": 8,
+      "community": 1,
       "norm_label": ".update_data()"
     },
     {
@@ -2934,7 +2970,7 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/presentation/view.py",
       "source_location": "L100",
       "id": "presentation_view_deliveryview_activate_button_state",
-      "community": 8,
+      "community": 1,
       "norm_label": ".activate_button_state()"
     },
     {
@@ -2943,7 +2979,7 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/presentation/view.py",
       "source_location": "L103",
       "id": "presentation_view_deliveryview_clear_content",
-      "community": 8,
+      "community": 1,
       "norm_label": ".clear_content()"
     },
     {
@@ -2952,7 +2988,7 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/presentation/view.py",
       "source_location": "L108",
       "id": "presentation_view_deliveryview_prepare_to_fetch",
-      "community": 8,
+      "community": 1,
       "norm_label": ".prepare_to_fetch()"
     },
     {
@@ -2960,9 +2996,9 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/features/cpf_validation/presentation/view.py",
       "source_location": "L1",
-      "id": "presentation_view_rationale_1",
-      "community": 1,
-      "norm_label": "view da feature cpf validation: dialog para validacao de cpf."
+      "community": 3,
+      "norm_label": "view da feature cpf validation: dialog para validacao de cpf.",
+      "id": "presentation_view_rationale_1"
     },
     {
       "label": "__init__.py",
@@ -2970,7 +3006,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/__init__.py",
       "source_location": "L1",
       "id": "maria_cacau_features_home_sub_features_summary_init_py",
-      "community": 1,
+      "community": 3,
       "norm_label": "__init__.py"
     },
     {
@@ -2979,7 +3015,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/data/mapper.py",
       "source_location": "L1",
       "id": "maria_cacau_features_home_sub_features_summary_data_mapper_py",
-      "community": 1,
+      "community": 3,
       "norm_label": "mapper.py"
     },
     {
@@ -2988,7 +3024,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/data/mapper.py",
       "source_location": "L23",
       "id": "data_mapper_orderssummarymapper",
-      "community": 1,
+      "community": 3,
       "norm_label": "orderssummarymapper"
     },
     {
@@ -2997,7 +3033,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/data/__init__.py",
       "source_location": "L1",
       "id": "maria_cacau_features_home_sub_features_summary_data_init_py",
-      "community": 1,
+      "community": 3,
       "norm_label": "__init__.py"
     },
     {
@@ -3006,7 +3042,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/data/apis.py",
       "source_location": "L1",
       "id": "maria_cacau_features_home_sub_features_summary_data_apis_py",
-      "community": 2,
+      "community": 3,
       "norm_label": "apis.py"
     },
     {
@@ -3015,7 +3051,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/data/apis.py",
       "source_location": "L6",
       "id": "data_apis_orderssummaryapi",
-      "community": 2,
+      "community": 3,
       "norm_label": "orderssummaryapi"
     },
     {
@@ -3024,7 +3060,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/data/apis.py",
       "source_location": "L11",
       "id": "data_apis_orderssummaryapi_for_period",
-      "community": 2,
+      "community": 3,
       "norm_label": ".for_period()"
     },
     {
@@ -3033,7 +3069,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/data/repository.py",
       "source_location": "L1",
       "id": "maria_cacau_features_home_sub_features_summary_data_repository_py",
-      "community": 1,
+      "community": 3,
       "norm_label": "repository.py"
     },
     {
@@ -3042,7 +3078,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/data/repository.py",
       "source_location": "L12",
       "id": "data_repository_summaryrepository",
-      "community": 1,
+      "community": 3,
       "norm_label": "summaryrepository"
     },
     {
@@ -3051,7 +3087,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/data/repository.py",
       "source_location": "L13",
       "id": "data_repository_summaryrepository_get_by_period",
-      "community": 2,
+      "community": 3,
       "norm_label": ".get_by_period()"
     },
     {
@@ -3060,7 +3096,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/domain/use_case.py",
       "source_location": "L1",
       "id": "maria_cacau_features_home_sub_features_summary_domain_use_case_py",
-      "community": 1,
+      "community": 3,
       "norm_label": "use_case.py"
     },
     {
@@ -3069,7 +3105,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/domain/use_case.py",
       "source_location": "L9",
       "id": "domain_use_case_summaryusecase",
-      "community": 1,
+      "community": 3,
       "norm_label": "summaryusecase"
     },
     {
@@ -3078,7 +3114,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/domain/use_case.py",
       "source_location": "L10",
       "id": "domain_use_case_summaryusecase_init",
-      "community": 1,
+      "community": 3,
       "norm_label": ".__init__()"
     },
     {
@@ -3087,7 +3123,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/domain/use_case.py",
       "source_location": "L13",
       "id": "domain_use_case_summaryusecase_get_summary",
-      "community": 1,
+      "community": 3,
       "norm_label": ".get_summary()"
     },
     {
@@ -3096,7 +3132,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/domain/use_case.py",
       "source_location": "L17",
       "id": "domain_use_case_summaryusecase_build_summary",
-      "community": 1,
+      "community": 3,
       "norm_label": "._build_summary()"
     },
     {
@@ -3105,7 +3141,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/domain/use_case.py",
       "source_location": "L51",
       "id": "domain_use_case_to_sorted_counts",
-      "community": 1,
+      "community": 3,
       "norm_label": "_to_sorted_counts()"
     },
     {
@@ -3114,7 +3150,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/domain/signals.py",
       "source_location": "L1",
       "id": "maria_cacau_features_home_sub_features_summary_domain_signals_py",
-      "community": 1,
+      "community": 3,
       "norm_label": "signals.py"
     },
     {
@@ -3123,7 +3159,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/domain/signals.py",
       "source_location": "L8",
       "id": "domain_signals_summarysignals",
-      "community": 1,
+      "community": 10,
       "norm_label": "summarysignals"
     },
     {
@@ -3132,7 +3168,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/domain/models.py",
       "source_location": "L1",
       "id": "maria_cacau_features_home_sub_features_summary_domain_models_py",
-      "community": 1,
+      "community": 3,
       "norm_label": "models.py"
     },
     {
@@ -3141,7 +3177,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/domain/models.py",
       "source_location": "L7",
       "id": "domain_models_productcount",
-      "community": 1,
+      "community": 3,
       "norm_label": "productcount"
     },
     {
@@ -3150,7 +3186,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/domain/models.py",
       "source_location": "L13",
       "id": "domain_models_orderdetail",
-      "community": 1,
+      "community": 3,
       "norm_label": "orderdetail"
     },
     {
@@ -3159,7 +3195,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/domain/models.py",
       "source_location": "L22",
       "id": "domain_models_daysummary",
-      "community": 1,
+      "community": 3,
       "norm_label": "daysummary"
     },
     {
@@ -3168,7 +3204,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/domain/models.py",
       "source_location": "L29",
       "id": "domain_models_productssummary",
-      "community": 1,
+      "community": 3,
       "norm_label": "productssummary"
     },
     {
@@ -3177,7 +3213,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/domain/models.py",
       "source_location": "L38",
       "id": "domain_models_productsviewdata",
-      "community": 1,
+      "community": 3,
       "norm_label": "productsviewdata"
     },
     {
@@ -3204,7 +3240,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/presentation/controller.py",
       "source_location": "L1",
       "id": "maria_cacau_features_home_sub_features_summary_presentation_controller_py",
-      "community": 1,
+      "community": 3,
       "norm_label": "controller.py"
     },
     {
@@ -3213,7 +3249,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/presentation/controller.py",
       "source_location": "L15",
       "id": "presentation_controller_summarycontroller",
-      "community": 3,
+      "community": 1,
       "norm_label": "summarycontroller"
     },
     {
@@ -3222,7 +3258,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/presentation/controller.py",
       "source_location": "L16",
       "id": "presentation_controller_summarycontroller_init",
-      "community": 3,
+      "community": 1,
       "norm_label": ".__init__()"
     },
     {
@@ -3231,7 +3267,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/presentation/controller.py",
       "source_location": "L21",
       "id": "presentation_controller_summarycontroller_setup_actions",
-      "community": 3,
+      "community": 1,
       "norm_label": "._setup_actions()"
     },
     {
@@ -3240,7 +3276,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/presentation/controller.py",
       "source_location": "L33",
       "id": "presentation_controller_summarycontroller_on_generate_report",
-      "community": 3,
+      "community": 1,
       "norm_label": ".on_generate_report()"
     },
     {
@@ -3249,7 +3285,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/presentation/controller.py",
       "source_location": "L40",
       "id": "presentation_controller_summarycontroller_on_copy_report",
-      "community": 3,
+      "community": 1,
       "norm_label": ".on_copy_report()"
     },
     {
@@ -3258,7 +3294,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/presentation/controller.py",
       "source_location": "L43",
       "id": "presentation_controller_summarycontroller_on_copy_graph",
-      "community": 3,
+      "community": 1,
       "norm_label": ".on_copy_graph()"
     },
     {
@@ -3267,7 +3303,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/presentation/controller.py",
       "source_location": "L46",
       "id": "presentation_controller_summarycontroller_on_download_graph",
-      "community": 3,
+      "community": 1,
       "norm_label": ".on_download_graph()"
     },
     {
@@ -3276,7 +3312,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/presentation/controller.py",
       "source_location": "L49",
       "id": "presentation_controller_summarycontroller_on_change_chart_type",
-      "community": 3,
+      "community": 1,
       "norm_label": ".on_change_chart_type()"
     },
     {
@@ -3285,7 +3321,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/presentation/controller.py",
       "source_location": "L54",
       "id": "presentation_controller_summarycontroller_handle_error",
-      "community": 3,
+      "community": 1,
       "norm_label": ".handle_error()"
     },
     {
@@ -3294,7 +3330,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/presentation/controller.py",
       "source_location": "L58",
       "id": "presentation_controller_summarycontroller_handle_report_generated",
-      "community": 3,
+      "community": 1,
       "norm_label": ".handle_report_generated()"
     },
     {
@@ -3312,7 +3348,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/presentation/viewmodel.py",
       "source_location": "L1",
       "id": "maria_cacau_features_home_sub_features_summary_presentation_viewmodel_py",
-      "community": 1,
+      "community": 3,
       "norm_label": "viewmodel.py"
     },
     {
@@ -3321,7 +3357,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/presentation/viewmodel.py",
       "source_location": "L14",
       "id": "presentation_viewmodel_summaryviewmodel",
-      "community": 1,
+      "community": 3,
       "norm_label": "summaryviewmodel"
     },
     {
@@ -3330,7 +3366,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/presentation/viewmodel.py",
       "source_location": "L15",
       "id": "presentation_viewmodel_summaryviewmodel_init",
-      "community": 1,
+      "community": 3,
       "norm_label": ".__init__()"
     },
     {
@@ -3339,7 +3375,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/presentation/viewmodel.py",
       "source_location": "L19",
       "id": "presentation_viewmodel_summaryviewmodel_on_generate",
-      "community": 1,
+      "community": 3,
       "norm_label": ".on_generate()"
     },
     {
@@ -3348,7 +3384,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/presentation/viewmodel.py",
       "source_location": "L22",
       "id": "presentation_viewmodel_summaryviewmodel_fetch",
-      "community": 1,
+      "community": 3,
       "norm_label": "._fetch()"
     },
     {
@@ -3357,7 +3393,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/presentation/viewmodel.py",
       "source_location": "L32",
       "id": "presentation_viewmodel_summaryviewmodel_build_view_data",
-      "community": 1,
+      "community": 3,
       "norm_label": "._build_view_data()"
     },
     {
@@ -3366,7 +3402,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/presentation/viewmodel.py",
       "source_location": "L38",
       "id": "presentation_viewmodel_summaryviewmodel_build_report",
-      "community": 1,
+      "community": 3,
       "norm_label": "._build_report()"
     },
     {
@@ -3375,7 +3411,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/presentation/viewmodel.py",
       "source_location": "L61",
       "id": "presentation_viewmodel_products_lines",
-      "community": 1,
+      "community": 3,
       "norm_label": "_products_lines()"
     },
     {
@@ -3384,7 +3420,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/presentation/view.py",
       "source_location": "L1",
       "id": "maria_cacau_features_home_sub_features_summary_presentation_view_py",
-      "community": 1,
+      "community": 3,
       "norm_label": "view.py"
     },
     {
@@ -3393,7 +3429,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/presentation/view.py",
       "source_location": "L16",
       "id": "presentation_view_summaryview",
-      "community": 3,
+      "community": 1,
       "norm_label": "summaryview"
     },
     {
@@ -3402,7 +3438,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/presentation/view.py",
       "source_location": "L23",
       "id": "presentation_view_summaryview_init",
-      "community": 3,
+      "community": 1,
       "norm_label": ".__init__()"
     },
     {
@@ -3411,7 +3447,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/presentation/view.py",
       "source_location": "L33",
       "id": "presentation_view_summaryview_setup_ui",
-      "community": 3,
+      "community": 1,
       "norm_label": "._setup_ui()"
     },
     {
@@ -3420,7 +3456,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/presentation/view.py",
       "source_location": "L38",
       "id": "presentation_view_summaryview_setup_components",
-      "community": 3,
+      "community": 1,
       "norm_label": "._setup_components()"
     },
     {
@@ -3429,7 +3465,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/presentation/view.py",
       "source_location": "L74",
       "id": "presentation_view_summaryview_setup_layout",
-      "community": 3,
+      "community": 1,
       "norm_label": "._setup_layout()"
     },
     {
@@ -3438,7 +3474,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/presentation/view.py",
       "source_location": "L105",
       "id": "presentation_view_summaryview_on_chart_type_changed",
-      "community": 3,
+      "community": 1,
       "norm_label": "._on_chart_type_changed()"
     },
     {
@@ -3447,7 +3483,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/presentation/view.py",
       "source_location": "L109",
       "id": "presentation_view_summaryview_update_buttons_state",
-      "community": 3,
+      "community": 1,
       "norm_label": "._update_buttons_state()"
     },
     {
@@ -3456,7 +3492,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/presentation/view.py",
       "source_location": "L117",
       "id": "presentation_view_summaryview_get_date_range",
-      "community": 3,
+      "community": 1,
       "norm_label": ".get_date_range()"
     },
     {
@@ -3465,7 +3501,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/presentation/view.py",
       "source_location": "L123",
       "id": "presentation_view_summaryview_update_data",
-      "community": 3,
+      "community": 1,
       "norm_label": ".update_data()"
     },
     {
@@ -3474,7 +3510,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/presentation/view.py",
       "source_location": "L129",
       "id": "presentation_view_summaryview_activate_button_state",
-      "community": 3,
+      "community": 1,
       "norm_label": ".activate_button_state()"
     },
     {
@@ -3483,7 +3519,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/presentation/view.py",
       "source_location": "L132",
       "id": "presentation_view_summaryview_clear_content",
-      "community": 3,
+      "community": 1,
       "norm_label": ".clear_content()"
     },
     {
@@ -3492,7 +3528,7 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/presentation/view.py",
       "source_location": "L137",
       "id": "presentation_view_summaryview_prepare_to_fetch",
-      "community": 3,
+      "community": 1,
       "norm_label": ".prepare_to_fetch()"
     },
     {
@@ -3662,9 +3698,9 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/features/sheets/data/repository.py",
       "source_location": "L78",
-      "id": "data_repository_rationale_78",
       "community": 2,
-      "norm_label": "retorna o sheet_id da ultima planilha salva em cache, sem http."
+      "norm_label": "retorna o sheet_id da ultima planilha salva em cache, sem http.",
+      "id": "data_repository_rationale_78"
     },
     {
       "label": "use_case.py",
@@ -3762,7 +3798,7 @@
       "source_file": "maria_cacau/features/sheets/domain/signals.py",
       "source_location": "L6",
       "id": "domain_signals_sheetssignals",
-      "community": 1,
+      "community": 10,
       "norm_label": "sheetssignals"
     },
     {
@@ -3879,7 +3915,7 @@
       "source_file": "maria_cacau/features/sheets/presentation/controller.py",
       "source_location": "L82",
       "id": "presentation_controller_sheetscontroller_on_remove_requested",
-      "community": 3,
+      "community": 7,
       "norm_label": "._on_remove_requested()"
     },
     {
@@ -3906,7 +3942,7 @@
       "source_file": "maria_cacau/features/sheets/presentation/controller.py",
       "source_location": "L101",
       "id": "presentation_controller_sheetscontroller_on_select",
-      "community": 3,
+      "community": 7,
       "norm_label": "._on_select()"
     },
     {
@@ -3924,7 +3960,7 @@
       "source_file": "maria_cacau/features/sheets/presentation/controller.py",
       "source_location": "L108",
       "id": "presentation_controller_sheetscontroller_on_removed",
-      "community": 3,
+      "community": 7,
       "norm_label": "._on_removed()"
     },
     {
@@ -3951,7 +3987,7 @@
       "source_file": "maria_cacau/features/sheets/presentation/controller.py",
       "source_location": "L121",
       "id": "presentation_controller_sheetscontroller_on_error",
-      "community": 3,
+      "community": 1,
       "norm_label": "._on_error()"
     },
     {
@@ -3978,7 +4014,7 @@
       "source_file": "maria_cacau/features/sheets/presentation/viewmodel.py",
       "source_location": "L11",
       "id": "presentation_viewmodel_sheetsviewmodel",
-      "community": 4,
+      "community": 12,
       "norm_label": "sheetsviewmodel"
     },
     {
@@ -3987,7 +4023,7 @@
       "source_file": "maria_cacau/features/sheets/presentation/viewmodel.py",
       "source_location": "L12",
       "id": "presentation_viewmodel_sheetsviewmodel_init",
-      "community": 4,
+      "community": 2,
       "norm_label": ".__init__()"
     },
     {
@@ -3996,7 +4032,7 @@
       "source_file": "maria_cacau/features/sheets/presentation/viewmodel.py",
       "source_location": "L18",
       "id": "presentation_viewmodel_sheetsviewmodel_load_all",
-      "community": 4,
+      "community": 2,
       "norm_label": ".load_all()"
     },
     {
@@ -4014,7 +4050,7 @@
       "source_file": "maria_cacau/features/sheets/presentation/viewmodel.py",
       "source_location": "L26",
       "id": "presentation_viewmodel_sheetsviewmodel_update_name",
-      "community": 4,
+      "community": 12,
       "norm_label": ".update_name()"
     },
     {
@@ -4023,7 +4059,7 @@
       "source_file": "maria_cacau/features/sheets/presentation/viewmodel.py",
       "source_location": "L38",
       "id": "presentation_viewmodel_sheetsviewmodel_connect",
-      "community": 4,
+      "community": 12,
       "norm_label": ".connect()"
     },
     {
@@ -4032,7 +4068,7 @@
       "source_file": "maria_cacau/features/sheets/presentation/viewmodel.py",
       "source_location": "L49",
       "id": "presentation_viewmodel_sheetsviewmodel_select",
-      "community": 4,
+      "community": 12,
       "norm_label": ".select()"
     },
     {
@@ -4041,7 +4077,7 @@
       "source_file": "maria_cacau/features/sheets/presentation/viewmodel.py",
       "source_location": "L59",
       "id": "presentation_viewmodel_sheetsviewmodel_remove",
-      "community": 4,
+      "community": 12,
       "norm_label": ".remove()"
     },
     {
@@ -4050,7 +4086,7 @@
       "source_file": "maria_cacau/features/sheets/presentation/view/sheet_create_view.py",
       "source_location": "L1",
       "id": "maria_cacau_features_sheets_presentation_view_sheet_create_view_py",
-      "community": 7,
+      "community": 4,
       "norm_label": "sheet_create_view.py"
     },
     {
@@ -4059,7 +4095,7 @@
       "source_file": "maria_cacau/features/sheets/presentation/view/sheet_create_view.py",
       "source_location": "L8",
       "id": "view_sheet_create_view_sheetcreateview",
-      "community": 7,
+      "community": 4,
       "norm_label": "sheetcreateview"
     },
     {
@@ -4068,7 +4104,7 @@
       "source_file": "",
       "source_location": "",
       "id": "qdialog",
-      "community": 7,
+      "community": 4,
       "norm_label": "qdialog"
     },
     {
@@ -4077,7 +4113,7 @@
       "source_file": "maria_cacau/features/sheets/presentation/view/sheet_create_view.py",
       "source_location": "L9",
       "id": "view_sheet_create_view_sheetcreateview_init",
-      "community": 7,
+      "community": 4,
       "norm_label": ".__init__()"
     },
     {
@@ -4086,7 +4122,7 @@
       "source_file": "maria_cacau/features/sheets/presentation/view/sheet_create_view.py",
       "source_location": "L14",
       "id": "view_sheet_create_view_link",
-      "community": 7,
+      "community": 4,
       "norm_label": "link()"
     },
     {
@@ -4095,7 +4131,7 @@
       "source_file": "maria_cacau/features/sheets/presentation/view/sheet_create_view.py",
       "source_location": "L18",
       "id": "view_sheet_create_view_name",
-      "community": 7,
+      "community": 4,
       "norm_label": "name()"
     },
     {
@@ -4104,7 +4140,7 @@
       "source_file": "maria_cacau/features/sheets/presentation/view/sheet_create_view.py",
       "source_location": "L21",
       "id": "view_sheet_create_view_sheetcreateview_setup_ui",
-      "community": 7,
+      "community": 4,
       "norm_label": "._setup_ui()"
     },
     {
@@ -4113,7 +4149,7 @@
       "source_file": "maria_cacau/features/sheets/presentation/view/sheet_create_view.py",
       "source_location": "L25",
       "id": "view_sheet_create_view_sheetcreateview_setup_components",
-      "community": 7,
+      "community": 4,
       "norm_label": "._setup_components()"
     },
     {
@@ -4122,7 +4158,7 @@
       "source_file": "maria_cacau/features/sheets/presentation/view/sheet_create_view.py",
       "source_location": "L41",
       "id": "view_sheet_create_view_sheetcreateview_setup_layout",
-      "community": 7,
+      "community": 4,
       "norm_label": "._setup_layout()"
     },
     {
@@ -4131,7 +4167,7 @@
       "source_file": "maria_cacau/features/sheets/presentation/view/sheets_menu_view.py",
       "source_location": "L1",
       "id": "maria_cacau_features_sheets_presentation_view_sheets_menu_view_py",
-      "community": 7,
+      "community": 4,
       "norm_label": "sheets_menu_view.py"
     },
     {
@@ -4167,7 +4203,7 @@
       "source_file": "maria_cacau/features/sheets/presentation/view/sheets_menu_view.py",
       "source_location": "L19",
       "id": "view_sheets_menu_view_view_title",
-      "community": 7,
+      "community": 4,
       "norm_label": "view_title()"
     },
     {
@@ -4230,7 +4266,7 @@
       "source_file": "maria_cacau/features/sheets/presentation/view/__init__.py",
       "source_location": "L1",
       "id": "maria_cacau_features_sheets_presentation_view_init_py",
-      "community": 7,
+      "community": 4,
       "norm_label": "__init__.py"
     },
     {
@@ -4257,7 +4293,7 @@
       "source_file": "maria_cacau/features/auth/data/apis.py",
       "source_location": "L1",
       "id": "maria_cacau_features_auth_data_apis_py",
-      "community": 2,
+      "community": 3,
       "norm_label": "apis.py"
     },
     {
@@ -4364,36 +4400,36 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/features/auth/data/repository.py",
       "source_location": "L16",
-      "id": "data_repository_rationale_16",
       "community": 2,
-      "norm_label": "le o json do caminho, envia ao backend e persiste apenas se der sucesso."
+      "norm_label": "le o json do caminho, envia ao backend e persiste apenas se der sucesso.",
+      "id": "data_repository_rationale_16"
     },
     {
       "label": "Reenvia credenciais ao backend com o sheet_id atual.",
       "file_type": "rationale",
       "source_file": "maria_cacau/features/auth/data/repository.py",
       "source_location": "L23",
-      "id": "data_repository_rationale_23",
       "community": 2,
-      "norm_label": "reenvia credenciais ao backend com o sheet_id atual."
+      "norm_label": "reenvia credenciais ao backend com o sheet_id atual.",
+      "id": "data_repository_rationale_23"
     },
     {
       "label": "L\u00ea credenciais do storage sem fazer chamada HTTP.",
       "file_type": "rationale",
       "source_file": "maria_cacau/features/auth/data/repository.py",
       "source_location": "L30",
-      "id": "data_repository_rationale_30",
       "community": 2,
-      "norm_label": "le credenciais do storage sem fazer chamada http."
+      "norm_label": "le credenciais do storage sem fazer chamada http.",
+      "id": "data_repository_rationale_30"
     },
     {
       "label": "Remove credenciais do storage e desautentica o backend.",
       "file_type": "rationale",
       "source_file": "maria_cacau/features/auth/data/repository.py",
       "source_location": "L35",
-      "id": "data_repository_rationale_35",
       "community": 2,
-      "norm_label": "remove credenciais do storage e desautentica o backend."
+      "norm_label": "remove credenciais do storage e desautentica o backend.",
+      "id": "data_repository_rationale_35"
     },
     {
       "label": "use_case.py",
@@ -4401,7 +4437,7 @@
       "source_file": "maria_cacau/features/auth/domain/use_case.py",
       "source_location": "L1",
       "id": "maria_cacau_features_auth_domain_use_case_py",
-      "community": 1,
+      "community": 10,
       "norm_label": "use_case.py"
     },
     {
@@ -4410,7 +4446,7 @@
       "source_file": "maria_cacau/features/auth/domain/use_case.py",
       "source_location": "L8",
       "id": "domain_use_case_authusecase",
-      "community": 1,
+      "community": 10,
       "norm_label": "authusecase"
     },
     {
@@ -4419,7 +4455,7 @@
       "source_file": "maria_cacau/features/auth/domain/use_case.py",
       "source_location": "L9",
       "id": "domain_use_case_authusecase_init",
-      "community": 1,
+      "community": 10,
       "norm_label": ".__init__()"
     },
     {
@@ -4428,7 +4464,7 @@
       "source_file": "maria_cacau/features/auth/domain/use_case.py",
       "source_location": "L12",
       "id": "domain_use_case_authusecase_configure",
-      "community": 1,
+      "community": 10,
       "norm_label": ".configure()"
     },
     {
@@ -4437,7 +4473,7 @@
       "source_file": "maria_cacau/features/auth/domain/use_case.py",
       "source_location": "L17",
       "id": "domain_use_case_authusecase_clear",
-      "community": 1,
+      "community": 10,
       "norm_label": ".clear()"
     },
     {
@@ -4445,18 +4481,18 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/features/auth/domain/use_case.py",
       "source_location": "L13",
-      "id": "domain_use_case_rationale_13",
-      "community": 1,
-      "norm_label": "le o arquivo json, salva em storage seguro e autentica o backend."
+      "community": 10,
+      "norm_label": "le o arquivo json, salva em storage seguro e autentica o backend.",
+      "id": "domain_use_case_rationale_13"
     },
     {
       "label": "Remove credenciais do storage e desautentica o backend.",
       "file_type": "rationale",
       "source_file": "maria_cacau/features/auth/domain/use_case.py",
       "source_location": "L18",
-      "id": "domain_use_case_rationale_18",
-      "community": 1,
-      "norm_label": "remove credenciais do storage e desautentica o backend."
+      "community": 10,
+      "norm_label": "remove credenciais do storage e desautentica o backend.",
+      "id": "domain_use_case_rationale_18"
     },
     {
       "label": "signals.py",
@@ -4464,7 +4500,7 @@
       "source_file": "maria_cacau/features/auth/domain/signals.py",
       "source_location": "L1",
       "id": "maria_cacau_features_auth_domain_signals_py",
-      "community": 1,
+      "community": 10,
       "norm_label": "signals.py"
     },
     {
@@ -4473,7 +4509,7 @@
       "source_file": "maria_cacau/features/auth/domain/signals.py",
       "source_location": "L8",
       "id": "domain_signals_authsignals",
-      "community": 1,
+      "community": 10,
       "norm_label": "authsignals"
     },
     {
@@ -4518,7 +4554,7 @@
       "source_file": "",
       "source_location": "",
       "id": "errormodel",
-      "community": 10,
+      "community": 12,
       "norm_label": "errormodel"
     },
     {
@@ -4572,7 +4608,7 @@
       "source_file": "maria_cacau/features/auth/presentation/controller.py",
       "source_location": "L1",
       "id": "maria_cacau_features_auth_presentation_controller_py",
-      "community": 1,
+      "community": 10,
       "norm_label": "controller.py"
     },
     {
@@ -4581,7 +4617,7 @@
       "source_file": "maria_cacau/features/auth/presentation/controller.py",
       "source_location": "L17",
       "id": "presentation_controller_authcontroller",
-      "community": 4,
+      "community": 10,
       "norm_label": "authcontroller"
     },
     {
@@ -4590,7 +4626,7 @@
       "source_file": "maria_cacau/features/auth/presentation/controller.py",
       "source_location": "L18",
       "id": "presentation_controller_authcontroller_init",
-      "community": 4,
+      "community": 10,
       "norm_label": ".__init__()"
     },
     {
@@ -4599,7 +4635,7 @@
       "source_file": "maria_cacau/features/auth/presentation/controller.py",
       "source_location": "L24",
       "id": "presentation_controller_authcontroller_setup_actions",
-      "community": 4,
+      "community": 10,
       "norm_label": "._setup_actions()"
     },
     {
@@ -4608,7 +4644,7 @@
       "source_file": "maria_cacau/features/auth/presentation/controller.py",
       "source_location": "L32",
       "id": "presentation_controller_authcontroller_on_configure",
-      "community": 4,
+      "community": 10,
       "norm_label": "._on_configure()"
     },
     {
@@ -4617,7 +4653,7 @@
       "source_file": "maria_cacau/features/auth/presentation/controller.py",
       "source_location": "L39",
       "id": "presentation_controller_authcontroller_on_clear",
-      "community": 4,
+      "community": 1,
       "norm_label": "._on_clear()"
     },
     {
@@ -4626,7 +4662,7 @@
       "source_file": "maria_cacau/features/auth/presentation/controller.py",
       "source_location": "L49",
       "id": "presentation_controller_authcontroller_on_configured",
-      "community": 4,
+      "community": 10,
       "norm_label": "._on_configured()"
     },
     {
@@ -4635,7 +4671,7 @@
       "source_file": "maria_cacau/features/auth/presentation/controller.py",
       "source_location": "L52",
       "id": "presentation_controller_authcontroller_on_cleared",
-      "community": 4,
+      "community": 10,
       "norm_label": "._on_cleared()"
     },
     {
@@ -4644,7 +4680,7 @@
       "source_file": "maria_cacau/features/auth/presentation/controller.py",
       "source_location": "L55",
       "id": "presentation_controller_authcontroller_on_error",
-      "community": 3,
+      "community": 1,
       "norm_label": "._on_error()"
     },
     {
@@ -4653,7 +4689,7 @@
       "source_file": "maria_cacau/features/auth/presentation/__init__.py",
       "source_location": "L1",
       "id": "maria_cacau_features_auth_presentation_init_py",
-      "community": 1,
+      "community": 10,
       "norm_label": "__init__.py"
     },
     {
@@ -4662,7 +4698,7 @@
       "source_file": "maria_cacau/features/auth/presentation/viewmodel.py",
       "source_location": "L1",
       "id": "maria_cacau_features_auth_presentation_viewmodel_py",
-      "community": 1,
+      "community": 10,
       "norm_label": "viewmodel.py"
     },
     {
@@ -4671,7 +4707,7 @@
       "source_file": "maria_cacau/features/auth/presentation/viewmodel.py",
       "source_location": "L12",
       "id": "presentation_viewmodel_authviewmodel",
-      "community": 1,
+      "community": 10,
       "norm_label": "authviewmodel"
     },
     {
@@ -4680,7 +4716,7 @@
       "source_file": "maria_cacau/features/auth/presentation/viewmodel.py",
       "source_location": "L13",
       "id": "presentation_viewmodel_authviewmodel_init",
-      "community": 1,
+      "community": 10,
       "norm_label": ".__init__()"
     },
     {
@@ -4689,7 +4725,7 @@
       "source_file": "maria_cacau/features/auth/presentation/viewmodel.py",
       "source_location": "L18",
       "id": "presentation_viewmodel_authviewmodel_configure",
-      "community": 4,
+      "community": 10,
       "norm_label": ".configure()"
     },
     {
@@ -4698,7 +4734,7 @@
       "source_file": "maria_cacau/features/auth/presentation/viewmodel.py",
       "source_location": "L29",
       "id": "presentation_viewmodel_authviewmodel_clear",
-      "community": 4,
+      "community": 1,
       "norm_label": ".clear()"
     },
     {
@@ -4707,7 +4743,7 @@
       "source_file": "maria_cacau/features/auth/presentation/view.py",
       "source_location": "L1",
       "id": "maria_cacau_features_auth_presentation_view_py",
-      "community": 1,
+      "community": 3,
       "norm_label": "view.py"
     },
     {
@@ -4716,7 +4752,7 @@
       "source_file": "maria_cacau/features/auth/presentation/view.py",
       "source_location": "L10",
       "id": "presentation_view_authview",
-      "community": 4,
+      "community": 10,
       "norm_label": "authview"
     },
     {
@@ -4725,7 +4761,7 @@
       "source_file": "maria_cacau/features/auth/presentation/view.py",
       "source_location": "L14",
       "id": "presentation_view_authview_init",
-      "community": 4,
+      "community": 10,
       "norm_label": ".__init__()"
     },
     {
@@ -4734,7 +4770,7 @@
       "source_file": "maria_cacau/features/auth/presentation/view.py",
       "source_location": "L22",
       "id": "presentation_view_authview_setup_actions",
-      "community": 4,
+      "community": 10,
       "norm_label": "._setup_actions()"
     },
     {
@@ -4752,7 +4788,7 @@
       "source_file": "maria_cacau/features/cpf_validation/domain/use_case.py",
       "source_location": "L1",
       "id": "maria_cacau_features_cpf_validation_domain_use_case_py",
-      "community": 1,
+      "community": 8,
       "norm_label": "use_case.py"
     },
     {
@@ -4761,7 +4797,7 @@
       "source_file": "maria_cacau/features/cpf_validation/domain/use_case.py",
       "source_location": "L6",
       "id": "domain_use_case_is_valid_cpf",
-      "community": 1,
+      "community": 8,
       "norm_label": "_is_valid_cpf()"
     },
     {
@@ -4770,7 +4806,7 @@
       "source_file": "maria_cacau/features/cpf_validation/domain/use_case.py",
       "source_location": "L29",
       "id": "domain_use_case_cpfvalidationusecase",
-      "community": 1,
+      "community": 8,
       "norm_label": "cpfvalidationusecase"
     },
     {
@@ -4779,7 +4815,7 @@
       "source_file": "maria_cacau/features/cpf_validation/domain/use_case.py",
       "source_location": "L30",
       "id": "domain_use_case_cpfvalidationusecase_validate",
-      "community": 1,
+      "community": 8,
       "norm_label": ".validate()"
     },
     {
@@ -4787,9 +4823,9 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/features/cpf_validation/domain/use_case.py",
       "source_location": "L7",
-      "id": "domain_use_case_rationale_7",
-      "community": 1,
-      "norm_label": "valida um cpf pela regra dos dois digitos verificadores (algoritmo da receita fe"
+      "community": 8,
+      "norm_label": "valida um cpf pela regra dos dois digitos verificadores (algoritmo da receita fe",
+      "id": "domain_use_case_rationale_7"
     },
     {
       "label": "signals.py",
@@ -4797,7 +4833,7 @@
       "source_file": "maria_cacau/features/cpf_validation/domain/signals.py",
       "source_location": "L1",
       "id": "maria_cacau_features_cpf_validation_domain_signals_py",
-      "community": 1,
+      "community": 8,
       "norm_label": "signals.py"
     },
     {
@@ -4806,7 +4842,7 @@
       "source_file": "maria_cacau/features/cpf_validation/domain/signals.py",
       "source_location": "L8",
       "id": "domain_signals_cpfvalidationsignals",
-      "community": 1,
+      "community": 8,
       "norm_label": "cpfvalidationsignals"
     },
     {
@@ -4815,7 +4851,7 @@
       "source_file": "maria_cacau/features/cpf_validation/domain/models.py",
       "source_location": "L1",
       "id": "maria_cacau_features_cpf_validation_domain_models_py",
-      "community": 1,
+      "community": 8,
       "norm_label": "models.py"
     },
     {
@@ -4824,7 +4860,7 @@
       "source_file": "maria_cacau/features/cpf_validation/domain/models.py",
       "source_location": "L7",
       "id": "domain_models_cpfvalidationresult",
-      "community": 1,
+      "community": 8,
       "norm_label": "cpfvalidationresult"
     },
     {
@@ -4842,7 +4878,7 @@
       "source_file": "maria_cacau/features/cpf_validation/domain/__init__.py",
       "source_location": "L1",
       "id": "maria_cacau_features_cpf_validation_domain_init_py",
-      "community": 1,
+      "community": 8,
       "norm_label": "__init__.py"
     },
     {
@@ -4851,7 +4887,7 @@
       "source_file": "maria_cacau/features/cpf_validation/presentation/controller.py",
       "source_location": "L1",
       "id": "maria_cacau_features_cpf_validation_presentation_controller_py",
-      "community": 1,
+      "community": 8,
       "norm_label": "controller.py"
     },
     {
@@ -4860,7 +4896,7 @@
       "source_file": "maria_cacau/features/cpf_validation/presentation/controller.py",
       "source_location": "L12",
       "id": "presentation_controller_cpfvalidationcontroller",
-      "community": 7,
+      "community": 8,
       "norm_label": "cpfvalidationcontroller"
     },
     {
@@ -4869,7 +4905,7 @@
       "source_file": "maria_cacau/features/cpf_validation/presentation/controller.py",
       "source_location": "L13",
       "id": "presentation_controller_cpfvalidationcontroller_init",
-      "community": 7,
+      "community": 8,
       "norm_label": ".__init__()"
     },
     {
@@ -4878,7 +4914,7 @@
       "source_file": "maria_cacau/features/cpf_validation/presentation/controller.py",
       "source_location": "L18",
       "id": "presentation_controller_cpfvalidationcontroller_setup_actions",
-      "community": 7,
+      "community": 8,
       "norm_label": "._setup_actions()"
     },
     {
@@ -4887,7 +4923,7 @@
       "source_file": "maria_cacau/features/cpf_validation/presentation/controller.py",
       "source_location": "L22",
       "id": "presentation_controller_cpfvalidationcontroller_on_validate",
-      "community": 7,
+      "community": 8,
       "norm_label": ".on_validate()"
     },
     {
@@ -4896,7 +4932,7 @@
       "source_file": "maria_cacau/features/cpf_validation/presentation/controller.py",
       "source_location": "L29",
       "id": "presentation_controller_cpfvalidationcontroller_handle_result",
-      "community": 7,
+      "community": 8,
       "norm_label": ".handle_result()"
     },
     {
@@ -4905,7 +4941,7 @@
       "source_file": "maria_cacau/features/cpf_validation/presentation/__init__.py",
       "source_location": "L1",
       "id": "maria_cacau_features_cpf_validation_presentation_init_py",
-      "community": 1,
+      "community": 8,
       "norm_label": "__init__.py"
     },
     {
@@ -4914,7 +4950,7 @@
       "source_file": "maria_cacau/features/cpf_validation/presentation/viewmodel.py",
       "source_location": "L1",
       "id": "maria_cacau_features_cpf_validation_presentation_viewmodel_py",
-      "community": 1,
+      "community": 8,
       "norm_label": "viewmodel.py"
     },
     {
@@ -4923,7 +4959,7 @@
       "source_file": "maria_cacau/features/cpf_validation/presentation/viewmodel.py",
       "source_location": "L7",
       "id": "presentation_viewmodel_cpfvalidationviewmodel",
-      "community": 1,
+      "community": 8,
       "norm_label": "cpfvalidationviewmodel"
     },
     {
@@ -4932,7 +4968,7 @@
       "source_file": "maria_cacau/features/cpf_validation/presentation/viewmodel.py",
       "source_location": "L8",
       "id": "presentation_viewmodel_cpfvalidationviewmodel_init",
-      "community": 1,
+      "community": 8,
       "norm_label": ".__init__()"
     },
     {
@@ -4941,7 +4977,7 @@
       "source_file": "maria_cacau/features/cpf_validation/presentation/viewmodel.py",
       "source_location": "L11",
       "id": "presentation_viewmodel_cpfvalidationviewmodel_on_validate",
-      "community": 1,
+      "community": 8,
       "norm_label": ".on_validate()"
     },
     {
@@ -4950,7 +4986,7 @@
       "source_file": "maria_cacau/features/cpf_validation/presentation/view.py",
       "source_location": "L1",
       "id": "maria_cacau_features_cpf_validation_presentation_view_py",
-      "community": 1,
+      "community": 8,
       "norm_label": "view.py"
     },
     {
@@ -4959,7 +4995,7 @@
       "source_file": "maria_cacau/features/cpf_validation/presentation/view.py",
       "source_location": "L14",
       "id": "presentation_view_cpfvalidationview",
-      "community": 7,
+      "community": 8,
       "norm_label": "cpfvalidationview"
     },
     {
@@ -4968,7 +5004,7 @@
       "source_file": "maria_cacau/features/cpf_validation/presentation/view.py",
       "source_location": "L20",
       "id": "presentation_view_cpfvalidationview_init",
-      "community": 7,
+      "community": 8,
       "norm_label": ".__init__()"
     },
     {
@@ -4977,7 +5013,7 @@
       "source_file": "maria_cacau/features/cpf_validation/presentation/view.py",
       "source_location": "L25",
       "id": "presentation_view_menu_title",
-      "community": 1,
+      "community": 8,
       "norm_label": "menu_title()"
     },
     {
@@ -4986,7 +5022,7 @@
       "source_file": "maria_cacau/features/cpf_validation/presentation/view.py",
       "source_location": "L28",
       "id": "presentation_view_cpfvalidationview_setup_ui",
-      "community": 7,
+      "community": 8,
       "norm_label": "._setup_ui()"
     },
     {
@@ -4995,7 +5031,7 @@
       "source_file": "maria_cacau/features/cpf_validation/presentation/view.py",
       "source_location": "L32",
       "id": "presentation_view_cpfvalidationview_setup_components",
-      "community": 7,
+      "community": 8,
       "norm_label": "._setup_components()"
     },
     {
@@ -5004,7 +5040,7 @@
       "source_file": "maria_cacau/features/cpf_validation/presentation/view.py",
       "source_location": "L46",
       "id": "presentation_view_cpfvalidationview_setup_layout",
-      "community": 7,
+      "community": 8,
       "norm_label": "._setup_layout()"
     },
     {
@@ -5013,7 +5049,7 @@
       "source_file": "maria_cacau/features/cpf_validation/presentation/view.py",
       "source_location": "L63",
       "id": "presentation_view_cpfvalidationview_get_cpf",
-      "community": 7,
+      "community": 8,
       "norm_label": ".get_cpf()"
     },
     {
@@ -5022,7 +5058,7 @@
       "source_file": "maria_cacau/features/cpf_validation/presentation/view.py",
       "source_location": "L66",
       "id": "presentation_view_cpfvalidationview_update_result",
-      "community": 7,
+      "community": 8,
       "norm_label": ".update_result()"
     },
     {
@@ -5274,7 +5310,7 @@
       "source_file": "maria_cacau/backend/_server.py",
       "source_location": "L1",
       "id": "maria_cacau_backend_server_py",
-      "community": 10,
+      "community": 17,
       "norm_label": "_server.py"
     },
     {
@@ -5283,7 +5319,7 @@
       "source_file": "maria_cacau/backend/_server.py",
       "source_location": "L15",
       "id": "backend_server_handle_data_source_error",
-      "community": 10,
+      "community": 17,
       "norm_label": "handle_data_source_error()"
     },
     {
@@ -5292,7 +5328,7 @@
       "source_file": "maria_cacau/backend/_server.py",
       "source_location": "L21",
       "id": "backend_server_handle_backend_error",
-      "community": 10,
+      "community": 17,
       "norm_label": "handle_backend_error()"
     },
     {
@@ -5301,7 +5337,7 @@
       "source_file": "maria_cacau/backend/_server.py",
       "source_location": "L26",
       "id": "backend_server_handle_unexpected_error",
-      "community": 10,
+      "community": 17,
       "norm_label": "handle_unexpected_error()"
     },
     {
@@ -5426,9 +5462,9 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/data_source/_google_sheets.py",
       "source_location": "L16",
-      "id": "data_source_google_sheets_rationale_16",
       "community": 0,
-      "norm_label": "implementacao de datasourceprotocol para google sheets via gspread."
+      "norm_label": "implementacao de datasourceprotocol para google sheets via gspread.",
+      "id": "data_source_google_sheets_rationale_16"
     },
     {
       "label": "__init__.py",
@@ -5445,7 +5481,7 @@
       "source_file": "maria_cacau/backend/data_source/_protocol.py",
       "source_location": "L1",
       "id": "maria_cacau_backend_data_source_protocol_py",
-      "community": 13,
+      "community": 7,
       "norm_label": "_protocol.py"
     },
     {
@@ -5454,7 +5490,7 @@
       "source_file": "maria_cacau/backend/data_source/_protocol.py",
       "source_location": "L5",
       "id": "data_source_protocol_datasourceprotocol",
-      "community": 13,
+      "community": 7,
       "norm_label": "datasourceprotocol"
     },
     {
@@ -5463,7 +5499,7 @@
       "source_file": "maria_cacau/backend/data_source/_protocol.py",
       "source_location": "L8",
       "id": "data_source_protocol_datasourceprotocol_is_ready",
-      "community": 13,
+      "community": 7,
       "norm_label": ".is_ready()"
     },
     {
@@ -5472,7 +5508,7 @@
       "source_file": "maria_cacau/backend/data_source/_protocol.py",
       "source_location": "L12",
       "id": "data_source_protocol_datasourceprotocol_set_credentials",
-      "community": 13,
+      "community": 7,
       "norm_label": ".set_credentials()"
     },
     {
@@ -5481,7 +5517,7 @@
       "source_file": "maria_cacau/backend/data_source/_protocol.py",
       "source_location": "L16",
       "id": "data_source_protocol_datasourceprotocol_clear_credentials",
-      "community": 13,
+      "community": 7,
       "norm_label": ".clear_credentials()"
     },
     {
@@ -5490,7 +5526,7 @@
       "source_file": "maria_cacau/backend/data_source/_protocol.py",
       "source_location": "L20",
       "id": "data_source_protocol_datasourceprotocol_clear_sheet",
-      "community": 13,
+      "community": 7,
       "norm_label": ".clear_sheet()"
     },
     {
@@ -5499,7 +5535,7 @@
       "source_file": "maria_cacau/backend/data_source/_protocol.py",
       "source_location": "L24",
       "id": "data_source_protocol_datasourceprotocol_set_sheet",
-      "community": 13,
+      "community": 7,
       "norm_label": ".set_sheet()"
     },
     {
@@ -5517,7 +5553,7 @@
       "source_file": "maria_cacau/backend/data_source/_protocol.py",
       "source_location": "L32",
       "id": "data_source_protocol_datasourceprotocol_fetch_orders_by_period",
-      "community": 13,
+      "community": 7,
       "norm_label": ".fetch_orders_by_period()"
     },
     {
@@ -5525,72 +5561,72 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/data_source/_protocol.py",
       "source_location": "L6",
-      "id": "data_source_protocol_rationale_6",
-      "community": 13,
-      "norm_label": "contrato agnostico de fonte de dados para pedidos."
+      "community": 7,
+      "norm_label": "contrato agnostico de fonte de dados para pedidos.",
+      "id": "data_source_protocol_rationale_6"
     },
     {
       "label": "Retorna True se credentials e sheet est\u00e3o configurados em mem\u00f3ria.",
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/data_source/_protocol.py",
       "source_location": "L9",
-      "id": "data_source_protocol_rationale_9",
-      "community": 13,
-      "norm_label": "retorna true se credentials e sheet estao configurados em memoria."
+      "community": 7,
+      "norm_label": "retorna true se credentials e sheet estao configurados em memoria.",
+      "id": "data_source_protocol_rationale_9"
     },
     {
       "label": "Autentica com o dict da service account e guarda o client em mem\u00f3ria.",
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/data_source/_protocol.py",
       "source_location": "L13",
-      "id": "data_source_protocol_rationale_13",
-      "community": 13,
-      "norm_label": "autentica com o dict da service account e guarda o client em memoria."
+      "community": 7,
+      "norm_label": "autentica com o dict da service account e guarda o client em memoria.",
+      "id": "data_source_protocol_rationale_13"
     },
     {
       "label": "Remove o client autenticado da mem\u00f3ria. Mant\u00e9m o sheet_id.",
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/data_source/_protocol.py",
       "source_location": "L17",
-      "id": "data_source_protocol_rationale_17",
-      "community": 13,
-      "norm_label": "remove o client autenticado da memoria. mantem o sheet_id."
+      "community": 7,
+      "norm_label": "remove o client autenticado da memoria. mantem o sheet_id.",
+      "id": "data_source_protocol_rationale_17"
     },
     {
       "label": "Remove a planilha ativa da mem\u00f3ria. Mant\u00e9m as credenciais.",
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/data_source/_protocol.py",
       "source_location": "L21",
-      "id": "data_source_protocol_rationale_21",
-      "community": 13,
-      "norm_label": "remove a planilha ativa da memoria. mantem as credenciais."
+      "community": 7,
+      "norm_label": "remove a planilha ativa da memoria. mantem as credenciais.",
+      "id": "data_source_protocol_rationale_21"
     },
     {
       "label": "Define a planilha ativa e dispara prewarm em background.",
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/data_source/_protocol.py",
       "source_location": "L25",
-      "id": "data_source_protocol_rationale_25",
-      "community": 13,
-      "norm_label": "define a planilha ativa e dispara prewarm em background."
+      "community": 7,
+      "norm_label": "define a planilha ativa e dispara prewarm em background.",
+      "id": "data_source_protocol_rationale_25"
     },
     {
       "label": "Retorna pedidos da data informada (DD/MM/YYYY).",
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/data_source/_protocol.py",
       "source_location": "L29",
-      "id": "data_source_protocol_rationale_29",
       "community": 6,
-      "norm_label": "retorna pedidos da data informada (dd/mm/yyyy)."
+      "norm_label": "retorna pedidos da data informada (dd/mm/yyyy).",
+      "id": "data_source_protocol_rationale_29"
     },
     {
       "label": "Retorna pedidos no intervalo de datas informado (DD/MM/YYYY).",
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/data_source/_protocol.py",
       "source_location": "L33",
-      "id": "data_source_protocol_rationale_33",
-      "community": 13,
-      "norm_label": "retorna pedidos no intervalo de datas informado (dd/mm/yyyy)."
+      "community": 7,
+      "norm_label": "retorna pedidos no intervalo de datas informado (dd/mm/yyyy).",
+      "id": "data_source_protocol_rationale_33"
     },
     {
       "label": "sheet_mapper.py",
@@ -5652,7 +5688,7 @@
       "source_file": "maria_cacau/backend/data_source/sheet_mapper.py",
       "source_location": "L82",
       "id": "data_source_sheet_mapper_paymentcols_slot",
-      "community": 12,
+      "community": 13,
       "norm_label": ".slot()"
     },
     {
@@ -5660,36 +5696,36 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/data_source/sheet_mapper.py",
       "source_location": "L1",
-      "id": "data_source_sheet_mapper_rationale_1",
       "community": 0,
-      "norm_label": "mapeamento de colunas e tabs da planilha."
+      "norm_label": "mapeamento de colunas e tabs da planilha.",
+      "id": "data_source_sheet_mapper_rationale_1"
     },
     {
       "label": "Colunas fixas da aba Cadastro, agrupadas por dom\u00ednio.",
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/data_source/sheet_mapper.py",
       "source_location": "L15",
-      "id": "data_source_sheet_mapper_rationale_15",
       "community": 0,
-      "norm_label": "colunas fixas da aba cadastro, agrupadas por dominio."
+      "norm_label": "colunas fixas da aba cadastro, agrupadas por dominio.",
+      "id": "data_source_sheet_mapper_rationale_15"
     },
     {
       "label": "Colunas dos slots de produto (1\u20137). Usar com .slot(n).",
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/data_source/sheet_mapper.py",
       "source_location": "L63",
-      "id": "data_source_sheet_mapper_rationale_63",
       "community": 0,
-      "norm_label": "colunas dos slots de produto (1\u20137). usar com .slot(n)."
+      "norm_label": "colunas dos slots de produto (1\u20137). usar com .slot(n).",
+      "id": "data_source_sheet_mapper_rationale_63"
     },
     {
       "label": "Colunas das parcelas de pagamento (1\u20136). Usar com .slot(n).",
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/data_source/sheet_mapper.py",
       "source_location": "L75",
-      "id": "data_source_sheet_mapper_rationale_75",
       "community": 0,
-      "norm_label": "colunas das parcelas de pagamento (1\u20136). usar com .slot(n)."
+      "norm_label": "colunas das parcelas de pagamento (1\u20136). usar com .slot(n).",
+      "id": "data_source_sheet_mapper_rationale_75"
     },
     {
       "label": "_normalizer.py",
@@ -5750,27 +5786,27 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/data_source/_normalizer.py",
       "source_location": "L1",
-      "id": "data_source_normalizer_rationale_1",
       "community": 0,
-      "norm_label": "normaliza headers inconsistentes da planilha para os valores canonicos dos enums"
+      "norm_label": "normaliza headers inconsistentes da planilha para os valores canonicos dos enums",
+      "id": "data_source_normalizer_rationale_1"
     },
     {
       "label": "Traduz headers reais da planilha para os nomes can\u00f4nicos definidos nos enums.",
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/data_source/_normalizer.py",
       "source_location": "L7",
-      "id": "data_source_normalizer_rationale_7",
       "community": 0,
-      "norm_label": "traduz headers reais da planilha para os nomes canonicos definidos nos enums."
+      "norm_label": "traduz headers reais da planilha para os nomes canonicos definidos nos enums.",
+      "id": "data_source_normalizer_rationale_7"
     },
     {
       "label": "Renomeia a coluna que segue prod3 para prod4, independente do header atual.",
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/data_source/_normalizer.py",
       "source_location": "L33",
-      "id": "data_source_normalizer_rationale_33",
       "community": 0,
-      "norm_label": "renomeia a coluna que segue prod3 para prod4, independente do header atual."
+      "norm_label": "renomeia a coluna que segue prod3 para prod4, independente do header atual.",
+      "id": "data_source_normalizer_rationale_33"
     },
     {
       "label": "_viewmodel.py",
@@ -5840,27 +5876,27 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/data_source/_viewmodel.py",
       "source_location": "L10",
-      "id": "data_source_viewmodel_rationale_10",
       "community": 0,
-      "norm_label": "encapsula o acesso a planilha: schema cacheado, prewarm e fetch."
+      "norm_label": "encapsula o acesso a planilha: schema cacheado, prewarm e fetch.",
+      "id": "data_source_viewmodel_rationale_10"
     },
     {
       "label": "Carrega cabe\u00e7alho e \u00edndice da coluna DATA na primeira chamada; no-op nas seguint",
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/data_source/_viewmodel.py",
       "source_location": "L29",
-      "id": "data_source_viewmodel_rationale_29",
       "community": 0,
-      "norm_label": "carrega cabecalho e indice da coluna data na primeira chamada; no-op nas seguint"
+      "norm_label": "carrega cabecalho e indice da coluna data na primeira chamada; no-op nas seguint",
+      "id": "data_source_viewmodel_rationale_29"
     },
     {
       "label": "Busca pedidos por datas usando dois passes para minimizar chamadas \u00e0 API.",
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/data_source/_viewmodel.py",
       "source_location": "L43",
-      "id": "data_source_viewmodel_rationale_43",
       "community": 0,
-      "norm_label": "busca pedidos por datas usando dois passes para minimizar chamadas a api."
+      "norm_label": "busca pedidos por datas usando dois passes para minimizar chamadas a api.",
+      "id": "data_source_viewmodel_rationale_43"
     },
     {
       "label": "_utils.py",
@@ -5912,36 +5948,36 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/data_source/_utils.py",
       "source_location": "L6",
-      "id": "data_source_utils_rationale_6",
       "community": 0,
-      "norm_label": "normaliza uma data para dd/mm/yyyy aceitando os formatos dd/mm/yy e dd/mm/yyyy."
+      "norm_label": "normaliza uma data para dd/mm/yyyy aceitando os formatos dd/mm/yy e dd/mm/yyyy.",
+      "id": "data_source_utils_rationale_6"
     },
     {
       "label": "Converte linhas da planilha em lista de dicts usando o cabe\u00e7alho como chaves (lo",
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/data_source/_utils.py",
       "source_location": "L16",
-      "id": "data_source_utils_rationale_16",
       "community": 0,
-      "norm_label": "converte linhas da planilha em lista de dicts usando o cabecalho como chaves (lo"
+      "norm_label": "converte linhas da planilha em lista de dicts usando o cabecalho como chaves (lo",
+      "id": "data_source_utils_rationale_16"
     },
     {
       "label": "Agrupa n\u00fameros de linha consecutivos em ranges A1 notation e divide em batches d",
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/data_source/_utils.py",
       "source_location": "L22",
-      "id": "data_source_utils_rationale_22",
       "community": 0,
-      "norm_label": "agrupa numeros de linha consecutivos em ranges a1 notation e divide em batches d"
+      "norm_label": "agrupa numeros de linha consecutivos em ranges a1 notation e divide em batches d",
+      "id": "data_source_utils_rationale_22"
     },
     {
       "label": "Retorna o conjunto de todas as datas (DD/MM/YYYY) entre start e end, inclusive.",
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/data_source/_utils.py",
       "source_location": "L35",
-      "id": "data_source_utils_rationale_35",
       "community": 0,
-      "norm_label": "retorna o conjunto de todas as datas (dd/mm/yyyy) entre start e end, inclusive."
+      "norm_label": "retorna o conjunto de todas as datas (dd/mm/yyyy) entre start e end, inclusive.",
+      "id": "data_source_utils_rationale_35"
     },
     {
       "label": "_handler.py",
@@ -6417,7 +6453,7 @@
       "source_file": "maria_cacau/backend/features/auth/service.py",
       "source_location": "L1",
       "id": "maria_cacau_backend_features_auth_service_py",
-      "community": 13,
+      "community": 7,
       "norm_label": "service.py"
     },
     {
@@ -6426,7 +6462,7 @@
       "source_file": "maria_cacau/backend/features/auth/service.py",
       "source_location": "L6",
       "id": "auth_service_authservice",
-      "community": 13,
+      "community": 7,
       "norm_label": "authservice"
     },
     {
@@ -6435,7 +6471,7 @@
       "source_file": "maria_cacau/backend/features/auth/service.py",
       "source_location": "L7",
       "id": "auth_service_authservice_connect",
-      "community": 13,
+      "community": 7,
       "norm_label": ".connect()"
     },
     {
@@ -6444,7 +6480,7 @@
       "source_file": "maria_cacau/backend/features/auth/service.py",
       "source_location": "L12",
       "id": "auth_service_authservice_disconnect",
-      "community": 13,
+      "community": 7,
       "norm_label": ".disconnect()"
     },
     {
@@ -6452,9 +6488,9 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/features/auth/service.py",
       "source_location": "L1",
-      "id": "auth_service_rationale_1",
-      "community": 13,
-      "norm_label": "service de autenticacao \u2014 gerencia o estado de conexao do datasource."
+      "community": 7,
+      "norm_label": "service de autenticacao \u2014 gerencia o estado de conexao do datasource.",
+      "id": "auth_service_rationale_1"
     },
     {
       "label": "route.py",
@@ -6462,7 +6498,7 @@
       "source_file": "maria_cacau/backend/features/auth/route.py",
       "source_location": "L1",
       "id": "maria_cacau_backend_features_auth_route_py",
-      "community": 13,
+      "community": 7,
       "norm_label": "route.py"
     },
     {
@@ -6480,7 +6516,7 @@
       "source_file": "maria_cacau/backend/features/auth/route.py",
       "source_location": "L19",
       "id": "auth_route_disconnect",
-      "community": 13,
+      "community": 7,
       "norm_label": "disconnect()"
     },
     {
@@ -6488,9 +6524,9 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/features/auth/route.py",
       "source_location": "L1",
-      "id": "auth_route_rationale_1",
-      "community": 13,
-      "norm_label": "rotas de autenticacao"
+      "community": 7,
+      "norm_label": "rotas de autenticacao",
+      "id": "auth_route_rationale_1"
     },
     {
       "label": "__init__.py",
@@ -6498,7 +6534,7 @@
       "source_file": "maria_cacau/backend/features/auth/__init__.py",
       "source_location": "L1",
       "id": "maria_cacau_backend_features_auth_init_py",
-      "community": 13,
+      "community": 7,
       "norm_label": "__init__.py"
     },
     {
@@ -6525,7 +6561,7 @@
       "source_file": "maria_cacau/backend/features/orders/shared/models.py",
       "source_location": "L1",
       "id": "maria_cacau_backend_features_orders_shared_models_py",
-      "community": 12,
+      "community": 13,
       "norm_label": "models.py"
     },
     {
@@ -6534,7 +6570,7 @@
       "source_file": "maria_cacau/backend/features/orders/shared/models.py",
       "source_location": "L5",
       "id": "shared_models_address",
-      "community": 12,
+      "community": 13,
       "norm_label": "address"
     },
     {
@@ -6543,7 +6579,7 @@
       "source_file": "maria_cacau/backend/features/orders/shared/models.py",
       "source_location": "L18",
       "id": "shared_models_event",
-      "community": 12,
+      "community": 13,
       "norm_label": "event"
     },
     {
@@ -6552,7 +6588,7 @@
       "source_file": "maria_cacau/backend/features/orders/shared/models.py",
       "source_location": "L24",
       "id": "shared_models_customer",
-      "community": 12,
+      "community": 13,
       "norm_label": "customer"
     },
     {
@@ -6561,7 +6597,7 @@
       "source_file": "maria_cacau/backend/features/orders/shared/models.py",
       "source_location": "L33",
       "id": "shared_models_receiver",
-      "community": 12,
+      "community": 13,
       "norm_label": "receiver"
     },
     {
@@ -6570,7 +6606,7 @@
       "source_file": "maria_cacau/backend/features/orders/shared/models.py",
       "source_location": "L40",
       "id": "shared_models_customization",
-      "community": 12,
+      "community": 13,
       "norm_label": "customization"
     },
     {
@@ -6579,7 +6615,7 @@
       "source_file": "maria_cacau/backend/features/orders/shared/models.py",
       "source_location": "L48",
       "id": "shared_models_productitem",
-      "community": 12,
+      "community": 13,
       "norm_label": "productitem"
     },
     {
@@ -6588,7 +6624,7 @@
       "source_file": "maria_cacau/backend/features/orders/shared/models.py",
       "source_location": "L56",
       "id": "shared_models_paymentitem",
-      "community": 12,
+      "community": 13,
       "norm_label": "paymentitem"
     },
     {
@@ -6597,7 +6633,7 @@
       "source_file": "maria_cacau/backend/features/orders/shared/models.py",
       "source_location": "L65",
       "id": "shared_models_financial",
-      "community": 12,
+      "community": 13,
       "norm_label": "financial"
     },
     {
@@ -6606,7 +6642,7 @@
       "source_file": "maria_cacau/backend/features/orders/shared/models.py",
       "source_location": "L76",
       "id": "shared_models_delivery",
-      "community": 12,
+      "community": 13,
       "norm_label": "delivery"
     },
     {
@@ -6615,7 +6651,7 @@
       "source_file": "maria_cacau/backend/features/orders/shared/models.py",
       "source_location": "L86",
       "id": "shared_models_order",
-      "community": 12,
+      "community": 13,
       "norm_label": "order"
     },
     {
@@ -6624,7 +6660,7 @@
       "source_file": "maria_cacau/backend/features/orders/shared/mapper.py",
       "source_location": "L1",
       "id": "maria_cacau_backend_features_orders_shared_mapper_py",
-      "community": 12,
+      "community": 13,
       "norm_label": "mapper.py"
     },
     {
@@ -6633,7 +6669,7 @@
       "source_file": "maria_cacau/backend/features/orders/shared/mapper.py",
       "source_location": "L11",
       "id": "shared_mapper_ordermapper",
-      "community": 12,
+      "community": 13,
       "norm_label": "ordermapper"
     },
     {
@@ -6642,7 +6678,7 @@
       "source_file": "maria_cacau/backend/features/orders/shared/mapper.py",
       "source_location": "L15",
       "id": "shared_mapper_to_model",
-      "community": 12,
+      "community": 13,
       "norm_label": "to_model()"
     },
     {
@@ -6651,7 +6687,7 @@
       "source_file": "maria_cacau/backend/features/orders/shared/mapper.py",
       "source_location": "L32",
       "id": "shared_mapper_customer",
-      "community": 12,
+      "community": 13,
       "norm_label": "_customer()"
     },
     {
@@ -6660,7 +6696,7 @@
       "source_file": "maria_cacau/backend/features/orders/shared/mapper.py",
       "source_location": "L42",
       "id": "shared_mapper_receiver",
-      "community": 12,
+      "community": 13,
       "norm_label": "_receiver()"
     },
     {
@@ -6669,7 +6705,7 @@
       "source_file": "maria_cacau/backend/features/orders/shared/mapper.py",
       "source_location": "L53",
       "id": "shared_mapper_customization",
-      "community": 12,
+      "community": 13,
       "norm_label": "_customization()"
     },
     {
@@ -6678,7 +6714,7 @@
       "source_file": "maria_cacau/backend/features/orders/shared/mapper.py",
       "source_location": "L62",
       "id": "shared_mapper_products",
-      "community": 12,
+      "community": 13,
       "norm_label": "_products()"
     },
     {
@@ -6687,7 +6723,7 @@
       "source_file": "maria_cacau/backend/features/orders/shared/mapper.py",
       "source_location": "L77",
       "id": "shared_mapper_payments",
-      "community": 12,
+      "community": 13,
       "norm_label": "_payments()"
     },
     {
@@ -6696,7 +6732,7 @@
       "source_file": "maria_cacau/backend/features/orders/shared/mapper.py",
       "source_location": "L94",
       "id": "shared_mapper_financial",
-      "community": 12,
+      "community": 13,
       "norm_label": "_financial()"
     },
     {
@@ -6705,7 +6741,7 @@
       "source_file": "maria_cacau/backend/features/orders/shared/mapper.py",
       "source_location": "L106",
       "id": "shared_mapper_delivery",
-      "community": 12,
+      "community": 13,
       "norm_label": "_delivery()"
     },
     {
@@ -6713,27 +6749,27 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/features/orders/shared/mapper.py",
       "source_location": "L1",
-      "id": "shared_mapper_rationale_1",
-      "community": 12,
-      "norm_label": "mapeamento de uma linha do dataframe para o model order."
+      "community": 13,
+      "norm_label": "mapeamento de uma linha do dataframe para o model order.",
+      "id": "shared_mapper_rationale_1"
     },
     {
       "label": "Converte uma linha do DataFrame (vinda do SheetsRepository) em um Order.",
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/features/orders/shared/mapper.py",
       "source_location": "L12",
-      "id": "shared_mapper_rationale_12",
-      "community": 12,
-      "norm_label": "converte uma linha do dataframe (vinda do sheetsrepository) em um order."
+      "community": 13,
+      "norm_label": "converte uma linha do dataframe (vinda do sheetsrepository) em um order.",
+      "id": "shared_mapper_rationale_12"
     },
     {
       "label": "Monta um Order completo a partir de uma linha do DataFrame.",
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/features/orders/shared/mapper.py",
       "source_location": "L16",
-      "id": "shared_mapper_rationale_16",
-      "community": 12,
-      "norm_label": "monta um order completo a partir de uma linha do dataframe."
+      "community": 13,
+      "norm_label": "monta um order completo a partir de uma linha do dataframe.",
+      "id": "shared_mapper_rationale_16"
     },
     {
       "label": "__init__.py",
@@ -6741,7 +6777,7 @@
       "source_file": "maria_cacau/backend/features/orders/shared/__init__.py",
       "source_location": "L1",
       "id": "maria_cacau_backend_features_orders_shared_init_py",
-      "community": 12,
+      "community": 13,
       "norm_label": "__init__.py"
     },
     {
@@ -6812,36 +6848,36 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/features/orders/subfeatures/payments/service.py",
       "source_location": "L1",
-      "id": "payments_service_rationale_1",
       "community": 6,
-      "norm_label": "service e mapper de pagamentos pendentes."
+      "norm_label": "service e mapper de pagamentos pendentes.",
+      "id": "payments_service_rationale_1"
     },
     {
       "label": "Serializa o resultado do PaymentsService para dict JSON-ready.",
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/features/orders/subfeatures/payments/service.py",
       "source_location": "L11",
-      "id": "payments_service_rationale_11",
       "community": 6,
-      "norm_label": "serializa o resultado do paymentsservice para dict json-ready."
+      "norm_label": "serializa o resultado do paymentsservice para dict json-ready.",
+      "id": "payments_service_rationale_11"
     },
     {
       "label": "Filtra pedidos com pagamento pendente e monta os objetos de dom\u00ednio.",
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/features/orders/subfeatures/payments/service.py",
       "source_location": "L22",
-      "id": "payments_service_rationale_22",
       "community": 6,
-      "norm_label": "filtra pedidos com pagamento pendente e monta os objetos de dominio."
+      "norm_label": "filtra pedidos com pagamento pendente e monta os objetos de dominio.",
+      "id": "payments_service_rationale_22"
     },
     {
       "label": "Retorna pedidos com amount_pendent > 0 para a data informada.",
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/features/orders/subfeatures/payments/service.py",
       "source_location": "L28",
-      "id": "payments_service_rationale_28",
       "community": 6,
-      "norm_label": "retorna pedidos com amount_pendent > 0 para a data informada."
+      "norm_label": "retorna pedidos com amount_pendent > 0 para a data informada.",
+      "id": "payments_service_rationale_28"
     },
     {
       "label": "route.py",
@@ -6866,9 +6902,9 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/features/orders/subfeatures/payments/route.py",
       "source_location": "L1",
-      "id": "payments_route_rationale_1",
       "community": 6,
-      "norm_label": "rota de pagamentos \u2014 get /orders/payments-pendent."
+      "norm_label": "rota de pagamentos \u2014 get /orders/payments-pendent.",
+      "id": "payments_route_rationale_1"
     },
     {
       "label": "__init__.py",
@@ -6929,45 +6965,45 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/features/orders/subfeatures/payments/repository.py",
       "source_location": "L1",
-      "id": "payments_repository_rationale_1",
       "community": 6,
-      "norm_label": "repositorio de pagamentos \u2014 busca e prepara dados da planilha para o paymentsser"
+      "norm_label": "repositorio de pagamentos \u2014 busca e prepara dados da planilha para o paymentsser",
+      "id": "payments_repository_rationale_1"
     },
     {
       "label": "Acessa o data source e entrega um DataFrame tipado para o PaymentsService.",
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/features/orders/subfeatures/payments/repository.py",
       "source_location": "L12",
-      "id": "payments_repository_rationale_12",
       "community": 6,
-      "norm_label": "acessa o data source e entrega um dataframe tipado para o paymentsservice."
+      "norm_label": "acessa o data source e entrega um dataframe tipado para o paymentsservice.",
+      "id": "payments_repository_rationale_12"
     },
     {
       "label": "Retorna todos os pedidos de uma data com colunas num\u00e9ricas convertidas para floa",
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/features/orders/subfeatures/payments/repository.py",
       "source_location": "L18",
-      "id": "payments_repository_rationale_18",
       "community": 6,
-      "norm_label": "retorna todos os pedidos de uma data com colunas numericas convertidas para floa"
+      "norm_label": "retorna todos os pedidos de uma data com colunas numericas convertidas para floa",
+      "id": "payments_repository_rationale_18"
     },
     {
       "label": "Converte list[dict] em DataFrame com cast num\u00e9rico de todas as colunas de valor.",
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/features/orders/subfeatures/payments/repository.py",
       "source_location": "L26",
-      "id": "payments_repository_rationale_26",
       "community": 38,
-      "norm_label": "converte list[dict] em dataframe com cast numerico de todas as colunas de valor."
+      "norm_label": "converte list[dict] em dataframe com cast numerico de todas as colunas de valor.",
+      "id": "payments_repository_rationale_26"
     },
     {
       "label": "Faz cast num\u00e9rico de uma coluna se ela existir no DataFrame.",
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/features/orders/subfeatures/payments/repository.py",
       "source_location": "L52",
-      "id": "payments_repository_rationale_52",
       "community": 39,
-      "norm_label": "faz cast numerico de uma coluna se ela existir no dataframe."
+      "norm_label": "faz cast numerico de uma coluna se ela existir no dataframe.",
+      "id": "payments_repository_rationale_52"
     },
     {
       "label": "service.py",
@@ -6975,7 +7011,7 @@
       "source_file": "maria_cacau/backend/features/orders/subfeatures/summary/service.py",
       "source_location": "L1",
       "id": "maria_cacau_backend_features_orders_subfeatures_summary_service_py",
-      "community": 14,
+      "community": 15,
       "norm_label": "service.py"
     },
     {
@@ -6984,7 +7020,7 @@
       "source_file": "maria_cacau/backend/features/orders/subfeatures/summary/service.py",
       "source_location": "L9",
       "id": "summary_service_ordersmapper",
-      "community": 14,
+      "community": 15,
       "norm_label": "ordersmapper"
     },
     {
@@ -6993,7 +7029,7 @@
       "source_file": "maria_cacau/backend/features/orders/subfeatures/summary/service.py",
       "source_location": "L13",
       "id": "summary_service_to_response",
-      "community": 14,
+      "community": 15,
       "norm_label": "to_response()"
     },
     {
@@ -7002,7 +7038,7 @@
       "source_file": "maria_cacau/backend/features/orders/subfeatures/summary/service.py",
       "source_location": "L20",
       "id": "summary_service_ordersservice",
-      "community": 14,
+      "community": 15,
       "norm_label": "ordersservice"
     },
     {
@@ -7011,7 +7047,7 @@
       "source_file": "maria_cacau/backend/features/orders/subfeatures/summary/service.py",
       "source_location": "L23",
       "id": "summary_service_ordersservice_init",
-      "community": 14,
+      "community": 15,
       "norm_label": ".__init__()"
     },
     {
@@ -7020,7 +7056,7 @@
       "source_file": "maria_cacau/backend/features/orders/subfeatures/summary/service.py",
       "source_location": "L26",
       "id": "summary_service_ordersservice_get_by_period",
-      "community": 14,
+      "community": 15,
       "norm_label": ".get_by_period()"
     },
     {
@@ -7028,36 +7064,36 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/features/orders/subfeatures/summary/service.py",
       "source_location": "L1",
-      "id": "summary_service_rationale_1",
-      "community": 14,
-      "norm_label": "service e mapper de resumo de pedidos por periodo."
+      "community": 15,
+      "norm_label": "service e mapper de resumo de pedidos por periodo.",
+      "id": "summary_service_rationale_1"
     },
     {
       "label": "Serializa o resultado do OrdersService para dict JSON-ready.",
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/features/orders/subfeatures/summary/service.py",
       "source_location": "L10",
-      "id": "summary_service_rationale_10",
-      "community": 14,
-      "norm_label": "serializa o resultado do ordersservice para dict json-ready."
+      "community": 15,
+      "norm_label": "serializa o resultado do ordersservice para dict json-ready.",
+      "id": "summary_service_rationale_10"
     },
     {
       "label": "Busca e monta os pedidos de um per\u00edodo.",
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/features/orders/subfeatures/summary/service.py",
       "source_location": "L21",
-      "id": "summary_service_rationale_21",
-      "community": 14,
-      "norm_label": "busca e monta os pedidos de um periodo."
+      "community": 15,
+      "norm_label": "busca e monta os pedidos de um periodo.",
+      "id": "summary_service_rationale_21"
     },
     {
       "label": "Retorna todos os pedidos do per\u00edodo informado.",
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/features/orders/subfeatures/summary/service.py",
       "source_location": "L27",
-      "id": "summary_service_rationale_27",
-      "community": 14,
-      "norm_label": "retorna todos os pedidos do periodo informado."
+      "community": 15,
+      "norm_label": "retorna todos os pedidos do periodo informado.",
+      "id": "summary_service_rationale_27"
     },
     {
       "label": "route.py",
@@ -7065,7 +7101,7 @@
       "source_file": "maria_cacau/backend/features/orders/subfeatures/summary/route.py",
       "source_location": "L1",
       "id": "maria_cacau_backend_features_orders_subfeatures_summary_route_py",
-      "community": 14,
+      "community": 15,
       "norm_label": "route.py"
     },
     {
@@ -7074,7 +7110,7 @@
       "source_file": "maria_cacau/backend/features/orders/subfeatures/summary/route.py",
       "source_location": "L12",
       "id": "summary_route_get_orders",
-      "community": 14,
+      "community": 15,
       "norm_label": "get_orders()"
     },
     {
@@ -7082,9 +7118,9 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/features/orders/subfeatures/summary/route.py",
       "source_location": "L1",
-      "id": "summary_route_rationale_1",
-      "community": 14,
-      "norm_label": "rota de pedidos \u2014 get /orders."
+      "community": 15,
+      "norm_label": "rota de pedidos \u2014 get /orders.",
+      "id": "summary_route_rationale_1"
     },
     {
       "label": "__init__.py",
@@ -7101,7 +7137,7 @@
       "source_file": "maria_cacau/backend/features/orders/subfeatures/summary/repository.py",
       "source_location": "L1",
       "id": "maria_cacau_backend_features_orders_subfeatures_summary_repository_py",
-      "community": 14,
+      "community": 15,
       "norm_label": "repository.py"
     },
     {
@@ -7110,7 +7146,7 @@
       "source_file": "maria_cacau/backend/features/orders/subfeatures/summary/repository.py",
       "source_location": "L11",
       "id": "summary_repository_orderssummaryrepository",
-      "community": 14,
+      "community": 15,
       "norm_label": "orderssummaryrepository"
     },
     {
@@ -7119,7 +7155,7 @@
       "source_file": "maria_cacau/backend/features/orders/subfeatures/summary/repository.py",
       "source_location": "L17",
       "id": "summary_repository_orderssummaryrepository_get_by_period",
-      "community": 14,
+      "community": 15,
       "norm_label": ".get_by_period()"
     },
     {
@@ -7128,7 +7164,7 @@
       "source_file": "maria_cacau/backend/features/orders/subfeatures/summary/repository.py",
       "source_location": "L25",
       "id": "summary_repository_to_dataframe",
-      "community": 14,
+      "community": 15,
       "norm_label": "_to_dataframe()"
     },
     {
@@ -7137,7 +7173,7 @@
       "source_file": "maria_cacau/backend/features/orders/subfeatures/summary/repository.py",
       "source_location": "L50",
       "id": "summary_repository_cast_numeric",
-      "community": 14,
+      "community": 15,
       "norm_label": "_cast_numeric()"
     },
     {
@@ -7145,45 +7181,45 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/features/orders/subfeatures/summary/repository.py",
       "source_location": "L1",
-      "id": "summary_repository_rationale_1",
-      "community": 14,
-      "norm_label": "repositorio de pedidos por periodo \u2014 busca e prepara dados da planilha para o or"
+      "community": 15,
+      "norm_label": "repositorio de pedidos por periodo \u2014 busca e prepara dados da planilha para o or",
+      "id": "summary_repository_rationale_1"
     },
     {
       "label": "Acessa o data source e entrega um DataFrame tipado para o OrdersService.      \u00dan",
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/features/orders/subfeatures/summary/repository.py",
       "source_location": "L12",
-      "id": "summary_repository_rationale_12",
-      "community": 14,
-      "norm_label": "acessa o data source e entrega um dataframe tipado para o ordersservice.      un"
+      "community": 15,
+      "norm_label": "acessa o data source e entrega um dataframe tipado para o ordersservice.      un",
+      "id": "summary_repository_rationale_12"
     },
     {
       "label": "Retorna todos os pedidos de um per\u00edodo com colunas num\u00e9ricas convertidas para fl",
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/features/orders/subfeatures/summary/repository.py",
       "source_location": "L18",
-      "id": "summary_repository_rationale_18",
-      "community": 14,
-      "norm_label": "retorna todos os pedidos de um periodo com colunas numericas convertidas para fl"
+      "community": 15,
+      "norm_label": "retorna todos os pedidos de um periodo com colunas numericas convertidas para fl",
+      "id": "summary_repository_rationale_18"
     },
     {
       "label": "Converte list[dict] em DataFrame com cast num\u00e9rico de todas as colunas de valor.",
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/features/orders/subfeatures/summary/repository.py",
       "source_location": "L26",
-      "id": "summary_repository_rationale_26",
       "community": 41,
-      "norm_label": "converte list[dict] em dataframe com cast numerico de todas as colunas de valor."
+      "norm_label": "converte list[dict] em dataframe com cast numerico de todas as colunas de valor.",
+      "id": "summary_repository_rationale_26"
     },
     {
       "label": "Faz cast num\u00e9rico de uma coluna se ela existir no DataFrame.",
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/features/orders/subfeatures/summary/repository.py",
       "source_location": "L51",
-      "id": "summary_repository_rationale_51",
       "community": 42,
-      "norm_label": "faz cast numerico de uma coluna se ela existir no dataframe."
+      "norm_label": "faz cast numerico de uma coluna se ela existir no dataframe.",
+      "id": "summary_repository_rationale_51"
     },
     {
       "label": "service.py",
@@ -7244,36 +7280,36 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/features/orders/subfeatures/deliveries/service.py",
       "source_location": "L1",
-      "id": "deliveries_service_rationale_1",
       "community": 6,
-      "norm_label": "service e mapper de entregas \u2014 agrupa pedidos do dia por tipo de entrega."
+      "norm_label": "service e mapper de entregas \u2014 agrupa pedidos do dia por tipo de entrega.",
+      "id": "deliveries_service_rationale_1"
     },
     {
       "label": "Serializa DeliveriesSummary para dict JSON-ready.",
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/features/orders/subfeatures/deliveries/service.py",
       "source_location": "L11",
-      "id": "deliveries_service_rationale_11",
       "community": 6,
-      "norm_label": "serializa deliveriessummary para dict json-ready."
+      "norm_label": "serializa deliveriessummary para dict json-ready.",
+      "id": "deliveries_service_rationale_11"
     },
     {
       "label": "Aplica regra de neg\u00f3cio sobre os pedidos do dia e retorna o resumo de entregas.",
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/features/orders/subfeatures/deliveries/service.py",
       "source_location": "L19",
-      "id": "deliveries_service_rationale_19",
       "community": 6,
-      "norm_label": "aplica regra de negocio sobre os pedidos do dia e retorna o resumo de entregas."
+      "norm_label": "aplica regra de negocio sobre os pedidos do dia e retorna o resumo de entregas.",
+      "id": "deliveries_service_rationale_19"
     },
     {
       "label": "Retorna contagem de pedidos agrupada por tipo de entrega para a data informada.",
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/features/orders/subfeatures/deliveries/service.py",
       "source_location": "L25",
-      "id": "deliveries_service_rationale_25",
       "community": 6,
-      "norm_label": "retorna contagem de pedidos agrupada por tipo de entrega para a data informada."
+      "norm_label": "retorna contagem de pedidos agrupada por tipo de entrega para a data informada.",
+      "id": "deliveries_service_rationale_25"
     },
     {
       "label": "models.py",
@@ -7299,7 +7335,7 @@
       "source_file": "maria_cacau/backend/features/orders/subfeatures/deliveries/models.py",
       "source_location": "L13",
       "id": "deliveries_models_deliveriessummary",
-      "community": 1,
+      "community": 3,
       "norm_label": "deliveriessummary"
     },
     {
@@ -7307,9 +7343,9 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/features/orders/subfeatures/deliveries/models.py",
       "source_location": "L1",
-      "id": "deliveries_models_rationale_1",
       "community": 6,
-      "norm_label": "models de dominio da feature de entregas."
+      "norm_label": "models de dominio da feature de entregas.",
+      "id": "deliveries_models_rationale_1"
     },
     {
       "label": "route.py",
@@ -7334,9 +7370,9 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/features/orders/subfeatures/deliveries/route.py",
       "source_location": "L1",
-      "id": "deliveries_route_rationale_1",
       "community": 6,
-      "norm_label": "rota de entregas \u2014 get /orders/deliveries."
+      "norm_label": "rota de entregas \u2014 get /orders/deliveries.",
+      "id": "deliveries_route_rationale_1"
     },
     {
       "label": "__init__.py",
@@ -7379,27 +7415,27 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/features/orders/subfeatures/deliveries/repository.py",
       "source_location": "L1",
-      "id": "deliveries_repository_rationale_1",
       "community": 6,
-      "norm_label": "repositorio de entregas \u2014 busca e prepara dados da planilha para o deliveriesser"
+      "norm_label": "repositorio de entregas \u2014 busca e prepara dados da planilha para o deliveriesser",
+      "id": "deliveries_repository_rationale_1"
     },
     {
       "label": "Acessa o data source e entrega um DataFrame para o DeliveriesService.      N\u00e3o f",
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/features/orders/subfeatures/deliveries/repository.py",
       "source_location": "L9",
-      "id": "deliveries_repository_rationale_9",
       "community": 6,
-      "norm_label": "acessa o data source e entrega um dataframe para o deliveriesservice.      nao f"
+      "norm_label": "acessa o data source e entrega um dataframe para o deliveriesservice.      nao f",
+      "id": "deliveries_repository_rationale_9"
     },
     {
       "label": "Retorna todos os pedidos de uma data como DataFrame bruto.",
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/features/orders/subfeatures/deliveries/repository.py",
       "source_location": "L15",
-      "id": "deliveries_repository_rationale_15",
       "community": 6,
-      "norm_label": "retorna todos os pedidos de uma data como dataframe bruto."
+      "norm_label": "retorna todos os pedidos de uma data como dataframe bruto.",
+      "id": "deliveries_repository_rationale_15"
     },
     {
       "label": "service.py",
@@ -7407,7 +7443,7 @@
       "source_file": "maria_cacau/backend/features/sheet/service.py",
       "source_location": "L1",
       "id": "maria_cacau_backend_features_sheet_service_py",
-      "community": 3,
+      "community": 7,
       "norm_label": "service.py"
     },
     {
@@ -7416,7 +7452,7 @@
       "source_file": "maria_cacau/backend/features/sheet/service.py",
       "source_location": "L6",
       "id": "sheet_service_sheetservice",
-      "community": 3,
+      "community": 7,
       "norm_label": "sheetservice"
     },
     {
@@ -7425,7 +7461,7 @@
       "source_file": "maria_cacau/backend/features/sheet/service.py",
       "source_location": "L7",
       "id": "sheet_service_sheetservice_select",
-      "community": 3,
+      "community": 7,
       "norm_label": ".select()"
     },
     {
@@ -7434,7 +7470,7 @@
       "source_file": "maria_cacau/backend/features/sheet/service.py",
       "source_location": "L10",
       "id": "sheet_service_sheetservice_remove",
-      "community": 3,
+      "community": 7,
       "norm_label": ".remove()"
     },
     {
@@ -7442,9 +7478,9 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/features/sheet/service.py",
       "source_location": "L1",
-      "id": "sheet_service_rationale_1",
-      "community": 3,
-      "norm_label": "service de planilha \u2014 gerencia a planilha ativa no datasource."
+      "community": 7,
+      "norm_label": "service de planilha \u2014 gerencia a planilha ativa no datasource.",
+      "id": "sheet_service_rationale_1"
     },
     {
       "label": "route.py",
@@ -7452,7 +7488,7 @@
       "source_file": "maria_cacau/backend/features/sheet/route.py",
       "source_location": "L1",
       "id": "maria_cacau_backend_features_sheet_route_py",
-      "community": 3,
+      "community": 7,
       "norm_label": "route.py"
     },
     {
@@ -7461,7 +7497,7 @@
       "source_file": "maria_cacau/backend/features/sheet/route.py",
       "source_location": "L12",
       "id": "sheet_route_select_sheet",
-      "community": 3,
+      "community": 7,
       "norm_label": "select_sheet()"
     },
     {
@@ -7470,7 +7506,7 @@
       "source_file": "maria_cacau/backend/features/sheet/route.py",
       "source_location": "L18",
       "id": "sheet_route_remove_sheet",
-      "community": 3,
+      "community": 7,
       "norm_label": "remove_sheet()"
     },
     {
@@ -7479,7 +7515,7 @@
       "source_file": "maria_cacau/backend/features/sheet/__init__.py",
       "source_location": "L1",
       "id": "maria_cacau_backend_features_sheet_init_py",
-      "community": 3,
+      "community": 7,
       "norm_label": "__init__.py"
     },
     {
@@ -7514,18 +7550,18 @@
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/utils/numbers.py",
       "source_location": "L1",
-      "id": "utils_numbers_rationale_1",
       "community": 18,
-      "norm_label": "utilitarios de formatacao numerica."
+      "norm_label": "utilitarios de formatacao numerica.",
+      "id": "utils_numbers_rationale_1"
     },
     {
       "label": "Converte n\u00famero no formato brasileiro para o formato ingl\u00eas.      Remove o separ",
       "file_type": "rationale",
       "source_file": "maria_cacau/backend/utils/numbers.py",
       "source_location": "L5",
-      "id": "utils_numbers_rationale_5",
       "community": 18,
-      "norm_label": "converte numero no formato brasileiro para o formato ingles.      remove o separ"
+      "norm_label": "converte numero no formato brasileiro para o formato ingles.      remove o separ",
+      "id": "utils_numbers_rationale_5"
     },
     {
       "label": "_errors.py",
@@ -7533,7 +7569,7 @@
       "source_file": "maria_cacau/backend/errors/_errors.py",
       "source_location": "L1",
       "id": "maria_cacau_backend_errors_errors_py",
-      "community": 10,
+      "community": 17,
       "norm_label": "_errors.py"
     },
     {
@@ -7542,7 +7578,7 @@
       "source_file": "maria_cacau/backend/errors/_errors.py",
       "source_location": "L1",
       "id": "errors_errors_backenderror",
-      "community": 10,
+      "community": 17,
       "norm_label": "backenderror"
     },
     {
@@ -7551,7 +7587,7 @@
       "source_file": "maria_cacau/backend/errors/_errors.py",
       "source_location": "L7",
       "id": "errors_errors_backenderror_to_dict",
-      "community": 10,
+      "community": 17,
       "norm_label": ".to_dict()"
     },
     {
@@ -7560,7 +7596,7 @@
       "source_file": "maria_cacau/backend/errors/__init__.py",
       "source_location": "L1",
       "id": "maria_cacau_backend_errors_init_py",
-      "community": 10,
+      "community": 17,
       "norm_label": "__init__.py"
     },
     {
@@ -7569,7 +7605,7 @@
       "source_file": "maria_cacau/backend/errors/_mapper.py",
       "source_location": "L1",
       "id": "maria_cacau_backend_errors_mapper_py",
-      "community": 10,
+      "community": 17,
       "norm_label": "_mapper.py"
     },
     {
@@ -7578,7 +7614,7 @@
       "source_file": "maria_cacau/backend/errors/_mapper.py",
       "source_location": "L26",
       "id": "errors_mapper_translate",
-      "community": 10,
+      "community": 17,
       "norm_label": "translate()"
     },
     {
@@ -7587,7 +7623,7 @@
       "source_file": "maria_cacau/backend/errors/_mapper.py",
       "source_location": "L35",
       "id": "errors_mapper_generic_mapper",
-      "community": 10,
+      "community": 17,
       "norm_label": "generic_mapper()"
     },
     {
@@ -7614,7 +7650,7 @@
       "source_file": "pocs/prototipacao/figma/figma-plugin.js",
       "source_location": "L1",
       "id": "pocs_prototipacao_figma_figma_plugin_js",
-      "community": 3,
+      "community": 7,
       "norm_label": "figma-plugin.js"
     },
     {
@@ -7623,7 +7659,7 @@
       "source_file": "pocs/prototipacao/figma/figma-plugin.js",
       "source_location": "L7",
       "id": "figma_figma_plugin_main",
-      "community": 3,
+      "community": 7,
       "norm_label": "main()"
     },
     {
@@ -7632,7 +7668,7 @@
       "source_file": "pocs/prototipacao/figma/figma-vetorial-14estados.js",
       "source_location": "L1",
       "id": "pocs_prototipacao_figma_figma_vetorial_14estados_js",
-      "community": 3,
+      "community": 7,
       "norm_label": "figma-vetorial-14estados.js"
     },
     {
@@ -7641,7 +7677,7 @@
       "source_file": "pocs/prototipacao/figma/figma-vetorial-14estados.js",
       "source_location": "L5",
       "id": "figma_figma_vetorial_14estados_main",
-      "community": 3,
+      "community": 7,
       "norm_label": "main()"
     },
     {
@@ -7650,7 +7686,7 @@
       "source_file": "pocs/prototipacao/figma/figma-14estados-generated.js",
       "source_location": "L1",
       "id": "pocs_prototipacao_figma_figma_14estados_generated_js",
-      "community": 3,
+      "community": 7,
       "norm_label": "figma-14estados-generated.js"
     },
     {
@@ -7659,7 +7695,7 @@
       "source_file": "pocs/prototipacao/figma/figma-14estados-generated.js",
       "source_location": "L5",
       "id": "figma_figma_14estados_generated_main",
-      "community": 3,
+      "community": 7,
       "norm_label": "main()"
     },
     {
@@ -7668,7 +7704,7 @@
       "source_file": "pocs/prototipacao/figma/figma-vetorial-mc-frames-f0.js",
       "source_location": "L1",
       "id": "pocs_prototipacao_figma_figma_vetorial_mc_frames_f0_js",
-      "community": 3,
+      "community": 7,
       "norm_label": "figma-vetorial-mc-frames-f0.js"
     },
     {
@@ -7677,7 +7713,7 @@
       "source_file": "pocs/prototipacao/figma/figma-vetorial-mc-frames-f0.js",
       "source_location": "L5",
       "id": "figma_figma_vetorial_mc_frames_f0_main",
-      "community": 3,
+      "community": 7,
       "norm_label": "main()"
     },
     {
@@ -7686,7 +7722,7 @@
       "source_file": "pocs/design-system/poc_date_picker.py",
       "source_location": "L1",
       "id": "pocs_design_system_poc_date_picker_py",
-      "community": 7,
+      "community": 14,
       "norm_label": "poc_date_picker.py"
     },
     {
@@ -7695,7 +7731,7 @@
       "source_file": "pocs/design-system/poc_date_picker.py",
       "source_location": "L60",
       "id": "design_system_poc_date_picker_date_field",
-      "community": 7,
+      "community": 14,
       "norm_label": "_date_field()"
     },
     {
@@ -7704,7 +7740,7 @@
       "source_file": "pocs/design-system/poc_date_picker.py",
       "source_location": "L78",
       "id": "design_system_poc_date_picker_daterangepicker",
-      "community": 7,
+      "community": 14,
       "norm_label": "daterangepicker"
     },
     {
@@ -7713,7 +7749,7 @@
       "source_file": "pocs/design-system/poc_date_picker.py",
       "source_location": "L79",
       "id": "design_system_poc_date_picker_daterangepicker_init",
-      "community": 7,
+      "community": 14,
       "norm_label": ".__init__()"
     },
     {
@@ -7722,7 +7758,7 @@
       "source_file": "pocs/design-system/poc_date_picker.py",
       "source_location": "L123",
       "id": "design_system_poc_date_picker_daterangepicker_on_consultar",
-      "community": 7,
+      "community": 14,
       "norm_label": "._on_consultar()"
     },
     {
@@ -7731,7 +7767,7 @@
       "source_file": "pocs/design-system/poc_date_picker.py",
       "source_location": "L128",
       "id": "design_system_poc_date_picker_daterangepicker_on_limpar",
-      "community": 7,
+      "community": 14,
       "norm_label": "._on_limpar()"
     },
     {
@@ -7739,9 +7775,27 @@
       "file_type": "rationale",
       "source_file": "pocs/design-system/poc_date_picker.py",
       "source_location": "L1",
-      "id": "design_system_poc_date_picker_rationale_1",
-      "community": 7,
-      "norm_label": "poc \u2014 date picker moderno com qdateedit + qss."
+      "community": 14,
+      "norm_label": "poc \u2014 date picker moderno com qdateedit + qss.",
+      "id": "design_system_poc_date_picker_rationale_1"
+    },
+    {
+      "label": "Contrato que qualquer client precisa cumprir.",
+      "file_type": "rationale",
+      "source_file": "maria_cacau/core/network/_client.py",
+      "source_location": "L12",
+      "community": 5,
+      "norm_label": "contrato que qualquer client precisa cumprir.",
+      "id": "network_client_rationale_12"
+    },
+    {
+      "label": "Roteia requests para o backend local (in-process).     Nenhuma rede envolvida \u2014",
+      "file_type": "rationale",
+      "source_file": "maria_cacau/core/network/_client.py",
+      "source_location": "L19",
+      "community": 5,
+      "norm_label": "roteia requests para o backend local (in-process).     nenhuma rede envolvida \u2014",
+      "id": "network_client_rationale_19"
     }
   ],
   "links": [
@@ -7788,8 +7842,8 @@
       "source_file": "maria_cacau/design_system/components/alerts/dialog.py",
       "source_location": "L32",
       "weight": 1.0,
-      "_src": "alerts_dialog_dsdialog_setup_ui",
-      "_tgt": "maria_cacau_init_asset",
+      "_src": "maria_cacau_init_asset",
+      "_tgt": "alerts_dialog_dsdialog_setup_ui",
       "source": "maria_cacau_init_asset",
       "target": "alerts_dialog_dsdialog_setup_ui"
     },
@@ -7883,11 +7937,11 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/data/repository.py",
       "source_location": "L5",
       "weight": 0.8,
-      "_src": "data_repository_ordersrepository",
-      "_tgt": "core_services_services",
+      "_src": "core_services_services",
+      "_tgt": "data_repository_ordersrepository",
+      "confidence_score": 0.5,
       "source": "core_services_services",
-      "target": "data_repository_ordersrepository",
-      "confidence_score": 0.5
+      "target": "data_repository_ordersrepository"
     },
     {
       "relation": "uses",
@@ -7895,11 +7949,11 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/data/repository.py",
       "source_location": "L5",
       "weight": 0.8,
-      "_src": "data_repository_rationale_1",
-      "_tgt": "core_services_services",
+      "_src": "core_services_services",
+      "_tgt": "data_repository_rationale_1",
+      "confidence_score": 0.5,
       "source": "core_services_services",
-      "target": "data_repository_rationale_1",
-      "confidence_score": 0.5
+      "target": "data_repository_rationale_1"
     },
     {
       "relation": "uses",
@@ -7907,11 +7961,11 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/data/repository.py",
       "source_location": "L5",
       "weight": 0.8,
-      "_src": "data_repository_summaryrepository",
-      "_tgt": "core_services_services",
+      "_src": "core_services_services",
+      "_tgt": "data_repository_summaryrepository",
+      "confidence_score": 0.5,
       "source": "core_services_services",
-      "target": "data_repository_summaryrepository",
-      "confidence_score": 0.5
+      "target": "data_repository_summaryrepository"
     },
     {
       "relation": "imports_from",
@@ -7959,6 +8013,30 @@
       "_tgt": "enum",
       "source": "enum",
       "target": "maria_cacau_core_network_method_py",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "maria_cacau/core/network/_observability.py",
+      "source_location": "L4",
+      "weight": 1.0,
+      "_src": "maria_cacau_core_network_observability_py",
+      "_tgt": "enum",
+      "source": "enum",
+      "target": "maria_cacau_core_network_observability_py",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "inherits",
+      "confidence": "EXTRACTED",
+      "source_file": "maria_cacau/core/network/_observability.py",
+      "source_location": "L12",
+      "weight": 1.0,
+      "_src": "network_observability_networkevent",
+      "_tgt": "enum",
+      "source": "enum",
+      "target": "network_observability_networkevent",
       "confidence_score": 1.0
     },
     {
@@ -8205,7 +8283,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "maria_cacau/core/observability.py",
-      "source_location": "L28",
+      "source_location": "L18",
       "weight": 1.0,
       "_src": "maria_cacau_core_observability_py",
       "_tgt": "core_observability_observability",
@@ -8226,22 +8304,34 @@
       "confidence_score": 1.0
     },
     {
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "maria_cacau/core/network/_observability.py",
+      "source_location": "L7",
+      "weight": 1.0,
+      "_src": "maria_cacau_core_network_observability_py",
+      "_tgt": "maria_cacau_core_observability_py",
+      "source": "maria_cacau_core_observability_py",
+      "target": "maria_cacau_core_network_observability_py",
+      "confidence_score": 1.0
+    },
+    {
       "relation": "uses",
       "confidence": "INFERRED",
       "source_file": "maria_cacau/app/coordinator.py",
       "source_location": "L11",
       "weight": 0.8,
-      "_src": "app_coordinator_appcoordinator",
-      "_tgt": "core_observability_appevent",
+      "_src": "core_observability_appevent",
+      "_tgt": "app_coordinator_appcoordinator",
+      "confidence_score": 0.5,
       "source": "core_observability_appevent",
-      "target": "app_coordinator_appcoordinator",
-      "confidence_score": 0.5
+      "target": "app_coordinator_appcoordinator"
     },
     {
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "maria_cacau/core/observability.py",
-      "source_location": "L29",
+      "source_location": "L19",
       "weight": 1.0,
       "_src": "core_observability_observability",
       "_tgt": "core_observability_observability_init",
@@ -8253,7 +8343,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "maria_cacau/core/observability.py",
-      "source_location": "L38",
+      "source_location": "L28",
       "weight": 1.0,
       "_src": "core_observability_observability",
       "_tgt": "core_observability_observability_log",
@@ -8265,11 +8355,23 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "confidence_score": 0.8,
+      "source_file": "maria_cacau/core/network/_observability.py",
+      "source_location": "L25",
+      "weight": 1.0,
+      "_src": "network_observability_track",
+      "_tgt": "core_observability_observability_log",
+      "source": "core_observability_observability_log",
+      "target": "network_observability_track"
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
       "source_file": "maria_cacau/app/coordinator.py",
       "source_location": "L44",
       "weight": 1.0,
-      "_src": "app_coordinator_appcoordinator_initialize",
-      "_tgt": "core_observability_observability_log",
+      "_src": "core_observability_observability_log",
+      "_tgt": "app_coordinator_appcoordinator_initialize",
       "source": "core_observability_observability_log",
       "target": "app_coordinator_appcoordinator_initialize"
     },
@@ -8280,8 +8382,8 @@
       "source_file": "maria_cacau/app/coordinator.py",
       "source_location": "L47",
       "weight": 1.0,
-      "_src": "app_coordinator_appcoordinator_on_quit",
-      "_tgt": "core_observability_observability_log",
+      "_src": "core_observability_observability_log",
+      "_tgt": "app_coordinator_appcoordinator_on_quit",
       "source": "core_observability_observability_log",
       "target": "app_coordinator_appcoordinator_on_quit"
     },
@@ -8292,8 +8394,8 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/presentation/controller.py",
       "source_location": "L40",
       "weight": 1.0,
-      "_src": "presentation_controller_deliverycontroller_on_generate_report",
-      "_tgt": "core_observability_observability_log",
+      "_src": "core_observability_observability_log",
+      "_tgt": "presentation_controller_deliverycontroller_on_generate_report",
       "source": "core_observability_observability_log",
       "target": "presentation_controller_deliverycontroller_on_generate_report"
     },
@@ -8304,8 +8406,8 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/presentation/controller.py",
       "source_location": "L43",
       "weight": 1.0,
-      "_src": "presentation_controller_deliverycontroller_on_copy_report",
-      "_tgt": "core_observability_observability_log",
+      "_src": "core_observability_observability_log",
+      "_tgt": "presentation_controller_deliverycontroller_on_copy_report",
       "source": "core_observability_observability_log",
       "target": "presentation_controller_deliverycontroller_on_copy_report"
     },
@@ -8316,8 +8418,8 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/presentation/controller.py",
       "source_location": "L46",
       "weight": 1.0,
-      "_src": "presentation_controller_deliverycontroller_on_copy_graph",
-      "_tgt": "core_observability_observability_log",
+      "_src": "core_observability_observability_log",
+      "_tgt": "presentation_controller_deliverycontroller_on_copy_graph",
       "source": "core_observability_observability_log",
       "target": "presentation_controller_deliverycontroller_on_copy_graph"
     },
@@ -8328,8 +8430,8 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/presentation/controller.py",
       "source_location": "L49",
       "weight": 1.0,
-      "_src": "presentation_controller_deliverycontroller_on_download_graph",
-      "_tgt": "core_observability_observability_log",
+      "_src": "core_observability_observability_log",
+      "_tgt": "presentation_controller_deliverycontroller_on_download_graph",
       "source": "core_observability_observability_log",
       "target": "presentation_controller_deliverycontroller_on_download_graph"
     },
@@ -8340,8 +8442,8 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/presentation/controller.py",
       "source_location": "L62",
       "weight": 1.0,
-      "_src": "presentation_controller_deliverycontroller_handle_report_generated",
-      "_tgt": "core_observability_observability_log",
+      "_src": "core_observability_observability_log",
+      "_tgt": "presentation_controller_deliverycontroller_handle_report_generated",
       "source": "core_observability_observability_log",
       "target": "presentation_controller_deliverycontroller_handle_report_generated"
     },
@@ -8352,8 +8454,8 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/presentation/controller.py",
       "source_location": "L38",
       "weight": 1.0,
-      "_src": "presentation_controller_summarycontroller_on_generate_report",
-      "_tgt": "core_observability_observability_log",
+      "_src": "core_observability_observability_log",
+      "_tgt": "presentation_controller_summarycontroller_on_generate_report",
       "source": "core_observability_observability_log",
       "target": "presentation_controller_summarycontroller_on_generate_report"
     },
@@ -8364,8 +8466,8 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/presentation/controller.py",
       "source_location": "L41",
       "weight": 1.0,
-      "_src": "presentation_controller_summarycontroller_on_copy_report",
-      "_tgt": "core_observability_observability_log",
+      "_src": "core_observability_observability_log",
+      "_tgt": "presentation_controller_summarycontroller_on_copy_report",
       "source": "core_observability_observability_log",
       "target": "presentation_controller_summarycontroller_on_copy_report"
     },
@@ -8376,8 +8478,8 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/presentation/controller.py",
       "source_location": "L44",
       "weight": 1.0,
-      "_src": "presentation_controller_summarycontroller_on_copy_graph",
-      "_tgt": "core_observability_observability_log",
+      "_src": "core_observability_observability_log",
+      "_tgt": "presentation_controller_summarycontroller_on_copy_graph",
       "source": "core_observability_observability_log",
       "target": "presentation_controller_summarycontroller_on_copy_graph"
     },
@@ -8388,8 +8490,8 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/presentation/controller.py",
       "source_location": "L47",
       "weight": 1.0,
-      "_src": "presentation_controller_summarycontroller_on_download_graph",
-      "_tgt": "core_observability_observability_log",
+      "_src": "core_observability_observability_log",
+      "_tgt": "presentation_controller_summarycontroller_on_download_graph",
       "source": "core_observability_observability_log",
       "target": "presentation_controller_summarycontroller_on_download_graph"
     },
@@ -8400,8 +8502,8 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/presentation/controller.py",
       "source_location": "L50",
       "weight": 1.0,
-      "_src": "presentation_controller_summarycontroller_on_change_chart_type",
-      "_tgt": "core_observability_observability_log",
+      "_src": "core_observability_observability_log",
+      "_tgt": "presentation_controller_summarycontroller_on_change_chart_type",
       "source": "core_observability_observability_log",
       "target": "presentation_controller_summarycontroller_on_change_chart_type"
     },
@@ -8412,8 +8514,8 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/presentation/controller.py",
       "source_location": "L61",
       "weight": 1.0,
-      "_src": "presentation_controller_summarycontroller_handle_report_generated",
-      "_tgt": "core_observability_observability_log",
+      "_src": "core_observability_observability_log",
+      "_tgt": "presentation_controller_summarycontroller_handle_report_generated",
       "source": "core_observability_observability_log",
       "target": "presentation_controller_summarycontroller_handle_report_generated"
     },
@@ -8424,8 +8526,8 @@
       "source_file": "maria_cacau/features/sheets/presentation/controller.py",
       "source_location": "L99",
       "weight": 1.0,
-      "_src": "presentation_controller_sheetscontroller_on_clear_cache",
-      "_tgt": "core_observability_observability_log",
+      "_src": "core_observability_observability_log",
+      "_tgt": "presentation_controller_sheetscontroller_on_clear_cache",
       "source": "core_observability_observability_log",
       "target": "presentation_controller_sheetscontroller_on_clear_cache"
     },
@@ -8436,8 +8538,8 @@
       "source_file": "maria_cacau/features/sheets/presentation/controller.py",
       "source_location": "L106",
       "weight": 1.0,
-      "_src": "presentation_controller_sheetscontroller_on_renamed",
-      "_tgt": "core_observability_observability_log",
+      "_src": "core_observability_observability_log",
+      "_tgt": "presentation_controller_sheetscontroller_on_renamed",
       "source": "core_observability_observability_log",
       "target": "presentation_controller_sheetscontroller_on_renamed"
     },
@@ -8448,8 +8550,8 @@
       "source_file": "maria_cacau/features/sheets/presentation/controller.py",
       "source_location": "L110",
       "weight": 1.0,
-      "_src": "presentation_controller_sheetscontroller_on_removed",
-      "_tgt": "core_observability_observability_log",
+      "_src": "core_observability_observability_log",
+      "_tgt": "presentation_controller_sheetscontroller_on_removed",
       "source": "core_observability_observability_log",
       "target": "presentation_controller_sheetscontroller_on_removed"
     },
@@ -8460,8 +8562,8 @@
       "source_file": "maria_cacau/features/sheets/presentation/controller.py",
       "source_location": "L115",
       "weight": 1.0,
-      "_src": "presentation_controller_sheetscontroller_on_connected",
-      "_tgt": "core_observability_observability_log",
+      "_src": "core_observability_observability_log",
+      "_tgt": "presentation_controller_sheetscontroller_on_connected",
       "source": "core_observability_observability_log",
       "target": "presentation_controller_sheetscontroller_on_connected"
     },
@@ -8472,8 +8574,8 @@
       "source_file": "maria_cacau/features/sheets/presentation/controller.py",
       "source_location": "L119",
       "weight": 1.0,
-      "_src": "presentation_controller_sheetscontroller_on_selected",
-      "_tgt": "core_observability_observability_log",
+      "_src": "core_observability_observability_log",
+      "_tgt": "presentation_controller_sheetscontroller_on_selected",
       "source": "core_observability_observability_log",
       "target": "presentation_controller_sheetscontroller_on_selected"
     },
@@ -8484,8 +8586,8 @@
       "source_file": "maria_cacau/features/sheets/presentation/controller.py",
       "source_location": "L123",
       "weight": 1.0,
-      "_src": "presentation_controller_sheetscontroller_on_error",
-      "_tgt": "core_observability_observability_log",
+      "_src": "core_observability_observability_log",
+      "_tgt": "presentation_controller_sheetscontroller_on_error",
       "source": "core_observability_observability_log",
       "target": "presentation_controller_sheetscontroller_on_error"
     },
@@ -8496,8 +8598,8 @@
       "source_file": "maria_cacau/features/auth/presentation/controller.py",
       "source_location": "L50",
       "weight": 1.0,
-      "_src": "presentation_controller_authcontroller_on_configured",
-      "_tgt": "core_observability_observability_log",
+      "_src": "core_observability_observability_log",
+      "_tgt": "presentation_controller_authcontroller_on_configured",
       "source": "core_observability_observability_log",
       "target": "presentation_controller_authcontroller_on_configured"
     },
@@ -8508,8 +8610,8 @@
       "source_file": "maria_cacau/features/auth/presentation/controller.py",
       "source_location": "L53",
       "weight": 1.0,
-      "_src": "presentation_controller_authcontroller_on_cleared",
-      "_tgt": "core_observability_observability_log",
+      "_src": "core_observability_observability_log",
+      "_tgt": "presentation_controller_authcontroller_on_cleared",
       "source": "core_observability_observability_log",
       "target": "presentation_controller_authcontroller_on_cleared"
     },
@@ -8520,8 +8622,8 @@
       "source_file": "maria_cacau/features/auth/presentation/controller.py",
       "source_location": "L57",
       "weight": 1.0,
-      "_src": "presentation_controller_authcontroller_on_error",
-      "_tgt": "core_observability_observability_log",
+      "_src": "core_observability_observability_log",
+      "_tgt": "presentation_controller_authcontroller_on_error",
       "source": "core_observability_observability_log",
       "target": "presentation_controller_authcontroller_on_error"
     },
@@ -8532,8 +8634,8 @@
       "source_file": "maria_cacau/features/cpf_validation/presentation/controller.py",
       "source_location": "L26",
       "weight": 1.0,
-      "_src": "presentation_controller_cpfvalidationcontroller_on_validate",
-      "_tgt": "core_observability_observability_log",
+      "_src": "core_observability_observability_log",
+      "_tgt": "presentation_controller_cpfvalidationcontroller_on_validate",
       "source": "core_observability_observability_log",
       "target": "presentation_controller_cpfvalidationcontroller_on_validate"
     },
@@ -8544,8 +8646,8 @@
       "source_file": "maria_cacau/features/cpf_validation/presentation/controller.py",
       "source_location": "L31",
       "weight": 1.0,
-      "_src": "presentation_controller_cpfvalidationcontroller_handle_result",
-      "_tgt": "core_observability_observability_log",
+      "_src": "core_observability_observability_log",
+      "_tgt": "presentation_controller_cpfvalidationcontroller_handle_result",
       "source": "core_observability_observability_log",
       "target": "presentation_controller_cpfvalidationcontroller_handle_result"
     },
@@ -8556,8 +8658,8 @@
       "source_file": "pocs/prototipacao/figma/figma-plugin.js",
       "source_location": "L560",
       "weight": 1.0,
-      "_src": "figma_figma_plugin_main",
-      "_tgt": "core_observability_observability_log",
+      "_src": "core_observability_observability_log",
+      "_tgt": "figma_figma_plugin_main",
       "source": "core_observability_observability_log",
       "target": "figma_figma_plugin_main"
     },
@@ -8568,8 +8670,8 @@
       "source_file": "pocs/prototipacao/figma/figma-vetorial-14estados.js",
       "source_location": "L17281",
       "weight": 1.0,
-      "_src": "figma_figma_vetorial_14estados_main",
-      "_tgt": "core_observability_observability_log",
+      "_src": "core_observability_observability_log",
+      "_tgt": "figma_figma_vetorial_14estados_main",
       "source": "core_observability_observability_log",
       "target": "figma_figma_vetorial_14estados_main"
     },
@@ -8580,8 +8682,8 @@
       "source_file": "pocs/prototipacao/figma/figma-14estados-generated.js",
       "source_location": "L97",
       "weight": 1.0,
-      "_src": "figma_figma_14estados_generated_main",
-      "_tgt": "core_observability_observability_log",
+      "_src": "core_observability_observability_log",
+      "_tgt": "figma_figma_14estados_generated_main",
       "source": "core_observability_observability_log",
       "target": "figma_figma_14estados_generated_main"
     },
@@ -8592,8 +8694,8 @@
       "source_file": "pocs/prototipacao/figma/figma-vetorial-mc-frames-f0.js",
       "source_location": "L1314",
       "weight": 1.0,
-      "_src": "figma_figma_vetorial_mc_frames_f0_main",
-      "_tgt": "core_observability_observability_log",
+      "_src": "core_observability_observability_log",
+      "_tgt": "figma_figma_vetorial_mc_frames_f0_main",
       "source": "core_observability_observability_log",
       "target": "figma_figma_vetorial_mc_frames_f0_main"
     },
@@ -8869,9 +8971,9 @@
       "weight": 0.8,
       "_src": "network_errors_networkerror",
       "_tgt": "network_response_httpresponse",
+      "confidence_score": 0.5,
       "source": "network_errors_networkerror",
-      "target": "network_response_httpresponse",
-      "confidence_score": 0.5
+      "target": "network_response_httpresponse"
     },
     {
       "relation": "inherits",
@@ -8941,9 +9043,9 @@
       "weight": 0.8,
       "_src": "network_errors_networknotconfigurederror",
       "_tgt": "network_response_httpresponse",
+      "confidence_score": 0.5,
       "source": "network_errors_networknotconfigurederror",
-      "target": "network_response_httpresponse",
-      "confidence_score": 0.5
+      "target": "network_response_httpresponse"
     },
     {
       "relation": "uses",
@@ -8951,11 +9053,11 @@
       "source_file": "maria_cacau/core/network/_config.py",
       "source_location": "L5",
       "weight": 0.8,
-      "_src": "network_config_rationale_1",
-      "_tgt": "network_errors_networknotconfigurederror",
+      "_src": "network_errors_networknotconfigurederror",
+      "_tgt": "network_config_rationale_1",
+      "confidence_score": 0.5,
       "source": "network_errors_networknotconfigurederror",
-      "target": "network_config_rationale_1",
-      "confidence_score": 0.5
+      "target": "network_config_rationale_1"
     },
     {
       "relation": "uses",
@@ -8963,11 +9065,11 @@
       "source_file": "maria_cacau/core/network/_config.py",
       "source_location": "L5",
       "weight": 0.8,
-      "_src": "network_config_rationale_16",
-      "_tgt": "network_errors_networknotconfigurederror",
+      "_src": "network_errors_networknotconfigurederror",
+      "_tgt": "network_config_rationale_16",
+      "confidence_score": 0.5,
       "source": "network_errors_networknotconfigurederror",
-      "target": "network_config_rationale_16",
-      "confidence_score": 0.5
+      "target": "network_config_rationale_16"
     },
     {
       "relation": "uses",
@@ -8975,11 +9077,11 @@
       "source_file": "maria_cacau/core/network/_config.py",
       "source_location": "L5",
       "weight": 0.8,
-      "_src": "network_config_rationale_21",
-      "_tgt": "network_errors_networknotconfigurederror",
+      "_src": "network_errors_networknotconfigurederror",
+      "_tgt": "network_config_rationale_21",
+      "confidence_score": 0.5,
       "source": "network_errors_networknotconfigurederror",
-      "target": "network_config_rationale_21",
-      "confidence_score": 0.5
+      "target": "network_config_rationale_21"
     },
     {
       "relation": "uses",
@@ -8987,11 +9089,11 @@
       "source_file": "maria_cacau/core/network/_config.py",
       "source_location": "L5",
       "weight": 0.8,
-      "_src": "network_config_rationale_26",
-      "_tgt": "network_errors_networknotconfigurederror",
+      "_src": "network_errors_networknotconfigurederror",
+      "_tgt": "network_config_rationale_26",
+      "confidence_score": 0.5,
       "source": "network_errors_networknotconfigurederror",
-      "target": "network_config_rationale_26",
-      "confidence_score": 0.5
+      "target": "network_config_rationale_26"
     },
     {
       "relation": "uses",
@@ -8999,11 +9101,11 @@
       "source_file": "maria_cacau/core/network/_config.py",
       "source_location": "L5",
       "weight": 0.8,
-      "_src": "network_config_rationale_31",
-      "_tgt": "network_errors_networknotconfigurederror",
+      "_src": "network_errors_networknotconfigurederror",
+      "_tgt": "network_config_rationale_31",
+      "confidence_score": 0.5,
       "source": "network_errors_networknotconfigurederror",
-      "target": "network_config_rationale_31",
-      "confidence_score": 0.5
+      "target": "network_config_rationale_31"
     },
     {
       "relation": "calls",
@@ -9012,8 +9114,8 @@
       "source_file": "maria_cacau/core/network/_config.py",
       "source_location": "L34",
       "weight": 1.0,
-      "_src": "network_config_get_client",
-      "_tgt": "network_errors_networknotconfigurederror",
+      "_src": "network_errors_networknotconfigurederror",
+      "_tgt": "network_config_get_client",
       "source": "network_errors_networknotconfigurederror",
       "target": "network_config_get_client"
     },
@@ -9061,9 +9163,9 @@
       "weight": 0.8,
       "_src": "network_errors_httprequesterror",
       "_tgt": "network_response_httpresponse",
+      "confidence_score": 0.5,
       "source": "network_errors_httprequesterror",
-      "target": "network_response_httpresponse",
-      "confidence_score": 0.5
+      "target": "network_response_httpresponse"
     },
     {
       "relation": "calls",
@@ -9109,9 +9211,9 @@
       "weight": 0.8,
       "_src": "network_errors_httpresponseerror",
       "_tgt": "network_response_httpresponse",
+      "confidence_score": 0.5,
       "source": "network_errors_httpresponseerror",
-      "target": "network_response_httpresponse",
-      "confidence_score": 0.5
+      "target": "network_response_httpresponse"
     },
     {
       "relation": "uses",
@@ -9119,11 +9221,11 @@
       "source_file": "maria_cacau/core/network/api.py",
       "source_location": "L7",
       "weight": 0.8,
-      "_src": "network_api_api",
-      "_tgt": "network_errors_httpresponseerror",
+      "_src": "network_errors_httpresponseerror",
+      "_tgt": "network_api_api",
+      "confidence_score": 0.5,
       "source": "network_errors_httpresponseerror",
-      "target": "network_api_api",
-      "confidence_score": 0.5
+      "target": "network_api_api"
     },
     {
       "relation": "uses",
@@ -9131,11 +9233,11 @@
       "source_file": "maria_cacau/core/network/api.py",
       "source_location": "L7",
       "weight": 0.8,
-      "_src": "network_api_rationale_1",
-      "_tgt": "network_errors_httpresponseerror",
+      "_src": "network_errors_httpresponseerror",
+      "_tgt": "network_api_rationale_1",
+      "confidence_score": 0.5,
       "source": "network_errors_httpresponseerror",
-      "target": "network_api_rationale_1",
-      "confidence_score": 0.5
+      "target": "network_api_rationale_1"
     },
     {
       "relation": "uses",
@@ -9143,11 +9245,11 @@
       "source_file": "maria_cacau/core/network/api.py",
       "source_location": "L7",
       "weight": 0.8,
-      "_src": "network_api_rationale_34",
-      "_tgt": "network_errors_httpresponseerror",
+      "_src": "network_errors_httpresponseerror",
+      "_tgt": "network_api_rationale_34",
+      "confidence_score": 0.5,
       "source": "network_errors_httpresponseerror",
-      "target": "network_api_rationale_34",
-      "confidence_score": 0.5
+      "target": "network_api_rationale_34"
     },
     {
       "relation": "calls",
@@ -9156,8 +9258,8 @@
       "source_file": "maria_cacau/core/network/api.py",
       "source_location": "L29",
       "weight": 1.0,
-      "_src": "network_api_call",
-      "_tgt": "network_errors_httpresponseerror",
+      "_src": "network_errors_httpresponseerror",
+      "_tgt": "network_api_call",
       "source": "network_errors_httpresponseerror",
       "target": "network_api_call"
     },
@@ -9181,9 +9283,9 @@
       "weight": 0.8,
       "_src": "network_errors_errormessages",
       "_tgt": "network_response_httpresponse",
+      "confidence_score": 0.5,
       "source": "network_errors_errormessages",
-      "target": "network_response_httpresponse",
-      "confidence_score": 0.5
+      "target": "network_response_httpresponse"
     },
     {
       "relation": "inherits",
@@ -9253,9 +9355,9 @@
       "weight": 0.8,
       "_src": "network_errors_rationale_1",
       "_tgt": "network_response_httpresponse",
+      "confidence_score": 0.5,
       "source": "network_errors_rationale_1",
-      "target": "network_response_httpresponse",
-      "confidence_score": 0.5
+      "target": "network_response_httpresponse"
     },
     {
       "relation": "uses",
@@ -9265,9 +9367,9 @@
       "weight": 0.8,
       "_src": "network_errors_rationale_10",
       "_tgt": "network_response_httpresponse",
+      "confidence_score": 0.5,
       "source": "network_errors_rationale_10",
-      "target": "network_response_httpresponse",
-      "confidence_score": 0.5
+      "target": "network_response_httpresponse"
     },
     {
       "relation": "uses",
@@ -9277,9 +9379,9 @@
       "weight": 0.8,
       "_src": "network_errors_rationale_15",
       "_tgt": "network_response_httpresponse",
+      "confidence_score": 0.5,
       "source": "network_errors_rationale_15",
-      "target": "network_response_httpresponse",
-      "confidence_score": 0.5
+      "target": "network_response_httpresponse"
     },
     {
       "relation": "uses",
@@ -9289,9 +9391,9 @@
       "weight": 0.8,
       "_src": "network_errors_rationale_20",
       "_tgt": "network_response_httpresponse",
+      "confidence_score": 0.5,
       "source": "network_errors_rationale_20",
-      "target": "network_response_httpresponse",
-      "confidence_score": 0.5
+      "target": "network_response_httpresponse"
     },
     {
       "relation": "uses",
@@ -9301,9 +9403,9 @@
       "weight": 0.8,
       "_src": "network_errors_rationale_26",
       "_tgt": "network_response_httpresponse",
+      "confidence_score": 0.5,
       "source": "network_errors_rationale_26",
-      "target": "network_response_httpresponse",
-      "confidence_score": 0.5
+      "target": "network_response_httpresponse"
     },
     {
       "relation": "contains",
@@ -9359,11 +9461,11 @@
       "source_file": "maria_cacau/core/network/_request.py",
       "source_location": "L5",
       "weight": 0.8,
-      "_src": "network_request_httprequest",
-      "_tgt": "network_method_httpmethod",
+      "_src": "network_method_httpmethod",
+      "_tgt": "network_request_httprequest",
+      "confidence_score": 0.5,
       "source": "network_method_httpmethod",
-      "target": "network_request_httprequest",
-      "confidence_score": 0.5
+      "target": "network_request_httprequest"
     },
     {
       "relation": "uses",
@@ -9371,11 +9473,11 @@
       "source_file": "maria_cacau/core/network/_request.py",
       "source_location": "L5",
       "weight": 0.8,
-      "_src": "network_request_rationale_1",
-      "_tgt": "network_method_httpmethod",
+      "_src": "network_method_httpmethod",
+      "_tgt": "network_request_rationale_1",
+      "confidence_score": 0.5,
       "source": "network_method_httpmethod",
-      "target": "network_request_rationale_1",
-      "confidence_score": 0.5
+      "target": "network_request_rationale_1"
     },
     {
       "relation": "uses",
@@ -9383,11 +9485,11 @@
       "source_file": "maria_cacau/features/sheets/data/apis.py",
       "source_location": "L1",
       "weight": 0.8,
-      "_src": "data_apis_selectsheetapi",
-      "_tgt": "network_method_httpmethod",
+      "_src": "network_method_httpmethod",
+      "_tgt": "data_apis_selectsheetapi",
+      "confidence_score": 0.5,
       "source": "network_method_httpmethod",
-      "target": "data_apis_selectsheetapi",
-      "confidence_score": 0.5
+      "target": "data_apis_selectsheetapi"
     },
     {
       "relation": "uses",
@@ -9395,11 +9497,11 @@
       "source_file": "maria_cacau/features/sheets/data/apis.py",
       "source_location": "L1",
       "weight": 0.8,
-      "_src": "data_apis_removesheetapi",
-      "_tgt": "network_method_httpmethod",
+      "_src": "network_method_httpmethod",
+      "_tgt": "data_apis_removesheetapi",
+      "confidence_score": 0.5,
       "source": "network_method_httpmethod",
-      "target": "data_apis_removesheetapi",
-      "confidence_score": 0.5
+      "target": "data_apis_removesheetapi"
     },
     {
       "relation": "uses",
@@ -9407,11 +9509,11 @@
       "source_file": "maria_cacau/features/auth/data/apis.py",
       "source_location": "L3",
       "weight": 0.8,
-      "_src": "data_apis_connectauthapi",
-      "_tgt": "network_method_httpmethod",
+      "_src": "network_method_httpmethod",
+      "_tgt": "data_apis_connectauthapi",
+      "confidence_score": 0.5,
       "source": "network_method_httpmethod",
-      "target": "data_apis_connectauthapi",
-      "confidence_score": 0.5
+      "target": "data_apis_connectauthapi"
     },
     {
       "relation": "uses",
@@ -9419,11 +9521,11 @@
       "source_file": "maria_cacau/features/auth/data/apis.py",
       "source_location": "L3",
       "weight": 0.8,
-      "_src": "data_apis_disconnectauthapi",
-      "_tgt": "network_method_httpmethod",
+      "_src": "network_method_httpmethod",
+      "_tgt": "data_apis_disconnectauthapi",
+      "confidence_score": 0.5,
       "source": "network_method_httpmethod",
-      "target": "data_apis_disconnectauthapi",
-      "confidence_score": 0.5
+      "target": "data_apis_disconnectauthapi"
     },
     {
       "relation": "uses",
@@ -9431,11 +9533,11 @@
       "source_file": "maria_cacau/features/auth/data/apis.py",
       "source_location": "L3",
       "weight": 0.8,
-      "_src": "data_apis_rationale_1",
-      "_tgt": "network_method_httpmethod",
+      "_src": "network_method_httpmethod",
+      "_tgt": "data_apis_rationale_1",
+      "confidence_score": 0.5,
       "source": "network_method_httpmethod",
-      "target": "data_apis_rationale_1",
-      "confidence_score": 0.5
+      "target": "data_apis_rationale_1"
     },
     {
       "relation": "contains",
@@ -9489,12 +9591,24 @@
       "relation": "imports_from",
       "confidence": "EXTRACTED",
       "source_file": "maria_cacau/core/network/_client.py",
-      "source_location": "L6",
+      "source_location": "L8",
       "weight": 1.0,
       "_src": "maria_cacau_core_network_client_py",
       "_tgt": "maria_cacau_core_network_response_py",
       "source": "maria_cacau_core_network_response_py",
       "target": "maria_cacau_core_network_client_py",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "maria_cacau/core/network/_observability.py",
+      "source_location": "L9",
+      "weight": 1.0,
+      "_src": "maria_cacau_core_network_observability_py",
+      "_tgt": "maria_cacau_core_network_response_py",
+      "source": "maria_cacau_core_network_response_py",
+      "target": "maria_cacau_core_network_observability_py",
       "confidence_score": 1.0
     },
     {
@@ -9515,11 +9629,11 @@
       "source_file": "maria_cacau/core/network/api.py",
       "source_location": "L9",
       "weight": 0.8,
-      "_src": "network_api_api",
-      "_tgt": "network_response_httpresponse",
+      "_src": "network_response_httpresponse",
+      "_tgt": "network_api_api",
+      "confidence_score": 0.5,
       "source": "network_response_httpresponse",
-      "target": "network_api_api",
-      "confidence_score": 0.5
+      "target": "network_api_api"
     },
     {
       "relation": "uses",
@@ -9527,11 +9641,11 @@
       "source_file": "maria_cacau/core/network/api.py",
       "source_location": "L9",
       "weight": 0.8,
-      "_src": "network_api_rationale_1",
-      "_tgt": "network_response_httpresponse",
+      "_src": "network_response_httpresponse",
+      "_tgt": "network_api_rationale_1",
+      "confidence_score": 0.5,
       "source": "network_response_httpresponse",
-      "target": "network_api_rationale_1",
-      "confidence_score": 0.5
+      "target": "network_api_rationale_1"
     },
     {
       "relation": "uses",
@@ -9539,11 +9653,11 @@
       "source_file": "maria_cacau/core/network/api.py",
       "source_location": "L9",
       "weight": 0.8,
-      "_src": "network_api_rationale_34",
-      "_tgt": "network_response_httpresponse",
+      "_src": "network_response_httpresponse",
+      "_tgt": "network_api_rationale_34",
+      "confidence_score": 0.5,
       "source": "network_response_httpresponse",
-      "target": "network_api_rationale_34",
-      "confidence_score": 0.5
+      "target": "network_api_rationale_34"
     },
     {
       "relation": "uses",
@@ -9551,11 +9665,11 @@
       "source_file": "maria_cacau/core/network/_client.py",
       "source_location": "L6",
       "weight": 0.8,
-      "_src": "network_client_httpclientcontract",
-      "_tgt": "network_response_httpresponse",
+      "_src": "network_response_httpresponse",
+      "_tgt": "network_client_httpclientcontract",
+      "confidence_score": 0.5,
       "source": "network_response_httpresponse",
-      "target": "network_client_httpclientcontract",
-      "confidence_score": 0.5
+      "target": "network_client_httpclientcontract"
     },
     {
       "relation": "uses",
@@ -9563,11 +9677,11 @@
       "source_file": "maria_cacau/core/network/_client.py",
       "source_location": "L6",
       "weight": 0.8,
-      "_src": "network_client_localclient",
-      "_tgt": "network_response_httpresponse",
+      "_src": "network_response_httpresponse",
+      "_tgt": "network_client_localclient",
+      "confidence_score": 0.5,
       "source": "network_response_httpresponse",
-      "target": "network_client_localclient",
-      "confidence_score": 0.5
+      "target": "network_client_localclient"
     },
     {
       "relation": "uses",
@@ -9575,34 +9689,58 @@
       "source_file": "maria_cacau/core/network/_client.py",
       "source_location": "L6",
       "weight": 0.8,
-      "_src": "network_client_rationale_1",
+      "_src": "network_response_httpresponse",
+      "_tgt": "network_client_rationale_1",
+      "confidence_score": 0.5,
+      "source": "network_response_httpresponse",
+      "target": "network_client_rationale_1"
+    },
+    {
+      "relation": "uses",
+      "confidence": "INFERRED",
+      "source_file": "maria_cacau/core/network/_client.py",
+      "source_location": "L8",
+      "weight": 0.8,
+      "_src": "network_client_rationale_14",
       "_tgt": "network_response_httpresponse",
       "source": "network_response_httpresponse",
-      "target": "network_client_rationale_1",
+      "target": "network_client_rationale_14",
       "confidence_score": 0.5
     },
     {
       "relation": "uses",
       "confidence": "INFERRED",
       "source_file": "maria_cacau/core/network/_client.py",
-      "source_location": "L6",
+      "source_location": "L8",
       "weight": 0.8,
-      "_src": "network_client_rationale_12",
+      "_src": "network_client_rationale_21",
       "_tgt": "network_response_httpresponse",
       "source": "network_response_httpresponse",
-      "target": "network_client_rationale_12",
+      "target": "network_client_rationale_21",
       "confidence_score": 0.5
     },
     {
       "relation": "uses",
       "confidence": "INFERRED",
-      "source_file": "maria_cacau/core/network/_client.py",
-      "source_location": "L6",
+      "source_file": "maria_cacau/core/network/_observability.py",
+      "source_location": "L9",
       "weight": 0.8,
-      "_src": "network_client_rationale_19",
+      "_src": "network_observability_networkevent",
       "_tgt": "network_response_httpresponse",
       "source": "network_response_httpresponse",
-      "target": "network_client_rationale_19",
+      "target": "network_observability_networkevent",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "uses",
+      "confidence": "INFERRED",
+      "source_file": "maria_cacau/core/network/_observability.py",
+      "source_location": "L9",
+      "weight": 0.8,
+      "_src": "network_observability_rationale_1",
+      "_tgt": "network_response_httpresponse",
+      "source": "network_response_httpresponse",
+      "target": "network_observability_rationale_1",
       "confidence_score": 0.5
     },
     {
@@ -9612,10 +9750,34 @@
       "source_file": "maria_cacau/backend/_server.py",
       "source_location": "L42",
       "weight": 1.0,
-      "_src": "backend_server_backendserver_execute",
-      "_tgt": "network_response_httpresponse",
+      "_src": "network_response_httpresponse",
+      "_tgt": "backend_server_backendserver_execute",
       "source": "network_response_httpresponse",
       "target": "backend_server_backendserver_execute"
+    },
+    {
+      "relation": "uses",
+      "confidence": "INFERRED",
+      "source_file": "maria_cacau/core/network/_client.py",
+      "source_location": "L6",
+      "weight": 0.8,
+      "_src": "network_response_httpresponse",
+      "_tgt": "network_client_rationale_12",
+      "confidence_score": 0.5,
+      "source": "network_response_httpresponse",
+      "target": "network_client_rationale_12"
+    },
+    {
+      "relation": "uses",
+      "confidence": "INFERRED",
+      "source_file": "maria_cacau/core/network/_client.py",
+      "source_location": "L6",
+      "weight": 0.8,
+      "_src": "network_response_httpresponse",
+      "_tgt": "network_client_rationale_19",
+      "confidence_score": 0.5,
+      "source": "network_response_httpresponse",
+      "target": "network_client_rationale_19"
     },
     {
       "relation": "rationale_for",
@@ -9636,8 +9798,8 @@
       "source_file": "maria_cacau/core/network/api.py",
       "source_location": "L35",
       "weight": 1.0,
-      "_src": "network_api_entity",
-      "_tgt": "network_response_httpresponse_json",
+      "_src": "network_response_httpresponse_json",
+      "_tgt": "network_api_entity",
       "source": "network_response_httpresponse_json",
       "target": "network_api_entity"
     },
@@ -9648,8 +9810,8 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/data/mapper.py",
       "source_location": "L14",
       "weight": 1.0,
-      "_src": "data_mapper_from_response",
-      "_tgt": "network_response_httpresponse_json",
+      "_src": "network_response_httpresponse_json",
+      "_tgt": "data_mapper_from_response",
       "source": "network_response_httpresponse_json",
       "target": "data_mapper_from_response"
     },
@@ -9741,7 +9903,7 @@
       "relation": "imports_from",
       "confidence": "EXTRACTED",
       "source_file": "maria_cacau/core/network/_client.py",
-      "source_location": "L5",
+      "source_location": "L7",
       "weight": 1.0,
       "_src": "maria_cacau_core_network_client_py",
       "_tgt": "maria_cacau_core_network_request_py",
@@ -9750,28 +9912,16 @@
       "confidence_score": 1.0
     },
     {
-      "relation": "uses",
-      "confidence": "INFERRED",
-      "source_file": "maria_cacau/core/network/api.py",
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "maria_cacau/core/network/_observability.py",
       "source_location": "L8",
-      "weight": 0.8,
-      "_src": "network_api_api",
-      "_tgt": "network_request_httprequest",
-      "source": "network_request_httprequest",
-      "target": "network_api_api",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "uses",
-      "confidence": "INFERRED",
-      "source_file": "maria_cacau/core/network/api.py",
-      "source_location": "L8",
-      "weight": 0.8,
-      "_src": "network_api_rationale_1",
-      "_tgt": "network_request_httprequest",
-      "source": "network_request_httprequest",
-      "target": "network_api_rationale_1",
-      "confidence_score": 0.5
+      "weight": 1.0,
+      "_src": "maria_cacau_core_network_observability_py",
+      "_tgt": "maria_cacau_core_network_request_py",
+      "source": "maria_cacau_core_network_request_py",
+      "target": "maria_cacau_core_network_observability_py",
+      "confidence_score": 1.0
     },
     {
       "relation": "uses",
@@ -9779,11 +9929,35 @@
       "source_file": "maria_cacau/core/network/api.py",
       "source_location": "L8",
       "weight": 0.8,
-      "_src": "network_api_rationale_34",
-      "_tgt": "network_request_httprequest",
+      "_src": "network_request_httprequest",
+      "_tgt": "network_api_api",
+      "confidence_score": 0.5,
       "source": "network_request_httprequest",
-      "target": "network_api_rationale_34",
-      "confidence_score": 0.5
+      "target": "network_api_api"
+    },
+    {
+      "relation": "uses",
+      "confidence": "INFERRED",
+      "source_file": "maria_cacau/core/network/api.py",
+      "source_location": "L8",
+      "weight": 0.8,
+      "_src": "network_request_httprequest",
+      "_tgt": "network_api_rationale_1",
+      "confidence_score": 0.5,
+      "source": "network_request_httprequest",
+      "target": "network_api_rationale_1"
+    },
+    {
+      "relation": "uses",
+      "confidence": "INFERRED",
+      "source_file": "maria_cacau/core/network/api.py",
+      "source_location": "L8",
+      "weight": 0.8,
+      "_src": "network_request_httprequest",
+      "_tgt": "network_api_rationale_34",
+      "confidence_score": 0.5,
+      "source": "network_request_httprequest",
+      "target": "network_api_rationale_34"
     },
     {
       "relation": "uses",
@@ -9791,11 +9965,11 @@
       "source_file": "maria_cacau/core/network/_client.py",
       "source_location": "L5",
       "weight": 0.8,
-      "_src": "network_client_httpclientcontract",
-      "_tgt": "network_request_httprequest",
+      "_src": "network_request_httprequest",
+      "_tgt": "network_client_httpclientcontract",
+      "confidence_score": 0.5,
       "source": "network_request_httprequest",
-      "target": "network_client_httpclientcontract",
-      "confidence_score": 0.5
+      "target": "network_client_httpclientcontract"
     },
     {
       "relation": "uses",
@@ -9803,11 +9977,11 @@
       "source_file": "maria_cacau/core/network/_client.py",
       "source_location": "L5",
       "weight": 0.8,
-      "_src": "network_client_localclient",
-      "_tgt": "network_request_httprequest",
+      "_src": "network_request_httprequest",
+      "_tgt": "network_client_localclient",
+      "confidence_score": 0.5,
       "source": "network_request_httprequest",
-      "target": "network_client_localclient",
-      "confidence_score": 0.5
+      "target": "network_client_localclient"
     },
     {
       "relation": "uses",
@@ -9815,34 +9989,58 @@
       "source_file": "maria_cacau/core/network/_client.py",
       "source_location": "L5",
       "weight": 0.8,
-      "_src": "network_client_rationale_1",
+      "_src": "network_request_httprequest",
+      "_tgt": "network_client_rationale_1",
+      "confidence_score": 0.5,
+      "source": "network_request_httprequest",
+      "target": "network_client_rationale_1"
+    },
+    {
+      "relation": "uses",
+      "confidence": "INFERRED",
+      "source_file": "maria_cacau/core/network/_client.py",
+      "source_location": "L7",
+      "weight": 0.8,
+      "_src": "network_client_rationale_14",
       "_tgt": "network_request_httprequest",
       "source": "network_request_httprequest",
-      "target": "network_client_rationale_1",
+      "target": "network_client_rationale_14",
       "confidence_score": 0.5
     },
     {
       "relation": "uses",
       "confidence": "INFERRED",
       "source_file": "maria_cacau/core/network/_client.py",
-      "source_location": "L5",
+      "source_location": "L7",
       "weight": 0.8,
-      "_src": "network_client_rationale_12",
+      "_src": "network_client_rationale_21",
       "_tgt": "network_request_httprequest",
       "source": "network_request_httprequest",
-      "target": "network_client_rationale_12",
+      "target": "network_client_rationale_21",
       "confidence_score": 0.5
     },
     {
       "relation": "uses",
       "confidence": "INFERRED",
-      "source_file": "maria_cacau/core/network/_client.py",
-      "source_location": "L5",
+      "source_file": "maria_cacau/core/network/_observability.py",
+      "source_location": "L8",
       "weight": 0.8,
-      "_src": "network_client_rationale_19",
+      "_src": "network_observability_networkevent",
       "_tgt": "network_request_httprequest",
       "source": "network_request_httprequest",
-      "target": "network_client_rationale_19",
+      "target": "network_observability_networkevent",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "uses",
+      "confidence": "INFERRED",
+      "source_file": "maria_cacau/core/network/_observability.py",
+      "source_location": "L8",
+      "weight": 0.8,
+      "_src": "network_observability_rationale_1",
+      "_tgt": "network_request_httprequest",
+      "source": "network_request_httprequest",
+      "target": "network_observability_rationale_1",
       "confidence_score": 0.5
     },
     {
@@ -9852,10 +10050,34 @@
       "source_file": "maria_cacau/core/network/api.py",
       "source_location": "L17",
       "weight": 1.0,
-      "_src": "network_api_api_init",
-      "_tgt": "network_request_httprequest",
+      "_src": "network_request_httprequest",
+      "_tgt": "network_api_api_init",
       "source": "network_request_httprequest",
       "target": "network_api_api_init"
+    },
+    {
+      "relation": "uses",
+      "confidence": "INFERRED",
+      "source_file": "maria_cacau/core/network/_client.py",
+      "source_location": "L5",
+      "weight": 0.8,
+      "_src": "network_request_httprequest",
+      "_tgt": "network_client_rationale_12",
+      "confidence_score": 0.5,
+      "source": "network_request_httprequest",
+      "target": "network_client_rationale_12"
+    },
+    {
+      "relation": "uses",
+      "confidence": "INFERRED",
+      "source_file": "maria_cacau/core/network/_client.py",
+      "source_location": "L5",
+      "weight": 0.8,
+      "_src": "network_request_httprequest",
+      "_tgt": "network_client_rationale_19",
+      "confidence_score": 0.5,
+      "source": "network_request_httprequest",
+      "target": "network_client_rationale_19"
     },
     {
       "relation": "imports_from",
@@ -9971,11 +10193,11 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/data/apis.py",
       "source_location": "L3",
       "weight": 0.8,
-      "_src": "data_apis_deliveriesapi",
-      "_tgt": "network_api_api",
+      "_src": "network_api_api",
+      "_tgt": "data_apis_deliveriesapi",
+      "confidence_score": 0.5,
       "source": "network_api_api",
-      "target": "data_apis_deliveriesapi",
-      "confidence_score": 0.5
+      "target": "data_apis_deliveriesapi"
     },
     {
       "relation": "uses",
@@ -9983,11 +10205,11 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/data/apis.py",
       "source_location": "L3",
       "weight": 0.8,
-      "_src": "data_apis_paymentspendentapi",
-      "_tgt": "network_api_api",
+      "_src": "network_api_api",
+      "_tgt": "data_apis_paymentspendentapi",
+      "confidence_score": 0.5,
       "source": "network_api_api",
-      "target": "data_apis_paymentspendentapi",
-      "confidence_score": 0.5
+      "target": "data_apis_paymentspendentapi"
     },
     {
       "relation": "uses",
@@ -9995,11 +10217,11 @@
       "source_file": "maria_cacau/features/auth/data/apis.py",
       "source_location": "L4",
       "weight": 0.8,
-      "_src": "data_apis_rationale_1",
-      "_tgt": "network_api_api",
+      "_src": "network_api_api",
+      "_tgt": "data_apis_rationale_1",
+      "confidence_score": 0.5,
       "source": "network_api_api",
-      "target": "data_apis_rationale_1",
-      "confidence_score": 0.5
+      "target": "data_apis_rationale_1"
     },
     {
       "relation": "uses",
@@ -10007,11 +10229,11 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/data/apis.py",
       "source_location": "L3",
       "weight": 0.8,
-      "_src": "data_apis_orderssummaryapi",
-      "_tgt": "network_api_api",
+      "_src": "network_api_api",
+      "_tgt": "data_apis_orderssummaryapi",
+      "confidence_score": 0.5,
       "source": "network_api_api",
-      "target": "data_apis_orderssummaryapi",
-      "confidence_score": 0.5
+      "target": "data_apis_orderssummaryapi"
     },
     {
       "relation": "uses",
@@ -10019,11 +10241,11 @@
       "source_file": "maria_cacau/features/sheets/data/apis.py",
       "source_location": "L2",
       "weight": 0.8,
-      "_src": "data_apis_selectsheetapi",
-      "_tgt": "network_api_api",
+      "_src": "network_api_api",
+      "_tgt": "data_apis_selectsheetapi",
+      "confidence_score": 0.5,
       "source": "network_api_api",
-      "target": "data_apis_selectsheetapi",
-      "confidence_score": 0.5
+      "target": "data_apis_selectsheetapi"
     },
     {
       "relation": "uses",
@@ -10031,11 +10253,11 @@
       "source_file": "maria_cacau/features/sheets/data/apis.py",
       "source_location": "L2",
       "weight": 0.8,
-      "_src": "data_apis_removesheetapi",
-      "_tgt": "network_api_api",
+      "_src": "network_api_api",
+      "_tgt": "data_apis_removesheetapi",
+      "confidence_score": 0.5,
       "source": "network_api_api",
-      "target": "data_apis_removesheetapi",
-      "confidence_score": 0.5
+      "target": "data_apis_removesheetapi"
     },
     {
       "relation": "uses",
@@ -10043,11 +10265,11 @@
       "source_file": "maria_cacau/features/auth/data/apis.py",
       "source_location": "L4",
       "weight": 0.8,
-      "_src": "data_apis_connectauthapi",
-      "_tgt": "network_api_api",
+      "_src": "network_api_api",
+      "_tgt": "data_apis_connectauthapi",
+      "confidence_score": 0.5,
       "source": "network_api_api",
-      "target": "data_apis_connectauthapi",
-      "confidence_score": 0.5
+      "target": "data_apis_connectauthapi"
     },
     {
       "relation": "uses",
@@ -10055,11 +10277,11 @@
       "source_file": "maria_cacau/features/auth/data/apis.py",
       "source_location": "L4",
       "weight": 0.8,
-      "_src": "data_apis_disconnectauthapi",
-      "_tgt": "network_api_api",
+      "_src": "network_api_api",
+      "_tgt": "data_apis_disconnectauthapi",
+      "confidence_score": 0.5,
       "source": "network_api_api",
-      "target": "data_apis_disconnectauthapi",
-      "confidence_score": 0.5
+      "target": "data_apis_disconnectauthapi"
     },
     {
       "relation": "imports_from",
@@ -10128,8 +10350,8 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/data/repository.py",
       "source_location": "L16",
       "weight": 1.0,
-      "_src": "data_repository_ordersrepository_get_deliveries",
-      "_tgt": "network_api_call",
+      "_src": "network_api_call",
+      "_tgt": "data_repository_ordersrepository_get_deliveries",
       "source": "network_api_call",
       "target": "data_repository_ordersrepository_get_deliveries"
     },
@@ -10140,8 +10362,8 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/data/repository.py",
       "source_location": "L26",
       "weight": 1.0,
-      "_src": "data_repository_ordersrepository_get_pendent_payments",
-      "_tgt": "network_api_call",
+      "_src": "network_api_call",
+      "_tgt": "data_repository_ordersrepository_get_pendent_payments",
       "source": "network_api_call",
       "target": "data_repository_ordersrepository_get_pendent_payments"
     },
@@ -10152,8 +10374,8 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/data/repository.py",
       "source_location": "L16",
       "weight": 1.0,
-      "_src": "data_repository_summaryrepository_get_by_period",
-      "_tgt": "network_api_call",
+      "_src": "network_api_call",
+      "_tgt": "data_repository_summaryrepository_get_by_period",
       "source": "network_api_call",
       "target": "data_repository_summaryrepository_get_by_period"
     },
@@ -10164,8 +10386,8 @@
       "source_file": "maria_cacau/features/sheets/data/repository.py",
       "source_location": "L37",
       "weight": 1.0,
-      "_src": "data_repository_sheetsrepository_connect",
-      "_tgt": "network_api_call",
+      "_src": "network_api_call",
+      "_tgt": "data_repository_sheetsrepository_connect",
       "source": "network_api_call",
       "target": "data_repository_sheetsrepository_connect"
     },
@@ -10176,8 +10398,8 @@
       "source_file": "maria_cacau/features/sheets/data/repository.py",
       "source_location": "L42",
       "weight": 1.0,
-      "_src": "data_repository_sheetsrepository_select",
-      "_tgt": "network_api_call",
+      "_src": "network_api_call",
+      "_tgt": "data_repository_sheetsrepository_select",
       "source": "network_api_call",
       "target": "data_repository_sheetsrepository_select"
     },
@@ -10188,8 +10410,8 @@
       "source_file": "maria_cacau/features/sheets/data/repository.py",
       "source_location": "L64",
       "weight": 1.0,
-      "_src": "data_repository_sheetsrepository_remove",
-      "_tgt": "network_api_call",
+      "_src": "network_api_call",
+      "_tgt": "data_repository_sheetsrepository_remove",
       "source": "network_api_call",
       "target": "data_repository_sheetsrepository_remove"
     },
@@ -10200,8 +10422,8 @@
       "source_file": "maria_cacau/features/auth/data/repository.py",
       "source_location": "L19",
       "weight": 1.0,
-      "_src": "data_repository_authrepository_configure",
-      "_tgt": "network_api_call",
+      "_src": "network_api_call",
+      "_tgt": "data_repository_authrepository_configure",
       "source": "network_api_call",
       "target": "data_repository_authrepository_configure"
     },
@@ -10212,8 +10434,8 @@
       "source_file": "maria_cacau/features/auth/data/repository.py",
       "source_location": "L27",
       "weight": 1.0,
-      "_src": "data_repository_authrepository_pre_login",
-      "_tgt": "network_api_call",
+      "_src": "network_api_call",
+      "_tgt": "data_repository_authrepository_pre_login",
       "source": "network_api_call",
       "target": "data_repository_authrepository_pre_login"
     },
@@ -10224,8 +10446,8 @@
       "source_file": "maria_cacau/features/auth/data/repository.py",
       "source_location": "L38",
       "weight": 1.0,
-      "_src": "data_repository_authrepository_clear",
-      "_tgt": "network_api_call",
+      "_src": "network_api_call",
+      "_tgt": "data_repository_authrepository_clear",
       "source": "network_api_call",
       "target": "data_repository_authrepository_clear"
     },
@@ -10233,7 +10455,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "maria_cacau/core/network/_client.py",
-      "source_location": "L11",
+      "source_location": "L13",
       "weight": 1.0,
       "_src": "maria_cacau_core_network_client_py",
       "_tgt": "network_client_httpclientcontract",
@@ -10245,7 +10467,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "maria_cacau/core/network/_client.py",
-      "source_location": "L18",
+      "source_location": "L20",
       "weight": 1.0,
       "_src": "maria_cacau_core_network_client_py",
       "_tgt": "network_client_localclient",
@@ -10281,7 +10503,7 @@
       "relation": "inherits",
       "confidence": "EXTRACTED",
       "source_file": "maria_cacau/core/network/_client.py",
-      "source_location": "L11",
+      "source_location": "L13",
       "weight": 1.0,
       "_src": "network_client_httpclientcontract",
       "_tgt": "protocol",
@@ -10293,7 +10515,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "maria_cacau/core/network/_client.py",
-      "source_location": "L13",
+      "source_location": "L15",
       "weight": 1.0,
       "_src": "network_client_httpclientcontract",
       "_tgt": "network_client_httpclientcontract_execute",
@@ -10305,12 +10527,12 @@
       "relation": "rationale_for",
       "confidence": "EXTRACTED",
       "source_file": "maria_cacau/core/network/_client.py",
-      "source_location": "L12",
+      "source_location": "L14",
       "weight": 1.0,
-      "_src": "network_client_rationale_12",
+      "_src": "network_client_rationale_14",
       "_tgt": "network_client_httpclientcontract",
       "source": "network_client_httpclientcontract",
-      "target": "network_client_rationale_12",
+      "target": "network_client_rationale_14",
       "confidence_score": 1.0
     },
     {
@@ -10319,11 +10541,11 @@
       "source_file": "maria_cacau/core/network/_config.py",
       "source_location": "L8",
       "weight": 0.8,
-      "_src": "network_config_rationale_1",
-      "_tgt": "network_client_httpclientcontract",
+      "_src": "network_client_httpclientcontract",
+      "_tgt": "network_config_rationale_1",
+      "confidence_score": 0.5,
       "source": "network_client_httpclientcontract",
-      "target": "network_config_rationale_1",
-      "confidence_score": 0.5
+      "target": "network_config_rationale_1"
     },
     {
       "relation": "uses",
@@ -10331,11 +10553,11 @@
       "source_file": "maria_cacau/core/network/_config.py",
       "source_location": "L8",
       "weight": 0.8,
-      "_src": "network_config_rationale_16",
-      "_tgt": "network_client_httpclientcontract",
+      "_src": "network_client_httpclientcontract",
+      "_tgt": "network_config_rationale_16",
+      "confidence_score": 0.5,
       "source": "network_client_httpclientcontract",
-      "target": "network_config_rationale_16",
-      "confidence_score": 0.5
+      "target": "network_config_rationale_16"
     },
     {
       "relation": "uses",
@@ -10343,11 +10565,11 @@
       "source_file": "maria_cacau/core/network/_config.py",
       "source_location": "L8",
       "weight": 0.8,
-      "_src": "network_config_rationale_21",
-      "_tgt": "network_client_httpclientcontract",
+      "_src": "network_client_httpclientcontract",
+      "_tgt": "network_config_rationale_21",
+      "confidence_score": 0.5,
       "source": "network_client_httpclientcontract",
-      "target": "network_config_rationale_21",
-      "confidence_score": 0.5
+      "target": "network_config_rationale_21"
     },
     {
       "relation": "uses",
@@ -10355,11 +10577,11 @@
       "source_file": "maria_cacau/core/network/_config.py",
       "source_location": "L8",
       "weight": 0.8,
-      "_src": "network_config_rationale_26",
-      "_tgt": "network_client_httpclientcontract",
+      "_src": "network_client_httpclientcontract",
+      "_tgt": "network_config_rationale_26",
+      "confidence_score": 0.5,
       "source": "network_client_httpclientcontract",
-      "target": "network_config_rationale_26",
-      "confidence_score": 0.5
+      "target": "network_config_rationale_26"
     },
     {
       "relation": "uses",
@@ -10367,11 +10589,11 @@
       "source_file": "maria_cacau/core/network/_config.py",
       "source_location": "L8",
       "weight": 0.8,
-      "_src": "network_config_rationale_31",
-      "_tgt": "network_client_httpclientcontract",
+      "_src": "network_client_httpclientcontract",
+      "_tgt": "network_config_rationale_31",
+      "confidence_score": 0.5,
       "source": "network_client_httpclientcontract",
-      "target": "network_config_rationale_31",
-      "confidence_score": 0.5
+      "target": "network_config_rationale_31"
     },
     {
       "relation": "inherits",
@@ -10389,7 +10611,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "maria_cacau/core/network/_client.py",
-      "source_location": "L23",
+      "source_location": "L25",
       "weight": 1.0,
       "_src": "network_client_localclient",
       "_tgt": "network_client_localclient_init",
@@ -10401,7 +10623,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "maria_cacau/core/network/_client.py",
-      "source_location": "L26",
+      "source_location": "L28",
       "weight": 1.0,
       "_src": "network_client_localclient",
       "_tgt": "network_client_localclient_execute",
@@ -10413,12 +10635,12 @@
       "relation": "rationale_for",
       "confidence": "EXTRACTED",
       "source_file": "maria_cacau/core/network/_client.py",
-      "source_location": "L19",
+      "source_location": "L21",
       "weight": 1.0,
-      "_src": "network_client_rationale_19",
+      "_src": "network_client_rationale_21",
       "_tgt": "network_client_localclient",
       "source": "network_client_localclient",
-      "target": "network_client_rationale_19",
+      "target": "network_client_rationale_21",
       "confidence_score": 1.0
     },
     {
@@ -10428,10 +10650,58 @@
       "source_file": "maria_cacau/app/coordinator.py",
       "source_location": "L25",
       "weight": 1.0,
-      "_src": "app_coordinator_appcoordinator_launch",
-      "_tgt": "network_client_localclient",
+      "_src": "network_client_localclient",
+      "_tgt": "app_coordinator_appcoordinator_launch",
       "source": "network_client_localclient",
       "target": "app_coordinator_appcoordinator_launch"
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "maria_cacau/core/network/_client.py",
+      "source_location": "L29",
+      "weight": 1.0,
+      "_src": "network_client_localclient_execute",
+      "_tgt": "network_observability_track",
+      "source": "network_client_localclient_execute",
+      "target": "network_observability_track"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "maria_cacau/core/network/_observability.py",
+      "source_location": "L12",
+      "weight": 1.0,
+      "_src": "maria_cacau_core_network_observability_py",
+      "_tgt": "network_observability_networkevent",
+      "source": "maria_cacau_core_network_observability_py",
+      "target": "network_observability_networkevent",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "maria_cacau/core/network/_observability.py",
+      "source_location": "L19",
+      "weight": 1.0,
+      "_src": "maria_cacau_core_network_observability_py",
+      "_tgt": "network_observability_track",
+      "source": "maria_cacau_core_network_observability_py",
+      "target": "network_observability_track",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "rationale_for",
+      "confidence": "EXTRACTED",
+      "source_file": "maria_cacau/core/network/_observability.py",
+      "source_location": "L1",
+      "weight": 1.0,
+      "_src": "network_observability_rationale_1",
+      "_tgt": "maria_cacau_core_network_observability_py",
+      "source": "maria_cacau_core_network_observability_py",
+      "target": "network_observability_rationale_1",
+      "confidence_score": 1.0
     },
     {
       "relation": "contains",
@@ -10619,11 +10889,11 @@
       "source_file": "maria_cacau/core/storage/security.py",
       "source_location": "L5",
       "weight": 0.8,
-      "_src": "storage_security_securitystorage",
-      "_tgt": "storage_handler_storagehandler",
+      "_src": "storage_handler_storagehandler",
+      "_tgt": "storage_security_securitystorage",
+      "confidence_score": 0.5,
       "source": "storage_handler_storagehandler",
-      "target": "storage_security_securitystorage",
-      "confidence_score": 0.5
+      "target": "storage_security_securitystorage"
     },
     {
       "relation": "uses",
@@ -10631,11 +10901,11 @@
       "source_file": "maria_cacau/core/storage/security.py",
       "source_location": "L5",
       "weight": 0.8,
-      "_src": "storage_security_rationale_1",
-      "_tgt": "storage_handler_storagehandler",
+      "_src": "storage_handler_storagehandler",
+      "_tgt": "storage_security_rationale_1",
+      "confidence_score": 0.5,
       "source": "storage_handler_storagehandler",
-      "target": "storage_security_rationale_1",
-      "confidence_score": 0.5
+      "target": "storage_security_rationale_1"
     },
     {
       "relation": "uses",
@@ -10643,11 +10913,11 @@
       "source_file": "maria_cacau/core/storage/cache.py",
       "source_location": "L7",
       "weight": 0.8,
-      "_src": "storage_cache_cachestorage",
-      "_tgt": "storage_handler_storagehandler",
+      "_src": "storage_handler_storagehandler",
+      "_tgt": "storage_cache_cachestorage",
+      "confidence_score": 0.5,
       "source": "storage_handler_storagehandler",
-      "target": "storage_cache_cachestorage",
-      "confidence_score": 0.5
+      "target": "storage_cache_cachestorage"
     },
     {
       "relation": "uses",
@@ -10655,11 +10925,11 @@
       "source_file": "maria_cacau/core/storage/cache.py",
       "source_location": "L7",
       "weight": 0.8,
-      "_src": "storage_cache_rationale_1",
-      "_tgt": "storage_handler_storagehandler",
+      "_src": "storage_handler_storagehandler",
+      "_tgt": "storage_cache_rationale_1",
+      "confidence_score": 0.5,
       "source": "storage_handler_storagehandler",
-      "target": "storage_cache_rationale_1",
-      "confidence_score": 0.5
+      "target": "storage_cache_rationale_1"
     },
     {
       "relation": "contains",
@@ -10763,11 +11033,11 @@
       "source_file": "maria_cacau/features/auth/data/repository.py",
       "source_location": "L5",
       "weight": 0.8,
-      "_src": "data_repository_authrepository",
-      "_tgt": "storage_security_securitystorage",
+      "_src": "storage_security_securitystorage",
+      "_tgt": "data_repository_authrepository",
+      "confidence_score": 0.5,
       "source": "storage_security_securitystorage",
-      "target": "data_repository_authrepository",
-      "confidence_score": 0.5
+      "target": "data_repository_authrepository"
     },
     {
       "relation": "uses",
@@ -10775,11 +11045,11 @@
       "source_file": "maria_cacau/features/auth/data/repository.py",
       "source_location": "L5",
       "weight": 0.8,
-      "_src": "data_repository_rationale_1",
-      "_tgt": "storage_security_securitystorage",
+      "_src": "storage_security_securitystorage",
+      "_tgt": "data_repository_rationale_1",
+      "confidence_score": 0.5,
       "source": "storage_security_securitystorage",
-      "target": "data_repository_rationale_1",
-      "confidence_score": 0.5
+      "target": "data_repository_rationale_1"
     },
     {
       "relation": "uses",
@@ -10787,11 +11057,11 @@
       "source_file": "maria_cacau/features/auth/data/repository.py",
       "source_location": "L5",
       "weight": 0.8,
-      "_src": "data_repository_rationale_16",
-      "_tgt": "storage_security_securitystorage",
+      "_src": "storage_security_securitystorage",
+      "_tgt": "data_repository_rationale_16",
+      "confidence_score": 0.5,
       "source": "storage_security_securitystorage",
-      "target": "data_repository_rationale_16",
-      "confidence_score": 0.5
+      "target": "data_repository_rationale_16"
     },
     {
       "relation": "uses",
@@ -10799,11 +11069,11 @@
       "source_file": "maria_cacau/features/auth/data/repository.py",
       "source_location": "L5",
       "weight": 0.8,
-      "_src": "data_repository_rationale_23",
-      "_tgt": "storage_security_securitystorage",
+      "_src": "storage_security_securitystorage",
+      "_tgt": "data_repository_rationale_23",
+      "confidence_score": 0.5,
       "source": "storage_security_securitystorage",
-      "target": "data_repository_rationale_23",
-      "confidence_score": 0.5
+      "target": "data_repository_rationale_23"
     },
     {
       "relation": "uses",
@@ -10811,11 +11081,11 @@
       "source_file": "maria_cacau/features/auth/data/repository.py",
       "source_location": "L5",
       "weight": 0.8,
-      "_src": "data_repository_rationale_30",
-      "_tgt": "storage_security_securitystorage",
+      "_src": "storage_security_securitystorage",
+      "_tgt": "data_repository_rationale_30",
+      "confidence_score": 0.5,
       "source": "storage_security_securitystorage",
-      "target": "data_repository_rationale_30",
-      "confidence_score": 0.5
+      "target": "data_repository_rationale_30"
     },
     {
       "relation": "uses",
@@ -10823,11 +11093,11 @@
       "source_file": "maria_cacau/features/auth/data/repository.py",
       "source_location": "L5",
       "weight": 0.8,
-      "_src": "data_repository_rationale_35",
-      "_tgt": "storage_security_securitystorage",
+      "_src": "storage_security_securitystorage",
+      "_tgt": "data_repository_rationale_35",
+      "confidence_score": 0.5,
       "source": "storage_security_securitystorage",
-      "target": "data_repository_rationale_35",
-      "confidence_score": 0.5
+      "target": "data_repository_rationale_35"
     },
     {
       "relation": "calls",
@@ -10980,8 +11250,8 @@
       "source_file": "maria_cacau/features/sheets/data/repository.py",
       "source_location": "L34",
       "weight": 1.0,
-      "_src": "data_repository_sheetsrepository_connect",
-      "_tgt": "storage_cache_cachestorage_save",
+      "_src": "storage_cache_cachestorage_save",
+      "_tgt": "data_repository_sheetsrepository_connect",
       "source": "storage_cache_cachestorage_save",
       "target": "data_repository_sheetsrepository_connect"
     },
@@ -10992,8 +11262,8 @@
       "source_file": "maria_cacau/features/sheets/data/repository.py",
       "source_location": "L61",
       "weight": 1.0,
-      "_src": "data_repository_sheetsrepository_remove",
-      "_tgt": "storage_cache_cachestorage_save",
+      "_src": "storage_cache_cachestorage_save",
+      "_tgt": "data_repository_sheetsrepository_remove",
       "source": "storage_cache_cachestorage_save",
       "target": "data_repository_sheetsrepository_remove"
     },
@@ -11004,8 +11274,8 @@
       "source_file": "maria_cacau/features/sheets/data/repository.py",
       "source_location": "L74",
       "weight": 1.0,
-      "_src": "data_repository_sheetsrepository_update_name",
-      "_tgt": "storage_cache_cachestorage_save",
+      "_src": "storage_cache_cachestorage_save",
+      "_tgt": "data_repository_sheetsrepository_update_name",
       "source": "storage_cache_cachestorage_save",
       "target": "data_repository_sheetsrepository_update_name"
     },
@@ -11016,8 +11286,8 @@
       "source_file": "maria_cacau/features/auth/data/repository.py",
       "source_location": "L20",
       "weight": 1.0,
-      "_src": "data_repository_authrepository_configure",
-      "_tgt": "storage_cache_cachestorage_save",
+      "_src": "storage_cache_cachestorage_save",
+      "_tgt": "data_repository_authrepository_configure",
       "source": "storage_cache_cachestorage_save",
       "target": "data_repository_authrepository_configure"
     },
@@ -11040,8 +11310,8 @@
       "source_file": "maria_cacau/features/sheets/data/repository.py",
       "source_location": "L83",
       "weight": 1.0,
-      "_src": "data_repository_sheetsrepository_load_raw",
-      "_tgt": "storage_cache_cachestorage_retrieve",
+      "_src": "storage_cache_cachestorage_retrieve",
+      "_tgt": "data_repository_sheetsrepository_load_raw",
       "source": "storage_cache_cachestorage_retrieve",
       "target": "data_repository_sheetsrepository_load_raw"
     },
@@ -11052,8 +11322,8 @@
       "source_file": "maria_cacau/features/auth/data/repository.py",
       "source_location": "L31",
       "weight": 1.0,
-      "_src": "data_repository_authrepository_read_credentials",
-      "_tgt": "storage_cache_cachestorage_retrieve",
+      "_src": "storage_cache_cachestorage_retrieve",
+      "_tgt": "data_repository_authrepository_read_credentials",
       "source": "storage_cache_cachestorage_retrieve",
       "target": "data_repository_authrepository_read_credentials"
     },
@@ -11076,8 +11346,8 @@
       "source_file": "maria_cacau/features/auth/data/repository.py",
       "source_location": "L36",
       "weight": 1.0,
-      "_src": "data_repository_authrepository_clear",
-      "_tgt": "storage_cache_cachestorage_delete",
+      "_src": "storage_cache_cachestorage_delete",
+      "_tgt": "data_repository_authrepository_clear",
       "source": "storage_cache_cachestorage_delete",
       "target": "data_repository_authrepository_clear"
     },
@@ -11159,11 +11429,11 @@
       "source_file": "maria_cacau/core/error/errors.py",
       "source_location": "L5",
       "weight": 0.8,
-      "_src": "error_errors_apperror",
-      "_tgt": "error_models_errormodel",
+      "_src": "error_models_errormodel",
+      "_tgt": "error_errors_apperror",
+      "confidence_score": 0.5,
       "source": "error_models_errormodel",
-      "target": "error_errors_apperror",
-      "confidence_score": 0.5
+      "target": "error_errors_apperror"
     },
     {
       "relation": "uses",
@@ -11171,11 +11441,11 @@
       "source_file": "maria_cacau/core/error/errors.py",
       "source_location": "L5",
       "weight": 0.8,
-      "_src": "error_errors_rationale_1",
-      "_tgt": "error_models_errormodel",
+      "_src": "error_models_errormodel",
+      "_tgt": "error_errors_rationale_1",
+      "confidence_score": 0.5,
       "source": "error_models_errormodel",
-      "target": "error_errors_rationale_1",
-      "confidence_score": 0.5
+      "target": "error_errors_rationale_1"
     },
     {
       "relation": "uses",
@@ -11183,11 +11453,11 @@
       "source_file": "maria_cacau/core/error/errors.py",
       "source_location": "L5",
       "weight": 0.8,
-      "_src": "error_errors_rationale_9",
-      "_tgt": "error_models_errormodel",
+      "_src": "error_models_errormodel",
+      "_tgt": "error_errors_rationale_9",
+      "confidence_score": 0.5,
       "source": "error_models_errormodel",
-      "target": "error_errors_rationale_9",
-      "confidence_score": 0.5
+      "target": "error_errors_rationale_9"
     },
     {
       "relation": "uses",
@@ -11195,11 +11465,11 @@
       "source_file": "maria_cacau/core/error/errors.py",
       "source_location": "L5",
       "weight": 0.8,
-      "_src": "error_errors_rationale_105",
-      "_tgt": "error_models_errormodel",
+      "_src": "error_models_errormodel",
+      "_tgt": "error_errors_rationale_105",
+      "confidence_score": 0.5,
       "source": "error_models_errormodel",
-      "target": "error_errors_rationale_105",
-      "confidence_score": 0.5
+      "target": "error_errors_rationale_105"
     },
     {
       "relation": "uses",
@@ -11207,11 +11477,11 @@
       "source_file": "maria_cacau/core/error/errors.py",
       "source_location": "L5",
       "weight": 0.8,
-      "_src": "error_errors_rationale_114",
-      "_tgt": "error_models_errormodel",
+      "_src": "error_models_errormodel",
+      "_tgt": "error_errors_rationale_114",
+      "confidence_score": 0.5,
       "source": "error_models_errormodel",
-      "target": "error_errors_rationale_114",
-      "confidence_score": 0.5
+      "target": "error_errors_rationale_114"
     },
     {
       "relation": "uses",
@@ -11219,11 +11489,11 @@
       "source_file": "maria_cacau/core/error/errors.py",
       "source_location": "L5",
       "weight": 0.8,
-      "_src": "error_errors_rationale_123",
-      "_tgt": "error_models_errormodel",
+      "_src": "error_models_errormodel",
+      "_tgt": "error_errors_rationale_123",
+      "confidence_score": 0.5,
       "source": "error_models_errormodel",
-      "target": "error_errors_rationale_123",
-      "confidence_score": 0.5
+      "target": "error_errors_rationale_123"
     },
     {
       "relation": "uses",
@@ -11231,11 +11501,11 @@
       "source_file": "maria_cacau/core/error/errors.py",
       "source_location": "L5",
       "weight": 0.8,
-      "_src": "error_errors_rationale_132",
-      "_tgt": "error_models_errormodel",
+      "_src": "error_models_errormodel",
+      "_tgt": "error_errors_rationale_132",
+      "confidence_score": 0.5,
       "source": "error_models_errormodel",
-      "target": "error_errors_rationale_132",
-      "confidence_score": 0.5
+      "target": "error_errors_rationale_132"
     },
     {
       "relation": "uses",
@@ -11243,11 +11513,11 @@
       "source_file": "maria_cacau/core/error/errors.py",
       "source_location": "L5",
       "weight": 0.8,
-      "_src": "error_errors_rationale_141",
-      "_tgt": "error_models_errormodel",
+      "_src": "error_models_errormodel",
+      "_tgt": "error_errors_rationale_141",
+      "confidence_score": 0.5,
       "source": "error_models_errormodel",
-      "target": "error_errors_rationale_141",
-      "confidence_score": 0.5
+      "target": "error_errors_rationale_141"
     },
     {
       "relation": "uses",
@@ -11255,11 +11525,11 @@
       "source_file": "maria_cacau/core/error/errors.py",
       "source_location": "L5",
       "weight": 0.8,
-      "_src": "error_errors_rationale_150",
-      "_tgt": "error_models_errormodel",
+      "_src": "error_models_errormodel",
+      "_tgt": "error_errors_rationale_150",
+      "confidence_score": 0.5,
       "source": "error_models_errormodel",
-      "target": "error_errors_rationale_150",
-      "confidence_score": 0.5
+      "target": "error_errors_rationale_150"
     },
     {
       "relation": "calls",
@@ -11292,8 +11562,8 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/presentation/controller.py",
       "source_location": "L54",
       "weight": 1.0,
-      "_src": "presentation_controller_deliverycontroller_handle_error",
-      "_tgt": "error_models_errormodel_to_popup",
+      "_src": "error_models_errormodel_to_popup",
+      "_tgt": "presentation_controller_deliverycontroller_handle_error",
       "source": "error_models_errormodel_to_popup",
       "target": "presentation_controller_deliverycontroller_handle_error"
     },
@@ -11304,8 +11574,8 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/presentation/controller.py",
       "source_location": "L55",
       "weight": 1.0,
-      "_src": "presentation_controller_summarycontroller_handle_error",
-      "_tgt": "error_models_errormodel_to_popup",
+      "_src": "error_models_errormodel_to_popup",
+      "_tgt": "presentation_controller_summarycontroller_handle_error",
       "source": "error_models_errormodel_to_popup",
       "target": "presentation_controller_summarycontroller_handle_error"
     },
@@ -11316,8 +11586,8 @@
       "source_file": "maria_cacau/features/sheets/presentation/controller.py",
       "source_location": "L122",
       "weight": 1.0,
-      "_src": "presentation_controller_sheetscontroller_on_error",
-      "_tgt": "error_models_errormodel_to_popup",
+      "_src": "error_models_errormodel_to_popup",
+      "_tgt": "presentation_controller_sheetscontroller_on_error",
       "source": "error_models_errormodel_to_popup",
       "target": "presentation_controller_sheetscontroller_on_error"
     },
@@ -11328,8 +11598,8 @@
       "source_file": "maria_cacau/features/auth/presentation/controller.py",
       "source_location": "L56",
       "weight": 1.0,
-      "_src": "presentation_controller_authcontroller_on_error",
-      "_tgt": "error_models_errormodel_to_popup",
+      "_src": "error_models_errormodel_to_popup",
+      "_tgt": "presentation_controller_authcontroller_on_error",
       "source": "error_models_errormodel_to_popup",
       "target": "presentation_controller_authcontroller_on_error"
     },
@@ -11580,8 +11850,8 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/presentation/viewmodel.py",
       "source_location": "L29",
       "weight": 1.0,
-      "_src": "presentation_viewmodel_deliveryviewmodel_fetch",
-      "_tgt": "error_errors_unexpected_error",
+      "_src": "error_errors_unexpected_error",
+      "_tgt": "presentation_viewmodel_deliveryviewmodel_fetch",
       "source": "error_errors_unexpected_error",
       "target": "presentation_viewmodel_deliveryviewmodel_fetch"
     },
@@ -11592,8 +11862,8 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/presentation/viewmodel.py",
       "source_location": "L30",
       "weight": 1.0,
-      "_src": "presentation_viewmodel_summaryviewmodel_fetch",
-      "_tgt": "error_errors_unexpected_error",
+      "_src": "error_errors_unexpected_error",
+      "_tgt": "presentation_viewmodel_summaryviewmodel_fetch",
       "source": "error_errors_unexpected_error",
       "target": "presentation_viewmodel_summaryviewmodel_fetch"
     },
@@ -11604,8 +11874,8 @@
       "source_file": "maria_cacau/features/sheets/presentation/viewmodel.py",
       "source_location": "L34",
       "weight": 1.0,
-      "_src": "presentation_viewmodel_sheetsviewmodel_update_name",
-      "_tgt": "error_errors_unexpected_error",
+      "_src": "error_errors_unexpected_error",
+      "_tgt": "presentation_viewmodel_sheetsviewmodel_update_name",
       "source": "error_errors_unexpected_error",
       "target": "presentation_viewmodel_sheetsviewmodel_update_name"
     },
@@ -11616,8 +11886,8 @@
       "source_file": "maria_cacau/features/sheets/presentation/viewmodel.py",
       "source_location": "L46",
       "weight": 1.0,
-      "_src": "presentation_viewmodel_sheetsviewmodel_connect",
-      "_tgt": "error_errors_unexpected_error",
+      "_src": "error_errors_unexpected_error",
+      "_tgt": "presentation_viewmodel_sheetsviewmodel_connect",
       "source": "error_errors_unexpected_error",
       "target": "presentation_viewmodel_sheetsviewmodel_connect"
     },
@@ -11628,8 +11898,8 @@
       "source_file": "maria_cacau/features/sheets/presentation/viewmodel.py",
       "source_location": "L57",
       "weight": 1.0,
-      "_src": "presentation_viewmodel_sheetsviewmodel_select",
-      "_tgt": "error_errors_unexpected_error",
+      "_src": "error_errors_unexpected_error",
+      "_tgt": "presentation_viewmodel_sheetsviewmodel_select",
       "source": "error_errors_unexpected_error",
       "target": "presentation_viewmodel_sheetsviewmodel_select"
     },
@@ -11640,8 +11910,8 @@
       "source_file": "maria_cacau/features/sheets/presentation/viewmodel.py",
       "source_location": "L67",
       "weight": 1.0,
-      "_src": "presentation_viewmodel_sheetsviewmodel_remove",
-      "_tgt": "error_errors_unexpected_error",
+      "_src": "error_errors_unexpected_error",
+      "_tgt": "presentation_viewmodel_sheetsviewmodel_remove",
       "source": "error_errors_unexpected_error",
       "target": "presentation_viewmodel_sheetsviewmodel_remove"
     },
@@ -11652,8 +11922,8 @@
       "source_file": "maria_cacau/features/auth/presentation/viewmodel.py",
       "source_location": "L26",
       "weight": 1.0,
-      "_src": "presentation_viewmodel_authviewmodel_configure",
-      "_tgt": "error_errors_unexpected_error",
+      "_src": "error_errors_unexpected_error",
+      "_tgt": "presentation_viewmodel_authviewmodel_configure",
       "source": "error_errors_unexpected_error",
       "target": "presentation_viewmodel_authviewmodel_configure"
     },
@@ -11664,8 +11934,8 @@
       "source_file": "maria_cacau/features/auth/presentation/viewmodel.py",
       "source_location": "L37",
       "weight": 1.0,
-      "_src": "presentation_viewmodel_authviewmodel_clear",
-      "_tgt": "error_errors_unexpected_error",
+      "_src": "error_errors_unexpected_error",
+      "_tgt": "presentation_viewmodel_authviewmodel_clear",
       "source": "error_errors_unexpected_error",
       "target": "presentation_viewmodel_authviewmodel_clear"
     },
@@ -11700,8 +11970,8 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/data/mapper.py",
       "source_location": "L16",
       "weight": 1.0,
-      "_src": "data_mapper_from_response",
-      "_tgt": "error_errors_http_error",
+      "_src": "error_errors_http_error",
+      "_tgt": "data_mapper_from_response",
       "source": "error_errors_http_error",
       "target": "data_mapper_from_response"
     },
@@ -11833,9 +12103,9 @@
       "weight": 0.8,
       "_src": "app_coordinator_appcoordinator",
       "_tgt": "backend_server_backendserver",
+      "confidence_score": 0.5,
       "source": "app_coordinator_appcoordinator",
-      "target": "backend_server_backendserver",
-      "confidence_score": 0.5
+      "target": "backend_server_backendserver"
     },
     {
       "relation": "uses",
@@ -11845,9 +12115,9 @@
       "weight": 0.8,
       "_src": "app_coordinator_appcoordinator",
       "_tgt": "app_window_mainwindow",
+      "confidence_score": 0.5,
       "source": "app_coordinator_appcoordinator",
-      "target": "app_window_mainwindow",
-      "confidence_score": 0.5
+      "target": "app_window_mainwindow"
     },
     {
       "relation": "calls",
@@ -12023,11 +12293,11 @@
       "source_file": "maria_cacau/app/window.py",
       "source_location": "L7",
       "weight": 0.8,
-      "_src": "app_window_mainwindow",
-      "_tgt": "app_handler_menuhandler",
+      "_src": "app_handler_menuhandler",
+      "_tgt": "app_window_mainwindow",
+      "confidence_score": 0.5,
       "source": "app_handler_menuhandler",
-      "target": "app_window_mainwindow",
-      "confidence_score": 0.5
+      "target": "app_window_mainwindow"
     },
     {
       "relation": "calls",
@@ -12036,8 +12306,8 @@
       "source_file": "maria_cacau/app/window.py",
       "source_location": "L14",
       "weight": 1.0,
-      "_src": "app_window_mainwindow_init",
-      "_tgt": "app_handler_menuhandler",
+      "_src": "app_handler_menuhandler",
+      "_tgt": "app_window_mainwindow_init",
       "source": "app_handler_menuhandler",
       "target": "app_window_mainwindow_init"
     },
@@ -12108,8 +12378,8 @@
       "source_file": "maria_cacau/app/window.py",
       "source_location": "L34",
       "weight": 1.0,
-      "_src": "app_window_mainwindow_setup_menus",
-      "_tgt": "app_handler_menuhandler_setup_menus",
+      "_src": "app_handler_menuhandler_setup_menus",
+      "_tgt": "app_window_mainwindow_setup_menus",
       "source": "app_handler_menuhandler_setup_menus",
       "target": "app_window_mainwindow_setup_menus"
     },
@@ -12397,9 +12667,9 @@
       "weight": 0.8,
       "_src": "buttons_button_dsbutton",
       "_tgt": "buttons_states_dsbuttonstate",
+      "confidence_score": 0.5,
       "source": "buttons_button_dsbutton",
-      "target": "buttons_states_dsbuttonstate",
-      "confidence_score": 0.5
+      "target": "buttons_states_dsbuttonstate"
     },
     {
       "relation": "calls",
@@ -12408,8 +12678,8 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/presentation/view.py",
       "source_location": "L43",
       "weight": 1.0,
-      "_src": "presentation_view_deliveryview_setup_components",
-      "_tgt": "buttons_button_dsbutton",
+      "_src": "buttons_button_dsbutton",
+      "_tgt": "presentation_view_deliveryview_setup_components",
       "source": "buttons_button_dsbutton",
       "target": "presentation_view_deliveryview_setup_components"
     },
@@ -12420,8 +12690,8 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/presentation/view.py",
       "source_location": "L52",
       "weight": 1.0,
-      "_src": "presentation_view_summaryview_setup_components",
-      "_tgt": "buttons_button_dsbutton",
+      "_src": "buttons_button_dsbutton",
+      "_tgt": "presentation_view_summaryview_setup_components",
       "source": "buttons_button_dsbutton",
       "target": "presentation_view_summaryview_setup_components"
     },
@@ -12432,8 +12702,8 @@
       "source_file": "maria_cacau/features/cpf_validation/presentation/view.py",
       "source_location": "L43",
       "weight": 1.0,
-      "_src": "presentation_view_cpfvalidationview_setup_components",
-      "_tgt": "buttons_button_dsbutton",
+      "_src": "buttons_button_dsbutton",
+      "_tgt": "presentation_view_cpfvalidationview_setup_components",
       "source": "buttons_button_dsbutton",
       "target": "presentation_view_cpfvalidationview_setup_components"
     },
@@ -12444,8 +12714,8 @@
       "source_file": "pocs/design-system/poc_date_picker.py",
       "source_location": "L106",
       "weight": 1.0,
-      "_src": "design_system_poc_date_picker_daterangepicker_init",
-      "_tgt": "qpushbutton",
+      "_src": "qpushbutton",
+      "_tgt": "design_system_poc_date_picker_daterangepicker_init",
       "source": "qpushbutton",
       "target": "design_system_poc_date_picker_daterangepicker_init"
     },
@@ -12492,8 +12762,8 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/presentation/view.py",
       "source_location": "L101",
       "weight": 1.0,
-      "_src": "presentation_view_deliveryview_activate_button_state",
-      "_tgt": "buttons_button_dsbutton_update_state",
+      "_src": "buttons_button_dsbutton_update_state",
+      "_tgt": "presentation_view_deliveryview_activate_button_state",
       "source": "buttons_button_dsbutton_update_state",
       "target": "presentation_view_deliveryview_activate_button_state"
     },
@@ -12504,8 +12774,8 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/presentation/view.py",
       "source_location": "L110",
       "weight": 1.0,
-      "_src": "presentation_view_deliveryview_prepare_to_fetch",
-      "_tgt": "buttons_button_dsbutton_update_state",
+      "_src": "buttons_button_dsbutton_update_state",
+      "_tgt": "presentation_view_deliveryview_prepare_to_fetch",
       "source": "buttons_button_dsbutton_update_state",
       "target": "presentation_view_deliveryview_prepare_to_fetch"
     },
@@ -12516,8 +12786,8 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/presentation/view.py",
       "source_location": "L130",
       "weight": 1.0,
-      "_src": "presentation_view_summaryview_activate_button_state",
-      "_tgt": "buttons_button_dsbutton_update_state",
+      "_src": "buttons_button_dsbutton_update_state",
+      "_tgt": "presentation_view_summaryview_activate_button_state",
       "source": "buttons_button_dsbutton_update_state",
       "target": "presentation_view_summaryview_activate_button_state"
     },
@@ -12528,8 +12798,8 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/presentation/view.py",
       "source_location": "L139",
       "weight": 1.0,
-      "_src": "presentation_view_summaryview_prepare_to_fetch",
-      "_tgt": "buttons_button_dsbutton_update_state",
+      "_src": "buttons_button_dsbutton_update_state",
+      "_tgt": "presentation_view_summaryview_prepare_to_fetch",
       "source": "buttons_button_dsbutton_update_state",
       "target": "presentation_view_summaryview_prepare_to_fetch"
     },
@@ -12587,11 +12857,11 @@
       "source_file": "maria_cacau/design_system/components/chart/chart_widget.py",
       "source_location": "L15",
       "weight": 0.8,
-      "_src": "chart_chart_widget_dschart",
-      "_tgt": "chart_chart_type_dscharttype",
+      "_src": "chart_chart_type_dscharttype",
+      "_tgt": "chart_chart_widget_dschart",
+      "confidence_score": 0.5,
       "source": "chart_chart_type_dscharttype",
-      "target": "chart_chart_widget_dschart",
-      "confidence_score": 0.5
+      "target": "chart_chart_widget_dschart"
     },
     {
       "relation": "uses",
@@ -12599,11 +12869,11 @@
       "source_file": "maria_cacau/design_system/components/chart/chart_widget.py",
       "source_location": "L15",
       "weight": 0.8,
-      "_src": "chart_chart_widget_rationale_1",
-      "_tgt": "chart_chart_type_dscharttype",
+      "_src": "chart_chart_type_dscharttype",
+      "_tgt": "chart_chart_widget_rationale_1",
+      "confidence_score": 0.5,
       "source": "chart_chart_type_dscharttype",
-      "target": "chart_chart_widget_rationale_1",
-      "confidence_score": 0.5
+      "target": "chart_chart_widget_rationale_1"
     },
     {
       "relation": "imports_from",
@@ -12828,8 +13098,8 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/presentation/view.py",
       "source_location": "L41",
       "weight": 1.0,
-      "_src": "presentation_view_deliveryview_setup_components",
-      "_tgt": "chart_chart_widget_dschart",
+      "_src": "chart_chart_widget_dschart",
+      "_tgt": "presentation_view_deliveryview_setup_components",
       "source": "chart_chart_widget_dschart",
       "target": "presentation_view_deliveryview_setup_components"
     },
@@ -12840,8 +13110,8 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/presentation/view.py",
       "source_location": "L43",
       "weight": 1.0,
-      "_src": "presentation_view_summaryview_setup_components",
-      "_tgt": "chart_chart_widget_dschart",
+      "_src": "chart_chart_widget_dschart",
+      "_tgt": "presentation_view_summaryview_setup_components",
       "source": "chart_chart_widget_dschart",
       "target": "presentation_view_summaryview_setup_components"
     },
@@ -12960,8 +13230,8 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/presentation/view.py",
       "source_location": "L106",
       "weight": 1.0,
-      "_src": "presentation_view_summaryview_on_chart_type_changed",
-      "_tgt": "chart_chart_widget_dschart_set_type",
+      "_src": "chart_chart_widget_dschart_set_type",
+      "_tgt": "presentation_view_summaryview_on_chart_type_changed",
       "source": "chart_chart_widget_dschart_set_type",
       "target": "presentation_view_summaryview_on_chart_type_changed"
     },
@@ -13104,8 +13374,8 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/presentation/view.py",
       "source_location": "L84",
       "weight": 1.0,
-      "_src": "presentation_view_summaryview_setup_layout",
-      "_tgt": "label_label_dslabel",
+      "_src": "label_label_dslabel",
+      "_tgt": "presentation_view_summaryview_setup_layout",
       "source": "label_label_dslabel",
       "target": "presentation_view_summaryview_setup_layout"
     },
@@ -13116,8 +13386,8 @@
       "source_file": "maria_cacau/features/cpf_validation/presentation/view.py",
       "source_location": "L40",
       "weight": 1.0,
-      "_src": "presentation_view_cpfvalidationview_setup_components",
-      "_tgt": "qlabel",
+      "_src": "qlabel",
+      "_tgt": "presentation_view_cpfvalidationview_setup_components",
       "source": "qlabel",
       "target": "presentation_view_cpfvalidationview_setup_components"
     },
@@ -13128,8 +13398,8 @@
       "source_file": "maria_cacau/features/status_bar/presentation/view.py",
       "source_location": "L15",
       "weight": 1.0,
-      "_src": "presentation_view_statusbarview_init",
-      "_tgt": "qlabel",
+      "_src": "qlabel",
+      "_tgt": "presentation_view_statusbarview_init",
       "source": "qlabel",
       "target": "presentation_view_statusbarview_init"
     },
@@ -13140,8 +13410,8 @@
       "source_file": "pocs/design-system/poc_date_picker.py",
       "source_location": "L64",
       "weight": 1.0,
-      "_src": "design_system_poc_date_picker_date_field",
-      "_tgt": "qlabel",
+      "_src": "qlabel",
+      "_tgt": "design_system_poc_date_picker_date_field",
       "source": "qlabel",
       "target": "design_system_poc_date_picker_date_field"
     },
@@ -13260,8 +13530,8 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/presentation/view.py",
       "source_location": "L37",
       "weight": 1.0,
-      "_src": "presentation_view_deliveryview_setup_components",
-      "_tgt": "alerts_dialog_dsdialog",
+      "_src": "alerts_dialog_dsdialog",
+      "_tgt": "presentation_view_deliveryview_setup_components",
       "source": "alerts_dialog_dsdialog",
       "target": "presentation_view_deliveryview_setup_components"
     },
@@ -13272,8 +13542,8 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/presentation/view.py",
       "source_location": "L39",
       "weight": 1.0,
-      "_src": "presentation_view_summaryview_setup_components",
-      "_tgt": "alerts_dialog_dsdialog",
+      "_src": "alerts_dialog_dsdialog",
+      "_tgt": "presentation_view_summaryview_setup_components",
       "source": "alerts_dialog_dsdialog",
       "target": "presentation_view_summaryview_setup_components"
     },
@@ -13284,8 +13554,8 @@
       "source_file": "maria_cacau/features/sheets/presentation/controller.py",
       "source_location": "L21",
       "weight": 1.0,
-      "_src": "presentation_controller_sheetscontroller_init",
-      "_tgt": "alerts_dialog_dsdialog",
+      "_src": "alerts_dialog_dsdialog",
+      "_tgt": "presentation_controller_sheetscontroller_init",
       "source": "alerts_dialog_dsdialog",
       "target": "presentation_controller_sheetscontroller_init"
     },
@@ -13296,8 +13566,8 @@
       "source_file": "maria_cacau/features/auth/presentation/controller.py",
       "source_location": "L21",
       "weight": 1.0,
-      "_src": "presentation_controller_authcontroller_init",
-      "_tgt": "alerts_dialog_dsdialog",
+      "_src": "alerts_dialog_dsdialog",
+      "_tgt": "presentation_controller_authcontroller_init",
       "source": "alerts_dialog_dsdialog",
       "target": "presentation_controller_authcontroller_init"
     },
@@ -13332,8 +13602,8 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/presentation/controller.py",
       "source_location": "L54",
       "weight": 1.0,
-      "_src": "presentation_controller_deliverycontroller_handle_error",
-      "_tgt": "alerts_dialog_dsdialog_show",
+      "_src": "alerts_dialog_dsdialog_show",
+      "_tgt": "presentation_controller_deliverycontroller_handle_error",
       "source": "alerts_dialog_dsdialog_show",
       "target": "presentation_controller_deliverycontroller_handle_error"
     },
@@ -13344,8 +13614,8 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/presentation/controller.py",
       "source_location": "L55",
       "weight": 1.0,
-      "_src": "presentation_controller_summarycontroller_handle_error",
-      "_tgt": "alerts_dialog_dsdialog_show",
+      "_src": "alerts_dialog_dsdialog_show",
+      "_tgt": "presentation_controller_summarycontroller_handle_error",
       "source": "alerts_dialog_dsdialog_show",
       "target": "presentation_controller_summarycontroller_handle_error"
     },
@@ -13356,8 +13626,8 @@
       "source_file": "maria_cacau/features/sheets/presentation/controller.py",
       "source_location": "L122",
       "weight": 1.0,
-      "_src": "presentation_controller_sheetscontroller_on_error",
-      "_tgt": "alerts_dialog_dsdialog_show",
+      "_src": "alerts_dialog_dsdialog_show",
+      "_tgt": "presentation_controller_sheetscontroller_on_error",
       "source": "alerts_dialog_dsdialog_show",
       "target": "presentation_controller_sheetscontroller_on_error"
     },
@@ -13368,8 +13638,8 @@
       "source_file": "maria_cacau/features/auth/presentation/controller.py",
       "source_location": "L56",
       "weight": 1.0,
-      "_src": "presentation_controller_authcontroller_on_error",
-      "_tgt": "alerts_dialog_dsdialog_show",
+      "_src": "alerts_dialog_dsdialog_show",
+      "_tgt": "presentation_controller_authcontroller_on_error",
       "source": "alerts_dialog_dsdialog_show",
       "target": "presentation_controller_authcontroller_on_error"
     },
@@ -13428,8 +13698,8 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/presentation/view.py",
       "source_location": "L62",
       "weight": 1.0,
-      "_src": "presentation_view_summaryview_setup_components",
-      "_tgt": "combo_box_combo_box_dscombobox",
+      "_src": "combo_box_combo_box_dscombobox",
+      "_tgt": "presentation_view_summaryview_setup_components",
       "source": "combo_box_combo_box_dscombobox",
       "target": "presentation_view_summaryview_setup_components"
     },
@@ -13500,8 +13770,8 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/presentation/view.py",
       "source_location": "L38",
       "weight": 1.0,
-      "_src": "presentation_view_deliveryview_setup_components",
-      "_tgt": "text_view_text_view_dstextview",
+      "_src": "text_view_text_view_dstextview",
+      "_tgt": "presentation_view_deliveryview_setup_components",
       "source": "text_view_text_view_dstextview",
       "target": "presentation_view_deliveryview_setup_components"
     },
@@ -13512,8 +13782,8 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/presentation/view.py",
       "source_location": "L40",
       "weight": 1.0,
-      "_src": "presentation_view_summaryview_setup_components",
-      "_tgt": "text_view_text_view_dstextview",
+      "_src": "text_view_text_view_dstextview",
+      "_tgt": "presentation_view_summaryview_setup_components",
       "source": "text_view_text_view_dstextview",
       "target": "presentation_view_summaryview_setup_components"
     },
@@ -13572,8 +13842,8 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/presentation/view.py",
       "source_location": "L62",
       "weight": 1.0,
-      "_src": "presentation_view_deliveryview_setup_layout",
-      "_tgt": "containers_group_box_dsgroupbox",
+      "_src": "containers_group_box_dsgroupbox",
+      "_tgt": "presentation_view_deliveryview_setup_layout",
       "source": "containers_group_box_dsgroupbox",
       "target": "presentation_view_deliveryview_setup_layout"
     },
@@ -13584,8 +13854,8 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/presentation/view.py",
       "source_location": "L75",
       "weight": 1.0,
-      "_src": "presentation_view_summaryview_setup_layout",
-      "_tgt": "containers_group_box_dsgroupbox",
+      "_src": "containers_group_box_dsgroupbox",
+      "_tgt": "presentation_view_summaryview_setup_layout",
       "source": "containers_group_box_dsgroupbox",
       "target": "presentation_view_summaryview_setup_layout"
     },
@@ -13644,8 +13914,8 @@
       "source_file": "maria_cacau/features/cpf_validation/presentation/view.py",
       "source_location": "L36",
       "weight": 1.0,
-      "_src": "presentation_view_cpfvalidationview_setup_components",
-      "_tgt": "inputs_text_input_dstextinput",
+      "_src": "inputs_text_input_dstextinput",
+      "_tgt": "presentation_view_cpfvalidationview_setup_components",
       "source": "inputs_text_input_dstextinput",
       "target": "presentation_view_cpfvalidationview_setup_components"
     },
@@ -13656,8 +13926,8 @@
       "source_file": "maria_cacau/features/sheets/presentation/view/sheet_create_view.py",
       "source_location": "L29",
       "weight": 1.0,
-      "_src": "view_sheet_create_view_sheetcreateview_setup_components",
-      "_tgt": "qlineedit",
+      "_src": "qlineedit",
+      "_tgt": "view_sheet_create_view_sheetcreateview_setup_components",
       "source": "qlineedit",
       "target": "view_sheet_create_view_sheetcreateview_setup_components"
     },
@@ -13716,8 +13986,8 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/presentation/view.py",
       "source_location": "L46",
       "weight": 1.0,
-      "_src": "presentation_view_deliveryview_setup_components",
-      "_tgt": "inputs_date_input_dsdateinput",
+      "_src": "inputs_date_input_dsdateinput",
+      "_tgt": "presentation_view_deliveryview_setup_components",
       "source": "inputs_date_input_dsdateinput",
       "target": "presentation_view_deliveryview_setup_components"
     },
@@ -13728,8 +13998,8 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/presentation/view.py",
       "source_location": "L49",
       "weight": 1.0,
-      "_src": "presentation_view_summaryview_setup_components",
-      "_tgt": "inputs_date_input_dsdateinput",
+      "_src": "inputs_date_input_dsdateinput",
+      "_tgt": "presentation_view_summaryview_setup_components",
       "source": "inputs_date_input_dsdateinput",
       "target": "presentation_view_summaryview_setup_components"
     },
@@ -13740,8 +14010,8 @@
       "source_file": "pocs/design-system/poc_date_picker.py",
       "source_location": "L68",
       "weight": 1.0,
-      "_src": "design_system_poc_date_picker_date_field",
-      "_tgt": "qdateedit",
+      "_src": "qdateedit",
+      "_tgt": "design_system_poc_date_picker_date_field",
       "source": "qdateedit",
       "target": "design_system_poc_date_picker_date_field"
     },
@@ -13981,9 +14251,9 @@
       "weight": 0.8,
       "_src": "source_controller_homecontroller",
       "_tgt": "source_models_homefeaturesmodel",
+      "confidence_score": 0.5,
       "source": "source_controller_homecontroller",
-      "target": "source_models_homefeaturesmodel",
-      "confidence_score": 0.5
+      "target": "source_models_homefeaturesmodel"
     },
     {
       "relation": "uses",
@@ -13993,9 +14263,9 @@
       "weight": 0.8,
       "_src": "source_controller_homecontroller",
       "_tgt": "source_view_homeview",
+      "confidence_score": 0.5,
       "source": "source_controller_homecontroller",
-      "target": "source_view_homeview",
-      "confidence_score": 0.5
+      "target": "source_view_homeview"
     },
     {
       "relation": "calls",
@@ -14099,11 +14369,11 @@
       "source_file": "maria_cacau/features/home/source/view.py",
       "source_location": "L4",
       "weight": 0.8,
-      "_src": "source_view_homeview",
-      "_tgt": "source_models_homefeaturesmodel",
+      "_src": "source_models_homefeaturesmodel",
+      "_tgt": "source_view_homeview",
+      "confidence_score": 0.5,
       "source": "source_models_homefeaturesmodel",
-      "target": "source_view_homeview",
-      "confidence_score": 0.5
+      "target": "source_view_homeview"
     },
     {
       "relation": "contains",
@@ -14257,9 +14527,9 @@
       "weight": 0.8,
       "_src": "data_mapper_errormapper",
       "_tgt": "deliveries_models_deliveriessummary",
+      "confidence_score": 0.5,
       "source": "data_mapper_errormapper",
-      "target": "deliveries_models_deliveriessummary",
-      "confidence_score": 0.5
+      "target": "deliveries_models_deliveriessummary"
     },
     {
       "relation": "uses",
@@ -14269,9 +14539,9 @@
       "weight": 0.8,
       "_src": "data_mapper_errormapper",
       "_tgt": "domain_models_deliverycount",
+      "confidence_score": 0.5,
       "source": "data_mapper_errormapper",
-      "target": "domain_models_deliverycount",
-      "confidence_score": 0.5
+      "target": "domain_models_deliverycount"
     },
     {
       "relation": "uses",
@@ -14281,9 +14551,9 @@
       "weight": 0.8,
       "_src": "data_mapper_errormapper",
       "_tgt": "domain_models_pendentorder",
+      "confidence_score": 0.5,
       "source": "data_mapper_errormapper",
-      "target": "domain_models_pendentorder",
-      "confidence_score": 0.5
+      "target": "domain_models_pendentorder"
     },
     {
       "relation": "uses",
@@ -14291,11 +14561,11 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/data/repository.py",
       "source_location": "L9",
       "weight": 0.8,
-      "_src": "data_repository_ordersrepository",
-      "_tgt": "data_mapper_errormapper",
+      "_src": "data_mapper_errormapper",
+      "_tgt": "data_repository_ordersrepository",
+      "confidence_score": 0.5,
       "source": "data_mapper_errormapper",
-      "target": "data_repository_ordersrepository",
-      "confidence_score": 0.5
+      "target": "data_repository_ordersrepository"
     },
     {
       "relation": "uses",
@@ -14303,11 +14573,11 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/data/repository.py",
       "source_location": "L9",
       "weight": 0.8,
-      "_src": "data_repository_rationale_1",
-      "_tgt": "data_mapper_errormapper",
+      "_src": "data_mapper_errormapper",
+      "_tgt": "data_repository_rationale_1",
+      "confidence_score": 0.5,
       "source": "data_mapper_errormapper",
-      "target": "data_repository_rationale_1",
-      "confidence_score": 0.5
+      "target": "data_repository_rationale_1"
     },
     {
       "relation": "uses",
@@ -14317,9 +14587,9 @@
       "weight": 0.8,
       "_src": "data_mapper_errormapper",
       "_tgt": "domain_models_orderdetail",
+      "confidence_score": 0.5,
       "source": "data_mapper_errormapper",
-      "target": "domain_models_orderdetail",
-      "confidence_score": 0.5
+      "target": "domain_models_orderdetail"
     },
     {
       "relation": "uses",
@@ -14329,9 +14599,9 @@
       "weight": 0.8,
       "_src": "data_mapper_errormapper",
       "_tgt": "domain_models_productcount",
+      "confidence_score": 0.5,
       "source": "data_mapper_errormapper",
-      "target": "domain_models_productcount",
-      "confidence_score": 0.5
+      "target": "domain_models_productcount"
     },
     {
       "relation": "uses",
@@ -14339,11 +14609,11 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/data/repository.py",
       "source_location": "L9",
       "weight": 0.8,
-      "_src": "data_repository_summaryrepository",
-      "_tgt": "data_mapper_errormapper",
+      "_src": "data_mapper_errormapper",
+      "_tgt": "data_repository_summaryrepository",
+      "confidence_score": 0.5,
       "source": "data_mapper_errormapper",
-      "target": "data_repository_summaryrepository",
-      "confidence_score": 0.5
+      "target": "data_repository_summaryrepository"
     },
     {
       "relation": "contains",
@@ -14412,8 +14682,8 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/data/repository.py",
       "source_location": "L18",
       "weight": 1.0,
-      "_src": "data_repository_ordersrepository_get_deliveries",
-      "_tgt": "data_mapper_from_response",
+      "_src": "data_mapper_from_response",
+      "_tgt": "data_repository_ordersrepository_get_deliveries",
       "source": "data_mapper_from_response",
       "target": "data_repository_ordersrepository_get_deliveries"
     },
@@ -14424,8 +14694,8 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/data/repository.py",
       "source_location": "L28",
       "weight": 1.0,
-      "_src": "data_repository_ordersrepository_get_pendent_payments",
-      "_tgt": "data_mapper_from_response",
+      "_src": "data_mapper_from_response",
+      "_tgt": "data_repository_ordersrepository_get_pendent_payments",
       "source": "data_mapper_from_response",
       "target": "data_repository_ordersrepository_get_pendent_payments"
     },
@@ -14460,8 +14730,8 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/data/repository.py",
       "source_location": "L18",
       "weight": 1.0,
-      "_src": "data_repository_summaryrepository_get_by_period",
-      "_tgt": "data_mapper_from_response",
+      "_src": "data_mapper_from_response",
+      "_tgt": "data_repository_summaryrepository_get_by_period",
       "source": "data_mapper_from_response",
       "target": "data_repository_summaryrepository_get_by_period"
     },
@@ -14473,9 +14743,9 @@
       "weight": 0.8,
       "_src": "data_mapper_deliveriesmapper",
       "_tgt": "deliveries_models_deliveriessummary",
+      "confidence_score": 0.5,
       "source": "data_mapper_deliveriesmapper",
-      "target": "deliveries_models_deliveriessummary",
-      "confidence_score": 0.5
+      "target": "deliveries_models_deliveriessummary"
     },
     {
       "relation": "uses",
@@ -14485,9 +14755,9 @@
       "weight": 0.8,
       "_src": "data_mapper_deliveriesmapper",
       "_tgt": "domain_models_deliverycount",
+      "confidence_score": 0.5,
       "source": "data_mapper_deliveriesmapper",
-      "target": "domain_models_deliverycount",
-      "confidence_score": 0.5
+      "target": "domain_models_deliverycount"
     },
     {
       "relation": "uses",
@@ -14497,9 +14767,9 @@
       "weight": 0.8,
       "_src": "data_mapper_deliveriesmapper",
       "_tgt": "domain_models_pendentorder",
+      "confidence_score": 0.5,
       "source": "data_mapper_deliveriesmapper",
-      "target": "domain_models_pendentorder",
-      "confidence_score": 0.5
+      "target": "domain_models_pendentorder"
     },
     {
       "relation": "uses",
@@ -14507,11 +14777,11 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/data/repository.py",
       "source_location": "L9",
       "weight": 0.8,
-      "_src": "data_repository_ordersrepository",
-      "_tgt": "data_mapper_deliveriesmapper",
+      "_src": "data_mapper_deliveriesmapper",
+      "_tgt": "data_repository_ordersrepository",
+      "confidence_score": 0.5,
       "source": "data_mapper_deliveriesmapper",
-      "target": "data_repository_ordersrepository",
-      "confidence_score": 0.5
+      "target": "data_repository_ordersrepository"
     },
     {
       "relation": "uses",
@@ -14519,11 +14789,11 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/data/repository.py",
       "source_location": "L9",
       "weight": 0.8,
-      "_src": "data_repository_rationale_1",
-      "_tgt": "data_mapper_deliveriesmapper",
+      "_src": "data_mapper_deliveriesmapper",
+      "_tgt": "data_repository_rationale_1",
+      "confidence_score": 0.5,
       "source": "data_mapper_deliveriesmapper",
-      "target": "data_repository_rationale_1",
-      "confidence_score": 0.5
+      "target": "data_repository_rationale_1"
     },
     {
       "relation": "uses",
@@ -14533,9 +14803,9 @@
       "weight": 0.8,
       "_src": "data_mapper_paymentsmapper",
       "_tgt": "deliveries_models_deliveriessummary",
+      "confidence_score": 0.5,
       "source": "data_mapper_paymentsmapper",
-      "target": "deliveries_models_deliveriessummary",
-      "confidence_score": 0.5
+      "target": "deliveries_models_deliveriessummary"
     },
     {
       "relation": "uses",
@@ -14545,9 +14815,9 @@
       "weight": 0.8,
       "_src": "data_mapper_paymentsmapper",
       "_tgt": "domain_models_deliverycount",
+      "confidence_score": 0.5,
       "source": "data_mapper_paymentsmapper",
-      "target": "domain_models_deliverycount",
-      "confidence_score": 0.5
+      "target": "domain_models_deliverycount"
     },
     {
       "relation": "uses",
@@ -14557,9 +14827,9 @@
       "weight": 0.8,
       "_src": "data_mapper_paymentsmapper",
       "_tgt": "domain_models_pendentorder",
+      "confidence_score": 0.5,
       "source": "data_mapper_paymentsmapper",
-      "target": "domain_models_pendentorder",
-      "confidence_score": 0.5
+      "target": "domain_models_pendentorder"
     },
     {
       "relation": "uses",
@@ -14567,11 +14837,11 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/data/repository.py",
       "source_location": "L9",
       "weight": 0.8,
-      "_src": "data_repository_ordersrepository",
-      "_tgt": "data_mapper_paymentsmapper",
+      "_src": "data_mapper_paymentsmapper",
+      "_tgt": "data_repository_ordersrepository",
+      "confidence_score": 0.5,
       "source": "data_mapper_paymentsmapper",
-      "target": "data_repository_ordersrepository",
-      "confidence_score": 0.5
+      "target": "data_repository_ordersrepository"
     },
     {
       "relation": "uses",
@@ -14579,11 +14849,11 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/data/repository.py",
       "source_location": "L9",
       "weight": 0.8,
-      "_src": "data_repository_rationale_1",
-      "_tgt": "data_mapper_paymentsmapper",
+      "_src": "data_mapper_paymentsmapper",
+      "_tgt": "data_repository_rationale_1",
+      "confidence_score": 0.5,
       "source": "data_mapper_paymentsmapper",
-      "target": "data_repository_rationale_1",
-      "confidence_score": 0.5
+      "target": "data_repository_rationale_1"
     },
     {
       "relation": "rationale_for",
@@ -14605,9 +14875,9 @@
       "weight": 0.8,
       "_src": "data_mapper_rationale_1",
       "_tgt": "deliveries_models_deliveriessummary",
+      "confidence_score": 0.5,
       "source": "data_mapper_rationale_1",
-      "target": "deliveries_models_deliveriessummary",
-      "confidence_score": 0.5
+      "target": "deliveries_models_deliveriessummary"
     },
     {
       "relation": "uses",
@@ -14617,9 +14887,9 @@
       "weight": 0.8,
       "_src": "data_mapper_rationale_1",
       "_tgt": "domain_models_deliverycount",
+      "confidence_score": 0.5,
       "source": "data_mapper_rationale_1",
-      "target": "domain_models_deliverycount",
-      "confidence_score": 0.5
+      "target": "domain_models_deliverycount"
     },
     {
       "relation": "uses",
@@ -14629,9 +14899,9 @@
       "weight": 0.8,
       "_src": "data_mapper_rationale_1",
       "_tgt": "domain_models_pendentorder",
+      "confidence_score": 0.5,
       "source": "data_mapper_rationale_1",
-      "target": "domain_models_pendentorder",
-      "confidence_score": 0.5
+      "target": "domain_models_pendentorder"
     },
     {
       "relation": "uses",
@@ -14641,9 +14911,9 @@
       "weight": 0.8,
       "_src": "data_mapper_rationale_1",
       "_tgt": "domain_models_orderdetail",
+      "confidence_score": 0.5,
       "source": "data_mapper_rationale_1",
-      "target": "domain_models_orderdetail",
-      "confidence_score": 0.5
+      "target": "domain_models_orderdetail"
     },
     {
       "relation": "uses",
@@ -14653,9 +14923,9 @@
       "weight": 0.8,
       "_src": "data_mapper_rationale_1",
       "_tgt": "domain_models_productcount",
+      "confidence_score": 0.5,
       "source": "data_mapper_rationale_1",
-      "target": "domain_models_productcount",
-      "confidence_score": 0.5
+      "target": "domain_models_productcount"
     },
     {
       "relation": "uses",
@@ -14665,9 +14935,9 @@
       "weight": 0.8,
       "_src": "data_mapper_rationale_12",
       "_tgt": "deliveries_models_deliveriessummary",
+      "confidence_score": 0.5,
       "source": "data_mapper_rationale_12",
-      "target": "deliveries_models_deliveriessummary",
-      "confidence_score": 0.5
+      "target": "deliveries_models_deliveriessummary"
     },
     {
       "relation": "uses",
@@ -14677,9 +14947,9 @@
       "weight": 0.8,
       "_src": "data_mapper_rationale_12",
       "_tgt": "domain_models_deliverycount",
+      "confidence_score": 0.5,
       "source": "data_mapper_rationale_12",
-      "target": "domain_models_deliverycount",
-      "confidence_score": 0.5
+      "target": "domain_models_deliverycount"
     },
     {
       "relation": "uses",
@@ -14689,9 +14959,9 @@
       "weight": 0.8,
       "_src": "data_mapper_rationale_12",
       "_tgt": "domain_models_pendentorder",
+      "confidence_score": 0.5,
       "source": "data_mapper_rationale_12",
-      "target": "domain_models_pendentorder",
-      "confidence_score": 0.5
+      "target": "domain_models_pendentorder"
     },
     {
       "relation": "imports_from",
@@ -14795,11 +15065,11 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/data/repository.py",
       "source_location": "L8",
       "weight": 0.8,
-      "_src": "data_repository_ordersrepository",
-      "_tgt": "data_apis_deliveriesapi",
+      "_src": "data_apis_deliveriesapi",
+      "_tgt": "data_repository_ordersrepository",
+      "confidence_score": 0.5,
       "source": "data_apis_deliveriesapi",
-      "target": "data_repository_ordersrepository",
-      "confidence_score": 0.5
+      "target": "data_repository_ordersrepository"
     },
     {
       "relation": "uses",
@@ -14807,11 +15077,11 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/data/repository.py",
       "source_location": "L8",
       "weight": 0.8,
-      "_src": "data_repository_rationale_1",
-      "_tgt": "data_apis_deliveriesapi",
+      "_src": "data_apis_deliveriesapi",
+      "_tgt": "data_repository_rationale_1",
+      "confidence_score": 0.5,
       "source": "data_apis_deliveriesapi",
-      "target": "data_repository_rationale_1",
-      "confidence_score": 0.5
+      "target": "data_repository_rationale_1"
     },
     {
       "relation": "calls",
@@ -14820,8 +15090,8 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/data/repository.py",
       "source_location": "L16",
       "weight": 1.0,
-      "_src": "data_repository_ordersrepository_get_deliveries",
-      "_tgt": "data_apis_deliveriesapi",
+      "_src": "data_apis_deliveriesapi",
+      "_tgt": "data_repository_ordersrepository_get_deliveries",
       "source": "data_apis_deliveriesapi",
       "target": "data_repository_ordersrepository_get_deliveries"
     },
@@ -14951,11 +15221,11 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/data/repository.py",
       "source_location": "L8",
       "weight": 0.8,
-      "_src": "data_repository_ordersrepository",
-      "_tgt": "data_apis_paymentspendentapi",
+      "_src": "data_apis_paymentspendentapi",
+      "_tgt": "data_repository_ordersrepository",
+      "confidence_score": 0.5,
       "source": "data_apis_paymentspendentapi",
-      "target": "data_repository_ordersrepository",
-      "confidence_score": 0.5
+      "target": "data_repository_ordersrepository"
     },
     {
       "relation": "uses",
@@ -14963,11 +15233,11 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/data/repository.py",
       "source_location": "L8",
       "weight": 0.8,
-      "_src": "data_repository_rationale_1",
-      "_tgt": "data_apis_paymentspendentapi",
+      "_src": "data_apis_paymentspendentapi",
+      "_tgt": "data_repository_rationale_1",
+      "confidence_score": 0.5,
       "source": "data_apis_paymentspendentapi",
-      "target": "data_repository_rationale_1",
-      "confidence_score": 0.5
+      "target": "data_repository_rationale_1"
     },
     {
       "relation": "calls",
@@ -14976,8 +15246,8 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/data/repository.py",
       "source_location": "L26",
       "weight": 1.0,
-      "_src": "data_repository_ordersrepository_get_pendent_payments",
-      "_tgt": "data_apis_paymentspendentapi",
+      "_src": "data_apis_paymentspendentapi",
+      "_tgt": "data_repository_ordersrepository_get_pendent_payments",
       "source": "data_apis_paymentspendentapi",
       "target": "data_repository_ordersrepository_get_pendent_payments"
     },
@@ -14988,8 +15258,8 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/data/repository.py",
       "source_location": "L16",
       "weight": 1.0,
-      "_src": "data_repository_ordersrepository_get_deliveries",
-      "_tgt": "data_apis_paymentspendentapi_for_date",
+      "_src": "data_apis_paymentspendentapi_for_date",
+      "_tgt": "data_repository_ordersrepository_get_deliveries",
       "source": "data_apis_paymentspendentapi_for_date",
       "target": "data_repository_ordersrepository_get_deliveries"
     },
@@ -15000,8 +15270,8 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/data/repository.py",
       "source_location": "L26",
       "weight": 1.0,
-      "_src": "data_repository_ordersrepository_get_pendent_payments",
-      "_tgt": "data_apis_paymentspendentapi_for_date",
+      "_src": "data_apis_paymentspendentapi_for_date",
+      "_tgt": "data_repository_ordersrepository_get_pendent_payments",
       "source": "data_apis_paymentspendentapi_for_date",
       "target": "data_repository_ordersrepository_get_pendent_payments"
     },
@@ -15097,9 +15367,9 @@
       "weight": 0.8,
       "_src": "data_repository_ordersrepository",
       "_tgt": "deliveries_models_deliveriessummary",
+      "confidence_score": 0.5,
       "source": "data_repository_ordersrepository",
-      "target": "deliveries_models_deliveriessummary",
-      "confidence_score": 0.5
+      "target": "deliveries_models_deliveriessummary"
     },
     {
       "relation": "uses",
@@ -15109,9 +15379,9 @@
       "weight": 0.8,
       "_src": "data_repository_ordersrepository",
       "_tgt": "domain_models_pendentorder",
+      "confidence_score": 0.5,
       "source": "data_repository_ordersrepository",
-      "target": "domain_models_pendentorder",
-      "confidence_score": 0.5
+      "target": "domain_models_pendentorder"
     },
     {
       "relation": "calls",
@@ -15120,8 +15390,8 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/domain/use_case.py",
       "source_location": "L11",
       "weight": 1.0,
-      "_src": "domain_use_case_deliveryusecase_init",
-      "_tgt": "data_repository_ordersrepository",
+      "_src": "data_repository_ordersrepository",
+      "_tgt": "domain_use_case_deliveryusecase_init",
       "source": "data_repository_ordersrepository",
       "target": "domain_use_case_deliveryusecase_init"
     },
@@ -15157,9 +15427,9 @@
       "weight": 0.8,
       "_src": "data_repository_rationale_1",
       "_tgt": "deliveries_models_deliveriessummary",
+      "confidence_score": 0.5,
       "source": "data_repository_rationale_1",
-      "target": "deliveries_models_deliveriessummary",
-      "confidence_score": 0.5
+      "target": "deliveries_models_deliveriessummary"
     },
     {
       "relation": "uses",
@@ -15169,9 +15439,9 @@
       "weight": 0.8,
       "_src": "data_repository_rationale_1",
       "_tgt": "domain_models_pendentorder",
+      "confidence_score": 0.5,
       "source": "data_repository_rationale_1",
-      "target": "domain_models_pendentorder",
-      "confidence_score": 0.5
+      "target": "domain_models_pendentorder"
     },
     {
       "relation": "uses",
@@ -15181,9 +15451,9 @@
       "weight": 0.8,
       "_src": "data_repository_rationale_1",
       "_tgt": "domain_models_orderdetail",
+      "confidence_score": 0.5,
       "source": "data_repository_rationale_1",
-      "target": "domain_models_orderdetail",
-      "confidence_score": 0.5
+      "target": "domain_models_orderdetail"
     },
     {
       "relation": "uses",
@@ -15193,9 +15463,9 @@
       "weight": 0.8,
       "_src": "data_repository_rationale_1",
       "_tgt": "data_apis_orderssummaryapi",
+      "confidence_score": 0.5,
       "source": "data_repository_rationale_1",
-      "target": "data_apis_orderssummaryapi",
-      "confidence_score": 0.5
+      "target": "data_apis_orderssummaryapi"
     },
     {
       "relation": "uses",
@@ -15205,9 +15475,9 @@
       "weight": 0.8,
       "_src": "data_repository_rationale_1",
       "_tgt": "data_mapper_orderssummarymapper",
+      "confidence_score": 0.5,
       "source": "data_repository_rationale_1",
-      "target": "data_mapper_orderssummarymapper",
-      "confidence_score": 0.5
+      "target": "data_mapper_orderssummarymapper"
     },
     {
       "relation": "uses",
@@ -15217,9 +15487,9 @@
       "weight": 0.8,
       "_src": "data_repository_rationale_1",
       "_tgt": "domain_errors_nocachedcredentialserror",
+      "confidence_score": 0.5,
       "source": "data_repository_rationale_1",
-      "target": "domain_errors_nocachedcredentialserror",
-      "confidence_score": 0.5
+      "target": "domain_errors_nocachedcredentialserror"
     },
     {
       "relation": "uses",
@@ -15229,9 +15499,9 @@
       "weight": 0.8,
       "_src": "data_repository_rationale_1",
       "_tgt": "data_apis_connectauthapi",
+      "confidence_score": 0.5,
       "source": "data_repository_rationale_1",
-      "target": "data_apis_connectauthapi",
-      "confidence_score": 0.5
+      "target": "data_apis_connectauthapi"
     },
     {
       "relation": "uses",
@@ -15241,9 +15511,9 @@
       "weight": 0.8,
       "_src": "data_repository_rationale_1",
       "_tgt": "data_apis_disconnectauthapi",
+      "confidence_score": 0.5,
       "source": "data_repository_rationale_1",
-      "target": "data_apis_disconnectauthapi",
-      "confidence_score": 0.5
+      "target": "data_apis_disconnectauthapi"
     },
     {
       "relation": "imports_from",
@@ -15337,9 +15607,9 @@
       "weight": 0.8,
       "_src": "domain_use_case_deliveryusecase",
       "_tgt": "domain_models_deliverymodel",
+      "confidence_score": 0.5,
       "source": "domain_use_case_deliveryusecase",
-      "target": "domain_models_deliverymodel",
-      "confidence_score": 0.5
+      "target": "domain_models_deliverymodel"
     },
     {
       "relation": "uses",
@@ -15347,11 +15617,11 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/presentation/viewmodel.py",
       "source_location": "L9",
       "weight": 0.8,
-      "_src": "presentation_viewmodel_deliveryviewmodel",
-      "_tgt": "domain_use_case_deliveryusecase",
+      "_src": "domain_use_case_deliveryusecase",
+      "_tgt": "presentation_viewmodel_deliveryviewmodel",
+      "confidence_score": 0.5,
       "source": "domain_use_case_deliveryusecase",
-      "target": "presentation_viewmodel_deliveryviewmodel",
-      "confidence_score": 0.5
+      "target": "presentation_viewmodel_deliveryviewmodel"
     },
     {
       "relation": "uses",
@@ -15359,11 +15629,11 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/presentation/viewmodel.py",
       "source_location": "L9",
       "weight": 0.8,
-      "_src": "presentation_viewmodel_rationale_1",
-      "_tgt": "domain_use_case_deliveryusecase",
+      "_src": "domain_use_case_deliveryusecase",
+      "_tgt": "presentation_viewmodel_rationale_1",
+      "confidence_score": 0.5,
       "source": "domain_use_case_deliveryusecase",
-      "target": "presentation_viewmodel_rationale_1",
-      "confidence_score": 0.5
+      "target": "presentation_viewmodel_rationale_1"
     },
     {
       "relation": "uses",
@@ -15371,11 +15641,11 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/presentation/viewmodel.py",
       "source_location": "L9",
       "weight": 0.8,
-      "_src": "presentation_viewmodel_rationale_21",
-      "_tgt": "domain_use_case_deliveryusecase",
+      "_src": "domain_use_case_deliveryusecase",
+      "_tgt": "presentation_viewmodel_rationale_21",
+      "confidence_score": 0.5,
       "source": "domain_use_case_deliveryusecase",
-      "target": "presentation_viewmodel_rationale_21",
-      "confidence_score": 0.5
+      "target": "presentation_viewmodel_rationale_21"
     },
     {
       "relation": "calls",
@@ -15384,8 +15654,8 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/presentation/viewmodel.py",
       "source_location": "L14",
       "weight": 1.0,
-      "_src": "presentation_viewmodel_deliveryviewmodel_init",
-      "_tgt": "domain_use_case_deliveryusecase",
+      "_src": "domain_use_case_deliveryusecase",
+      "_tgt": "presentation_viewmodel_deliveryviewmodel_init",
       "source": "domain_use_case_deliveryusecase",
       "target": "presentation_viewmodel_deliveryviewmodel_init"
     },
@@ -15457,9 +15727,9 @@
       "weight": 0.8,
       "_src": "domain_use_case_rationale_1",
       "_tgt": "domain_models_deliverymodel",
+      "confidence_score": 0.5,
       "source": "domain_use_case_rationale_1",
-      "target": "domain_models_deliverymodel",
-      "confidence_score": 0.5
+      "target": "domain_models_deliverymodel"
     },
     {
       "relation": "uses",
@@ -15469,9 +15739,9 @@
       "weight": 0.8,
       "_src": "domain_use_case_rationale_1",
       "_tgt": "data_repository_summaryrepository",
+      "confidence_score": 0.5,
       "source": "domain_use_case_rationale_1",
-      "target": "data_repository_summaryrepository",
-      "confidence_score": 0.5
+      "target": "data_repository_summaryrepository"
     },
     {
       "relation": "uses",
@@ -15481,9 +15751,9 @@
       "weight": 0.8,
       "_src": "domain_use_case_rationale_1",
       "_tgt": "domain_models_daysummary",
+      "confidence_score": 0.5,
       "source": "domain_use_case_rationale_1",
-      "target": "domain_models_daysummary",
-      "confidence_score": 0.5
+      "target": "domain_models_daysummary"
     },
     {
       "relation": "uses",
@@ -15493,9 +15763,9 @@
       "weight": 0.8,
       "_src": "domain_use_case_rationale_1",
       "_tgt": "domain_models_orderdetail",
+      "confidence_score": 0.5,
       "source": "domain_use_case_rationale_1",
-      "target": "domain_models_orderdetail",
-      "confidence_score": 0.5
+      "target": "domain_models_orderdetail"
     },
     {
       "relation": "uses",
@@ -15505,9 +15775,9 @@
       "weight": 0.8,
       "_src": "domain_use_case_rationale_1",
       "_tgt": "domain_models_productcount",
+      "confidence_score": 0.5,
       "source": "domain_use_case_rationale_1",
-      "target": "domain_models_productcount",
-      "confidence_score": 0.5
+      "target": "domain_models_productcount"
     },
     {
       "relation": "uses",
@@ -15517,9 +15787,9 @@
       "weight": 0.8,
       "_src": "domain_use_case_rationale_1",
       "_tgt": "domain_models_productssummary",
+      "confidence_score": 0.5,
       "source": "domain_use_case_rationale_1",
-      "target": "domain_models_productssummary",
-      "confidence_score": 0.5
+      "target": "domain_models_productssummary"
     },
     {
       "relation": "uses",
@@ -15529,9 +15799,9 @@
       "weight": 0.8,
       "_src": "domain_use_case_rationale_1",
       "_tgt": "domain_models_cpfvalidationresult",
+      "confidence_score": 0.5,
       "source": "domain_use_case_rationale_1",
-      "target": "domain_models_cpfvalidationresult",
-      "confidence_score": 0.5
+      "target": "domain_models_cpfvalidationresult"
     },
     {
       "relation": "uses",
@@ -15541,9 +15811,9 @@
       "weight": 0.8,
       "_src": "domain_use_case_rationale_14",
       "_tgt": "domain_models_deliverymodel",
+      "confidence_score": 0.5,
       "source": "domain_use_case_rationale_14",
-      "target": "domain_models_deliverymodel",
-      "confidence_score": 0.5
+      "target": "domain_models_deliverymodel"
     },
     {
       "relation": "contains",
@@ -15767,11 +16037,11 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/presentation/viewmodel.py",
       "source_location": "L7",
       "weight": 0.8,
-      "_src": "presentation_viewmodel_deliveryviewmodel",
-      "_tgt": "domain_models_deliverymodel",
+      "_src": "domain_models_deliverymodel",
+      "_tgt": "presentation_viewmodel_deliveryviewmodel",
+      "confidence_score": 0.5,
       "source": "domain_models_deliverymodel",
-      "target": "presentation_viewmodel_deliveryviewmodel",
-      "confidence_score": 0.5
+      "target": "presentation_viewmodel_deliveryviewmodel"
     },
     {
       "relation": "uses",
@@ -15779,11 +16049,11 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/presentation/viewmodel.py",
       "source_location": "L7",
       "weight": 0.8,
-      "_src": "presentation_viewmodel_rationale_1",
-      "_tgt": "domain_models_deliverymodel",
+      "_src": "domain_models_deliverymodel",
+      "_tgt": "presentation_viewmodel_rationale_1",
+      "confidence_score": 0.5,
       "source": "domain_models_deliverymodel",
-      "target": "presentation_viewmodel_rationale_1",
-      "confidence_score": 0.5
+      "target": "presentation_viewmodel_rationale_1"
     },
     {
       "relation": "uses",
@@ -15791,11 +16061,11 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/presentation/viewmodel.py",
       "source_location": "L7",
       "weight": 0.8,
-      "_src": "presentation_viewmodel_rationale_21",
-      "_tgt": "domain_models_deliverymodel",
+      "_src": "domain_models_deliverymodel",
+      "_tgt": "presentation_viewmodel_rationale_21",
+      "confidence_score": 0.5,
       "source": "domain_models_deliverymodel",
-      "target": "presentation_viewmodel_rationale_21",
-      "confidence_score": 0.5
+      "target": "presentation_viewmodel_rationale_21"
     },
     {
       "relation": "uses",
@@ -15803,11 +16073,11 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/presentation/controller.py",
       "source_location": "L9",
       "weight": 0.8,
-      "_src": "presentation_controller_deliverycontroller",
-      "_tgt": "domain_models_deliveryviewdata",
+      "_src": "domain_models_deliveryviewdata",
+      "_tgt": "presentation_controller_deliverycontroller",
+      "confidence_score": 0.5,
       "source": "domain_models_deliveryviewdata",
-      "target": "presentation_controller_deliverycontroller",
-      "confidence_score": 0.5
+      "target": "presentation_controller_deliverycontroller"
     },
     {
       "relation": "uses",
@@ -15815,11 +16085,11 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/presentation/controller.py",
       "source_location": "L9",
       "weight": 0.8,
-      "_src": "presentation_controller_rationale_1",
-      "_tgt": "domain_models_deliveryviewdata",
+      "_src": "domain_models_deliveryviewdata",
+      "_tgt": "presentation_controller_rationale_1",
+      "confidence_score": 0.5,
       "source": "domain_models_deliveryviewdata",
-      "target": "presentation_controller_rationale_1",
-      "confidence_score": 0.5
+      "target": "presentation_controller_rationale_1"
     },
     {
       "relation": "uses",
@@ -15827,11 +16097,11 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/presentation/controller.py",
       "source_location": "L9",
       "weight": 0.8,
-      "_src": "presentation_controller_rationale_34",
-      "_tgt": "domain_models_deliveryviewdata",
+      "_src": "domain_models_deliveryviewdata",
+      "_tgt": "presentation_controller_rationale_34",
+      "confidence_score": 0.5,
       "source": "domain_models_deliveryviewdata",
-      "target": "presentation_controller_rationale_34",
-      "confidence_score": 0.5
+      "target": "presentation_controller_rationale_34"
     },
     {
       "relation": "uses",
@@ -15839,11 +16109,11 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/presentation/controller.py",
       "source_location": "L9",
       "weight": 0.8,
-      "_src": "presentation_controller_rationale_58",
-      "_tgt": "domain_models_deliveryviewdata",
+      "_src": "domain_models_deliveryviewdata",
+      "_tgt": "presentation_controller_rationale_58",
+      "confidence_score": 0.5,
       "source": "domain_models_deliveryviewdata",
-      "target": "presentation_controller_rationale_58",
-      "confidence_score": 0.5
+      "target": "presentation_controller_rationale_58"
     },
     {
       "relation": "uses",
@@ -15851,11 +16121,11 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/presentation/viewmodel.py",
       "source_location": "L7",
       "weight": 0.8,
-      "_src": "presentation_viewmodel_deliveryviewmodel",
-      "_tgt": "domain_models_deliveryviewdata",
+      "_src": "domain_models_deliveryviewdata",
+      "_tgt": "presentation_viewmodel_deliveryviewmodel",
+      "confidence_score": 0.5,
       "source": "domain_models_deliveryviewdata",
-      "target": "presentation_viewmodel_deliveryviewmodel",
-      "confidence_score": 0.5
+      "target": "presentation_viewmodel_deliveryviewmodel"
     },
     {
       "relation": "uses",
@@ -15863,11 +16133,11 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/presentation/viewmodel.py",
       "source_location": "L7",
       "weight": 0.8,
-      "_src": "presentation_viewmodel_rationale_1",
-      "_tgt": "domain_models_deliveryviewdata",
+      "_src": "domain_models_deliveryviewdata",
+      "_tgt": "presentation_viewmodel_rationale_1",
+      "confidence_score": 0.5,
       "source": "domain_models_deliveryviewdata",
-      "target": "presentation_viewmodel_rationale_1",
-      "confidence_score": 0.5
+      "target": "presentation_viewmodel_rationale_1"
     },
     {
       "relation": "uses",
@@ -15875,11 +16145,11 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/presentation/viewmodel.py",
       "source_location": "L7",
       "weight": 0.8,
-      "_src": "presentation_viewmodel_rationale_21",
-      "_tgt": "domain_models_deliveryviewdata",
+      "_src": "domain_models_deliveryviewdata",
+      "_tgt": "presentation_viewmodel_rationale_21",
+      "confidence_score": 0.5,
       "source": "domain_models_deliveryviewdata",
-      "target": "presentation_viewmodel_rationale_21",
-      "confidence_score": 0.5
+      "target": "presentation_viewmodel_rationale_21"
     },
     {
       "relation": "uses",
@@ -15887,11 +16157,11 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/presentation/view.py",
       "source_location": "L12",
       "weight": 0.8,
-      "_src": "presentation_view_deliveryview",
-      "_tgt": "domain_models_deliveryviewdata",
+      "_src": "domain_models_deliveryviewdata",
+      "_tgt": "presentation_view_deliveryview",
+      "confidence_score": 0.5,
       "source": "domain_models_deliveryviewdata",
-      "target": "presentation_view_deliveryview",
-      "confidence_score": 0.5
+      "target": "presentation_view_deliveryview"
     },
     {
       "relation": "uses",
@@ -15899,11 +16169,11 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/presentation/view.py",
       "source_location": "L12",
       "weight": 0.8,
-      "_src": "presentation_view_rationale_1",
-      "_tgt": "domain_models_deliveryviewdata",
+      "_src": "domain_models_deliveryviewdata",
+      "_tgt": "presentation_view_rationale_1",
+      "confidence_score": 0.5,
       "source": "domain_models_deliveryviewdata",
-      "target": "presentation_view_rationale_1",
-      "confidence_score": 0.5
+      "target": "presentation_view_rationale_1"
     },
     {
       "relation": "calls",
@@ -15912,8 +16182,8 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/presentation/viewmodel.py",
       "source_location": "L32",
       "weight": 1.0,
-      "_src": "presentation_viewmodel_deliveryviewmodel_build_view_data",
-      "_tgt": "domain_models_deliveryviewdata",
+      "_src": "domain_models_deliveryviewdata",
+      "_tgt": "presentation_viewmodel_deliveryviewmodel_build_view_data",
       "source": "domain_models_deliveryviewdata",
       "target": "presentation_viewmodel_deliveryviewmodel_build_view_data"
     },
@@ -16043,11 +16313,11 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/presentation/controller.py",
       "source_location": "L8",
       "weight": 0.8,
-      "_src": "presentation_controller_deliverycontroller",
-      "_tgt": "domain_events_featureevents",
+      "_src": "domain_events_featureevents",
+      "_tgt": "presentation_controller_deliverycontroller",
+      "confidence_score": 0.5,
       "source": "domain_events_featureevents",
-      "target": "presentation_controller_deliverycontroller",
-      "confidence_score": 0.5
+      "target": "presentation_controller_deliverycontroller"
     },
     {
       "relation": "uses",
@@ -16055,11 +16325,11 @@
       "source_file": "maria_cacau/features/cpf_validation/presentation/controller.py",
       "source_location": "L5",
       "weight": 0.8,
-      "_src": "presentation_controller_rationale_1",
-      "_tgt": "domain_events_featureevents",
+      "_src": "domain_events_featureevents",
+      "_tgt": "presentation_controller_rationale_1",
+      "confidence_score": 0.5,
       "source": "domain_events_featureevents",
-      "target": "presentation_controller_rationale_1",
-      "confidence_score": 0.5
+      "target": "presentation_controller_rationale_1"
     },
     {
       "relation": "uses",
@@ -16067,11 +16337,11 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/presentation/controller.py",
       "source_location": "L8",
       "weight": 0.8,
-      "_src": "presentation_controller_rationale_34",
-      "_tgt": "domain_events_featureevents",
+      "_src": "domain_events_featureevents",
+      "_tgt": "presentation_controller_rationale_34",
+      "confidence_score": 0.5,
       "source": "domain_events_featureevents",
-      "target": "presentation_controller_rationale_34",
-      "confidence_score": 0.5
+      "target": "presentation_controller_rationale_34"
     },
     {
       "relation": "uses",
@@ -16079,11 +16349,11 @@
       "source_file": "maria_cacau/features/home/sub_features/delivery/presentation/controller.py",
       "source_location": "L8",
       "weight": 0.8,
-      "_src": "presentation_controller_rationale_58",
-      "_tgt": "domain_events_featureevents",
+      "_src": "domain_events_featureevents",
+      "_tgt": "presentation_controller_rationale_58",
+      "confidence_score": 0.5,
       "source": "domain_events_featureevents",
-      "target": "presentation_controller_rationale_58",
-      "confidence_score": 0.5
+      "target": "presentation_controller_rationale_58"
     },
     {
       "relation": "uses",
@@ -16091,11 +16361,11 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/presentation/controller.py",
       "source_location": "L8",
       "weight": 0.8,
-      "_src": "presentation_controller_summarycontroller",
-      "_tgt": "domain_events_featureevents",
+      "_src": "domain_events_featureevents",
+      "_tgt": "presentation_controller_summarycontroller",
+      "confidence_score": 0.5,
       "source": "domain_events_featureevents",
-      "target": "presentation_controller_summarycontroller",
-      "confidence_score": 0.5
+      "target": "presentation_controller_summarycontroller"
     },
     {
       "relation": "uses",
@@ -16103,11 +16373,11 @@
       "source_file": "maria_cacau/features/sheets/presentation/controller.py",
       "source_location": "L10",
       "weight": 0.8,
-      "_src": "presentation_controller_sheetscontroller",
-      "_tgt": "domain_events_featureevents",
+      "_src": "domain_events_featureevents",
+      "_tgt": "presentation_controller_sheetscontroller",
+      "confidence_score": 0.5,
       "source": "domain_events_featureevents",
-      "target": "presentation_controller_sheetscontroller",
-      "confidence_score": 0.5
+      "target": "presentation_controller_sheetscontroller"
     },
     {
       "relation": "uses",
@@ -16115,11 +16385,11 @@
       "source_file": "maria_cacau/features/auth/presentation/controller.py",
       "source_location": "L11",
       "weight": 0.8,
-      "_src": "presentation_controller_authcontroller",
-      "_tgt": "domain_events_featureevents",
+      "_src": "domain_events_featureevents",
+      "_tgt": "presentation_controller_authcontroller",
+      "confidence_score": 0.5,
       "source": "domain_events_featureevents",
-      "target": "presentation_controller_authcontroller",
-      "confidence_score": 0.5
+      "target": "presentation_controller_authcontroller"
     },
     {
       "relation": "uses",
@@ -16127,11 +16397,11 @@
       "source_file": "maria_cacau/features/cpf_validation/presentation/controller.py",
       "source_location": "L5",
       "weight": 0.8,
-      "_src": "presentation_controller_cpfvalidationcontroller",
-      "_tgt": "domain_events_featureevents",
+      "_src": "domain_events_featureevents",
+      "_tgt": "presentation_controller_cpfvalidationcontroller",
+      "confidence_score": 0.5,
       "source": "domain_events_featureevents",
-      "target": "presentation_controller_cpfvalidationcontroller",
-      "confidence_score": 0.5
+      "target": "presentation_controller_cpfvalidationcontroller"
     },
     {
       "relation": "rationale_for",
@@ -16333,9 +16603,9 @@
       "weight": 0.8,
       "_src": "presentation_controller_deliverycontroller",
       "_tgt": "presentation_view_deliveryview",
+      "confidence_score": 0.5,
       "source": "presentation_controller_deliverycontroller",
-      "target": "presentation_view_deliveryview",
-      "confidence_score": 0.5
+      "target": "presentation_view_deliveryview"
     },
     {
       "relation": "uses",
@@ -16345,9 +16615,9 @@
       "weight": 0.8,
       "_src": "presentation_controller_deliverycontroller",
       "_tgt": "presentation_viewmodel_deliveryviewmodel",
+      "confidence_score": 0.5,
       "source": "presentation_controller_deliverycontroller",
-      "target": "presentation_viewmodel_deliveryviewmodel",
-      "confidence_score": 0.5
+      "target": "presentation_viewmodel_deliveryviewmodel"
     },
     {
       "relation": "calls",
@@ -16525,9 +16795,9 @@
       "weight": 0.8,
       "_src": "presentation_controller_rationale_1",
       "_tgt": "presentation_view_deliveryview",
+      "confidence_score": 0.5,
       "source": "presentation_controller_rationale_1",
-      "target": "presentation_view_deliveryview",
-      "confidence_score": 0.5
+      "target": "presentation_view_deliveryview"
     },
     {
       "relation": "uses",
@@ -16537,9 +16807,9 @@
       "weight": 0.8,
       "_src": "presentation_controller_rationale_1",
       "_tgt": "presentation_viewmodel_deliveryviewmodel",
+      "confidence_score": 0.5,
       "source": "presentation_controller_rationale_1",
-      "target": "presentation_viewmodel_deliveryviewmodel",
-      "confidence_score": 0.5
+      "target": "presentation_viewmodel_deliveryviewmodel"
     },
     {
       "relation": "uses",
@@ -16549,9 +16819,9 @@
       "weight": 0.8,
       "_src": "presentation_controller_rationale_1",
       "_tgt": "domain_models_productsviewdata",
+      "confidence_score": 0.5,
       "source": "presentation_controller_rationale_1",
-      "target": "domain_models_productsviewdata",
-      "confidence_score": 0.5
+      "target": "domain_models_productsviewdata"
     },
     {
       "relation": "uses",
@@ -16561,9 +16831,9 @@
       "weight": 0.8,
       "_src": "presentation_controller_rationale_1",
       "_tgt": "presentation_view_summaryview",
+      "confidence_score": 0.5,
       "source": "presentation_controller_rationale_1",
-      "target": "presentation_view_summaryview",
-      "confidence_score": 0.5
+      "target": "presentation_view_summaryview"
     },
     {
       "relation": "uses",
@@ -16573,9 +16843,9 @@
       "weight": 0.8,
       "_src": "presentation_controller_rationale_1",
       "_tgt": "presentation_viewmodel_summaryviewmodel",
+      "confidence_score": 0.5,
       "source": "presentation_controller_rationale_1",
-      "target": "presentation_viewmodel_summaryviewmodel",
-      "confidence_score": 0.5
+      "target": "presentation_viewmodel_summaryviewmodel"
     },
     {
       "relation": "uses",
@@ -16585,9 +16855,9 @@
       "weight": 0.8,
       "_src": "presentation_controller_rationale_1",
       "_tgt": "presentation_view_authview",
+      "confidence_score": 0.5,
       "source": "presentation_controller_rationale_1",
-      "target": "presentation_view_authview",
-      "confidence_score": 0.5
+      "target": "presentation_view_authview"
     },
     {
       "relation": "uses",
@@ -16597,9 +16867,9 @@
       "weight": 0.8,
       "_src": "presentation_controller_rationale_1",
       "_tgt": "presentation_viewmodel_authviewmodel",
+      "confidence_score": 0.5,
       "source": "presentation_controller_rationale_1",
-      "target": "presentation_viewmodel_authviewmodel",
-      "confidence_score": 0.5
+      "target": "presentation_viewmodel_authviewmodel"
     },
     {
       "relation": "uses",
@@ -16609,9 +16879,9 @@
       "weight": 0.8,
       "_src": "presentation_controller_rationale_1",
       "_tgt": "domain_models_cpfvalidationresult",
+      "confidence_score": 0.5,
       "source": "presentation_controller_rationale_1",
-      "target": "domain_models_cpfvalidationresult",
-      "confidence_score": 0.5
+      "target": "domain_models_cpfvalidationresult"
     },
     {
       "relation": "uses",
@@ -16621,9 +16891,9 @@
       "weight": 0.8,
       "_src": "presentation_controller_rationale_1",
       "_tgt": "presentation_view_cpfvalidationview",
+      "confidence_score": 0.5,
       "source": "presentation_controller_rationale_1",
-      "target": "presentation_view_cpfvalidationview",
-      "confidence_score": 0.5
+      "target": "presentation_view_cpfvalidationview"
     },
     {
       "relation": "uses",
@@ -16633,9 +16903,9 @@
       "weight": 0.8,
       "_src": "presentation_controller_rationale_1",
       "_tgt": "presentation_viewmodel_cpfvalidationviewmodel",
+      "confidence_score": 0.5,
       "source": "presentation_controller_rationale_1",
-      "target": "presentation_viewmodel_cpfvalidationviewmodel",
-      "confidence_score": 0.5
+      "target": "presentation_viewmodel_cpfvalidationviewmodel"
     },
     {
       "relation": "uses",
@@ -16645,9 +16915,9 @@
       "weight": 0.8,
       "_src": "presentation_controller_rationale_34",
       "_tgt": "presentation_view_deliveryview",
+      "confidence_score": 0.5,
       "source": "presentation_controller_rationale_34",
-      "target": "presentation_view_deliveryview",
-      "confidence_score": 0.5
+      "target": "presentation_view_deliveryview"
     },
     {
       "relation": "uses",
@@ -16657,9 +16927,9 @@
       "weight": 0.8,
       "_src": "presentation_controller_rationale_34",
       "_tgt": "presentation_viewmodel_deliveryviewmodel",
+      "confidence_score": 0.5,
       "source": "presentation_controller_rationale_34",
-      "target": "presentation_viewmodel_deliveryviewmodel",
-      "confidence_score": 0.5
+      "target": "presentation_viewmodel_deliveryviewmodel"
     },
     {
       "relation": "uses",
@@ -16669,9 +16939,9 @@
       "weight": 0.8,
       "_src": "presentation_controller_rationale_58",
       "_tgt": "presentation_view_deliveryview",
+      "confidence_score": 0.5,
       "source": "presentation_controller_rationale_58",
-      "target": "presentation_view_deliveryview",
-      "confidence_score": 0.5
+      "target": "presentation_view_deliveryview"
     },
     {
       "relation": "uses",
@@ -16681,9 +16951,9 @@
       "weight": 0.8,
       "_src": "presentation_controller_rationale_58",
       "_tgt": "presentation_viewmodel_deliveryviewmodel",
+      "confidence_score": 0.5,
       "source": "presentation_controller_rationale_58",
-      "target": "presentation_viewmodel_deliveryviewmodel",
-      "confidence_score": 0.5
+      "target": "presentation_viewmodel_deliveryviewmodel"
     },
     {
       "relation": "contains",
@@ -16873,9 +17143,9 @@
       "weight": 0.8,
       "_src": "presentation_viewmodel_rationale_1",
       "_tgt": "domain_models_productcount",
+      "confidence_score": 0.5,
       "source": "presentation_viewmodel_rationale_1",
-      "target": "domain_models_productcount",
-      "confidence_score": 0.5
+      "target": "domain_models_productcount"
     },
     {
       "relation": "uses",
@@ -16885,9 +17155,9 @@
       "weight": 0.8,
       "_src": "presentation_viewmodel_rationale_1",
       "_tgt": "domain_models_productssummary",
+      "confidence_score": 0.5,
       "source": "presentation_viewmodel_rationale_1",
-      "target": "domain_models_productssummary",
-      "confidence_score": 0.5
+      "target": "domain_models_productssummary"
     },
     {
       "relation": "uses",
@@ -16897,9 +17167,9 @@
       "weight": 0.8,
       "_src": "presentation_viewmodel_rationale_1",
       "_tgt": "domain_models_productsviewdata",
+      "confidence_score": 0.5,
       "source": "presentation_viewmodel_rationale_1",
-      "target": "domain_models_productsviewdata",
-      "confidence_score": 0.5
+      "target": "domain_models_productsviewdata"
     },
     {
       "relation": "uses",
@@ -16909,9 +17179,9 @@
       "weight": 0.8,
       "_src": "presentation_viewmodel_rationale_1",
       "_tgt": "domain_use_case_summaryusecase",
+      "confidence_score": 0.5,
       "source": "presentation_viewmodel_rationale_1",
-      "target": "domain_use_case_summaryusecase",
-      "confidence_score": 0.5
+      "target": "domain_use_case_summaryusecase"
     },
     {
       "relation": "uses",
@@ -16921,9 +17191,9 @@
       "weight": 0.8,
       "_src": "presentation_viewmodel_rationale_1",
       "_tgt": "domain_use_case_authusecase",
+      "confidence_score": 0.5,
       "source": "presentation_viewmodel_rationale_1",
-      "target": "domain_use_case_authusecase",
-      "confidence_score": 0.5
+      "target": "domain_use_case_authusecase"
     },
     {
       "relation": "uses",
@@ -16933,9 +17203,9 @@
       "weight": 0.8,
       "_src": "presentation_viewmodel_rationale_1",
       "_tgt": "domain_use_case_cpfvalidationusecase",
+      "confidence_score": 0.5,
       "source": "presentation_viewmodel_rationale_1",
-      "target": "domain_use_case_cpfvalidationusecase",
-      "confidence_score": 0.5
+      "target": "domain_use_case_cpfvalidationusecase"
     },
     {
       "relation": "contains",
@@ -17281,9 +17551,9 @@
       "weight": 0.8,
       "_src": "presentation_view_rationale_1",
       "_tgt": "domain_models_productsviewdata",
+      "confidence_score": 0.5,
       "source": "presentation_view_rationale_1",
-      "target": "domain_models_productsviewdata",
-      "confidence_score": 0.5
+      "target": "domain_models_productsviewdata"
     },
     {
       "relation": "uses",
@@ -17293,9 +17563,9 @@
       "weight": 0.8,
       "_src": "presentation_view_rationale_1",
       "_tgt": "domain_models_cpfvalidationresult",
+      "confidence_score": 0.5,
       "source": "presentation_view_rationale_1",
-      "target": "domain_models_cpfvalidationresult",
-      "confidence_score": 0.5
+      "target": "domain_models_cpfvalidationresult"
     },
     {
       "relation": "imports_from",
@@ -17353,9 +17623,9 @@
       "weight": 0.8,
       "_src": "data_mapper_orderssummarymapper",
       "_tgt": "domain_models_orderdetail",
+      "confidence_score": 0.5,
       "source": "data_mapper_orderssummarymapper",
-      "target": "domain_models_orderdetail",
-      "confidence_score": 0.5
+      "target": "domain_models_orderdetail"
     },
     {
       "relation": "uses",
@@ -17365,9 +17635,9 @@
       "weight": 0.8,
       "_src": "data_mapper_orderssummarymapper",
       "_tgt": "domain_models_productcount",
+      "confidence_score": 0.5,
       "source": "data_mapper_orderssummarymapper",
-      "target": "domain_models_productcount",
-      "confidence_score": 0.5
+      "target": "domain_models_productcount"
     },
     {
       "relation": "uses",
@@ -17375,11 +17645,11 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/data/repository.py",
       "source_location": "L9",
       "weight": 0.8,
-      "_src": "data_repository_summaryrepository",
-      "_tgt": "data_mapper_orderssummarymapper",
+      "_src": "data_mapper_orderssummarymapper",
+      "_tgt": "data_repository_summaryrepository",
+      "confidence_score": 0.5,
       "source": "data_mapper_orderssummarymapper",
-      "target": "data_repository_summaryrepository",
-      "confidence_score": 0.5
+      "target": "data_repository_summaryrepository"
     },
     {
       "relation": "imports_from",
@@ -17435,11 +17705,11 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/data/repository.py",
       "source_location": "L8",
       "weight": 0.8,
-      "_src": "data_repository_summaryrepository",
-      "_tgt": "data_apis_orderssummaryapi",
+      "_src": "data_apis_orderssummaryapi",
+      "_tgt": "data_repository_summaryrepository",
+      "confidence_score": 0.5,
       "source": "data_apis_orderssummaryapi",
-      "target": "data_repository_summaryrepository",
-      "confidence_score": 0.5
+      "target": "data_repository_summaryrepository"
     },
     {
       "relation": "calls",
@@ -17448,8 +17718,8 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/data/repository.py",
       "source_location": "L16",
       "weight": 1.0,
-      "_src": "data_repository_summaryrepository_get_by_period",
-      "_tgt": "data_apis_orderssummaryapi",
+      "_src": "data_apis_orderssummaryapi",
+      "_tgt": "data_repository_summaryrepository_get_by_period",
       "source": "data_apis_orderssummaryapi",
       "target": "data_repository_summaryrepository_get_by_period"
     },
@@ -17460,8 +17730,8 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/data/repository.py",
       "source_location": "L16",
       "weight": 1.0,
-      "_src": "data_repository_summaryrepository_get_by_period",
-      "_tgt": "data_apis_orderssummaryapi_for_period",
+      "_src": "data_apis_orderssummaryapi_for_period",
+      "_tgt": "data_repository_summaryrepository_get_by_period",
       "source": "data_apis_orderssummaryapi_for_period",
       "target": "data_repository_summaryrepository_get_by_period"
     },
@@ -17521,9 +17791,9 @@
       "weight": 0.8,
       "_src": "data_repository_summaryrepository",
       "_tgt": "domain_models_orderdetail",
+      "confidence_score": 0.5,
       "source": "data_repository_summaryrepository",
-      "target": "domain_models_orderdetail",
-      "confidence_score": 0.5
+      "target": "domain_models_orderdetail"
     },
     {
       "relation": "uses",
@@ -17531,11 +17801,11 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/domain/use_case.py",
       "source_location": "L5",
       "weight": 0.8,
-      "_src": "domain_use_case_summaryusecase",
-      "_tgt": "data_repository_summaryrepository",
+      "_src": "data_repository_summaryrepository",
+      "_tgt": "domain_use_case_summaryusecase",
+      "confidence_score": 0.5,
       "source": "data_repository_summaryrepository",
-      "target": "domain_use_case_summaryusecase",
-      "confidence_score": 0.5
+      "target": "domain_use_case_summaryusecase"
     },
     {
       "relation": "calls",
@@ -17544,8 +17814,8 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/domain/use_case.py",
       "source_location": "L11",
       "weight": 1.0,
-      "_src": "domain_use_case_summaryusecase_init",
-      "_tgt": "data_repository_summaryrepository",
+      "_src": "data_repository_summaryrepository",
+      "_tgt": "domain_use_case_summaryusecase_init",
       "source": "data_repository_summaryrepository",
       "target": "domain_use_case_summaryusecase_init"
     },
@@ -17641,9 +17911,9 @@
       "weight": 0.8,
       "_src": "domain_use_case_summaryusecase",
       "_tgt": "domain_models_daysummary",
+      "confidence_score": 0.5,
       "source": "domain_use_case_summaryusecase",
-      "target": "domain_models_daysummary",
-      "confidence_score": 0.5
+      "target": "domain_models_daysummary"
     },
     {
       "relation": "uses",
@@ -17653,9 +17923,9 @@
       "weight": 0.8,
       "_src": "domain_use_case_summaryusecase",
       "_tgt": "domain_models_orderdetail",
+      "confidence_score": 0.5,
       "source": "domain_use_case_summaryusecase",
-      "target": "domain_models_orderdetail",
-      "confidence_score": 0.5
+      "target": "domain_models_orderdetail"
     },
     {
       "relation": "uses",
@@ -17665,9 +17935,9 @@
       "weight": 0.8,
       "_src": "domain_use_case_summaryusecase",
       "_tgt": "domain_models_productcount",
+      "confidence_score": 0.5,
       "source": "domain_use_case_summaryusecase",
-      "target": "domain_models_productcount",
-      "confidence_score": 0.5
+      "target": "domain_models_productcount"
     },
     {
       "relation": "uses",
@@ -17677,9 +17947,9 @@
       "weight": 0.8,
       "_src": "domain_use_case_summaryusecase",
       "_tgt": "domain_models_productssummary",
+      "confidence_score": 0.5,
       "source": "domain_use_case_summaryusecase",
-      "target": "domain_models_productssummary",
-      "confidence_score": 0.5
+      "target": "domain_models_productssummary"
     },
     {
       "relation": "uses",
@@ -17687,11 +17957,11 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/presentation/viewmodel.py",
       "source_location": "L9",
       "weight": 0.8,
-      "_src": "presentation_viewmodel_summaryviewmodel",
-      "_tgt": "domain_use_case_summaryusecase",
+      "_src": "domain_use_case_summaryusecase",
+      "_tgt": "presentation_viewmodel_summaryviewmodel",
+      "confidence_score": 0.5,
       "source": "domain_use_case_summaryusecase",
-      "target": "presentation_viewmodel_summaryviewmodel",
-      "confidence_score": 0.5
+      "target": "presentation_viewmodel_summaryviewmodel"
     },
     {
       "relation": "calls",
@@ -17700,8 +17970,8 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/presentation/viewmodel.py",
       "source_location": "L16",
       "weight": 1.0,
-      "_src": "presentation_viewmodel_summaryviewmodel_init",
-      "_tgt": "domain_use_case_summaryusecase",
+      "_src": "domain_use_case_summaryusecase",
+      "_tgt": "presentation_viewmodel_summaryviewmodel_init",
       "source": "domain_use_case_summaryusecase",
       "target": "presentation_viewmodel_summaryviewmodel_init"
     },
@@ -17736,8 +18006,8 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/presentation/viewmodel.py",
       "source_location": "L24",
       "weight": 1.0,
-      "_src": "presentation_viewmodel_summaryviewmodel_fetch",
-      "_tgt": "domain_use_case_summaryusecase_get_summary",
+      "_src": "domain_use_case_summaryusecase_get_summary",
+      "_tgt": "presentation_viewmodel_summaryviewmodel_fetch",
       "source": "domain_use_case_summaryusecase_get_summary",
       "target": "presentation_viewmodel_summaryviewmodel_fetch"
     },
@@ -17927,11 +18197,11 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/presentation/viewmodel.py",
       "source_location": "L7",
       "weight": 0.8,
-      "_src": "presentation_viewmodel_summaryviewmodel",
-      "_tgt": "domain_models_productcount",
+      "_src": "domain_models_productcount",
+      "_tgt": "presentation_viewmodel_summaryviewmodel",
+      "confidence_score": 0.5,
       "source": "domain_models_productcount",
-      "target": "presentation_viewmodel_summaryviewmodel",
-      "confidence_score": 0.5
+      "target": "presentation_viewmodel_summaryviewmodel"
     },
     {
       "relation": "uses",
@@ -17939,11 +18209,11 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/presentation/viewmodel.py",
       "source_location": "L7",
       "weight": 0.8,
-      "_src": "presentation_viewmodel_summaryviewmodel",
-      "_tgt": "domain_models_productssummary",
+      "_src": "domain_models_productssummary",
+      "_tgt": "presentation_viewmodel_summaryviewmodel",
+      "confidence_score": 0.5,
       "source": "domain_models_productssummary",
-      "target": "presentation_viewmodel_summaryviewmodel",
-      "confidence_score": 0.5
+      "target": "presentation_viewmodel_summaryviewmodel"
     },
     {
       "relation": "uses",
@@ -17951,11 +18221,11 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/presentation/controller.py",
       "source_location": "L9",
       "weight": 0.8,
-      "_src": "presentation_controller_summarycontroller",
-      "_tgt": "domain_models_productsviewdata",
+      "_src": "domain_models_productsviewdata",
+      "_tgt": "presentation_controller_summarycontroller",
+      "confidence_score": 0.5,
       "source": "domain_models_productsviewdata",
-      "target": "presentation_controller_summarycontroller",
-      "confidence_score": 0.5
+      "target": "presentation_controller_summarycontroller"
     },
     {
       "relation": "uses",
@@ -17963,11 +18233,11 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/presentation/viewmodel.py",
       "source_location": "L7",
       "weight": 0.8,
-      "_src": "presentation_viewmodel_summaryviewmodel",
-      "_tgt": "domain_models_productsviewdata",
+      "_src": "domain_models_productsviewdata",
+      "_tgt": "presentation_viewmodel_summaryviewmodel",
+      "confidence_score": 0.5,
       "source": "domain_models_productsviewdata",
-      "target": "presentation_viewmodel_summaryviewmodel",
-      "confidence_score": 0.5
+      "target": "presentation_viewmodel_summaryviewmodel"
     },
     {
       "relation": "uses",
@@ -17975,11 +18245,11 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/presentation/view.py",
       "source_location": "L13",
       "weight": 0.8,
-      "_src": "presentation_view_summaryview",
-      "_tgt": "domain_models_productsviewdata",
+      "_src": "domain_models_productsviewdata",
+      "_tgt": "presentation_view_summaryview",
+      "confidence_score": 0.5,
       "source": "domain_models_productsviewdata",
-      "target": "presentation_view_summaryview",
-      "confidence_score": 0.5
+      "target": "presentation_view_summaryview"
     },
     {
       "relation": "calls",
@@ -17988,8 +18258,8 @@
       "source_file": "maria_cacau/features/home/sub_features/summary/presentation/viewmodel.py",
       "source_location": "L33",
       "weight": 1.0,
-      "_src": "presentation_viewmodel_summaryviewmodel_build_view_data",
-      "_tgt": "domain_models_productsviewdata",
+      "_src": "domain_models_productsviewdata",
+      "_tgt": "presentation_viewmodel_summaryviewmodel_build_view_data",
       "source": "domain_models_productsviewdata",
       "target": "presentation_viewmodel_summaryviewmodel_build_view_data"
     },
@@ -18157,9 +18427,9 @@
       "weight": 0.8,
       "_src": "presentation_controller_summarycontroller",
       "_tgt": "presentation_view_summaryview",
+      "confidence_score": 0.5,
       "source": "presentation_controller_summarycontroller",
-      "target": "presentation_view_summaryview",
-      "confidence_score": 0.5
+      "target": "presentation_view_summaryview"
     },
     {
       "relation": "uses",
@@ -18169,9 +18439,9 @@
       "weight": 0.8,
       "_src": "presentation_controller_summarycontroller",
       "_tgt": "presentation_viewmodel_summaryviewmodel",
+      "confidence_score": 0.5,
       "source": "presentation_controller_summarycontroller",
-      "target": "presentation_viewmodel_summaryviewmodel",
-      "confidence_score": 0.5
+      "target": "presentation_viewmodel_summaryviewmodel"
     },
     {
       "relation": "calls",
@@ -18743,11 +19013,11 @@
       "source_file": "maria_cacau/features/sheets/data/repository.py",
       "source_location": "L8",
       "weight": 0.8,
-      "_src": "data_repository_sheetsrepository",
-      "_tgt": "data_apis_selectsheetapi",
+      "_src": "data_apis_selectsheetapi",
+      "_tgt": "data_repository_sheetsrepository",
+      "confidence_score": 0.5,
       "source": "data_apis_selectsheetapi",
-      "target": "data_repository_sheetsrepository",
-      "confidence_score": 0.5
+      "target": "data_repository_sheetsrepository"
     },
     {
       "relation": "uses",
@@ -18755,11 +19025,11 @@
       "source_file": "maria_cacau/features/sheets/data/repository.py",
       "source_location": "L8",
       "weight": 0.8,
-      "_src": "data_repository_rationale_78",
-      "_tgt": "data_apis_selectsheetapi",
+      "_src": "data_apis_selectsheetapi",
+      "_tgt": "data_repository_rationale_78",
+      "confidence_score": 0.5,
       "source": "data_apis_selectsheetapi",
-      "target": "data_repository_rationale_78",
-      "confidence_score": 0.5
+      "target": "data_repository_rationale_78"
     },
     {
       "relation": "calls",
@@ -18768,8 +19038,8 @@
       "source_file": "maria_cacau/features/sheets/data/repository.py",
       "source_location": "L37",
       "weight": 1.0,
-      "_src": "data_repository_sheetsrepository_connect",
-      "_tgt": "data_apis_selectsheetapi",
+      "_src": "data_apis_selectsheetapi",
+      "_tgt": "data_repository_sheetsrepository_connect",
       "source": "data_apis_selectsheetapi",
       "target": "data_repository_sheetsrepository_connect"
     },
@@ -18780,8 +19050,8 @@
       "source_file": "maria_cacau/features/sheets/data/repository.py",
       "source_location": "L42",
       "weight": 1.0,
-      "_src": "data_repository_sheetsrepository_select",
-      "_tgt": "data_apis_selectsheetapi",
+      "_src": "data_apis_selectsheetapi",
+      "_tgt": "data_repository_sheetsrepository_select",
       "source": "data_apis_selectsheetapi",
       "target": "data_repository_sheetsrepository_select"
     },
@@ -18815,11 +19085,11 @@
       "source_file": "maria_cacau/features/sheets/data/repository.py",
       "source_location": "L8",
       "weight": 0.8,
-      "_src": "data_repository_sheetsrepository",
-      "_tgt": "data_apis_removesheetapi",
+      "_src": "data_apis_removesheetapi",
+      "_tgt": "data_repository_sheetsrepository",
+      "confidence_score": 0.5,
       "source": "data_apis_removesheetapi",
-      "target": "data_repository_sheetsrepository",
-      "confidence_score": 0.5
+      "target": "data_repository_sheetsrepository"
     },
     {
       "relation": "uses",
@@ -18827,11 +19097,11 @@
       "source_file": "maria_cacau/features/sheets/data/repository.py",
       "source_location": "L8",
       "weight": 0.8,
-      "_src": "data_repository_rationale_78",
-      "_tgt": "data_apis_removesheetapi",
+      "_src": "data_apis_removesheetapi",
+      "_tgt": "data_repository_rationale_78",
+      "confidence_score": 0.5,
       "source": "data_apis_removesheetapi",
-      "target": "data_repository_rationale_78",
-      "confidence_score": 0.5
+      "target": "data_repository_rationale_78"
     },
     {
       "relation": "calls",
@@ -18840,8 +19110,8 @@
       "source_file": "maria_cacau/features/sheets/data/repository.py",
       "source_location": "L64",
       "weight": 1.0,
-      "_src": "data_repository_sheetsrepository_remove",
-      "_tgt": "data_apis_removesheetapi",
+      "_src": "data_apis_removesheetapi",
+      "_tgt": "data_repository_sheetsrepository_remove",
       "source": "data_apis_removesheetapi",
       "target": "data_repository_sheetsrepository_remove"
     },
@@ -19009,9 +19279,9 @@
       "weight": 0.8,
       "_src": "data_repository_sheetsrepository",
       "_tgt": "domain_models_sheetmodel",
+      "confidence_score": 0.5,
       "source": "data_repository_sheetsrepository",
-      "target": "domain_models_sheetmodel",
-      "confidence_score": 0.5
+      "target": "domain_models_sheetmodel"
     },
     {
       "relation": "calls",
@@ -19020,8 +19290,8 @@
       "source_file": "maria_cacau/features/sheets/domain/use_case.py",
       "source_location": "L9",
       "weight": 1.0,
-      "_src": "domain_use_case_sheetsusecase_init",
-      "_tgt": "data_repository_sheetsrepository",
+      "_src": "data_repository_sheetsrepository",
+      "_tgt": "domain_use_case_sheetsusecase_init",
       "source": "data_repository_sheetsrepository",
       "target": "domain_use_case_sheetsusecase_init"
     },
@@ -19032,8 +19302,8 @@
       "source_file": "maria_cacau/features/auth/domain/init_use_case.py",
       "source_location": "L10",
       "weight": 1.0,
-      "_src": "domain_init_use_case_appinitusecase_init",
-      "_tgt": "data_repository_sheetsrepository",
+      "_src": "data_repository_sheetsrepository",
+      "_tgt": "domain_init_use_case_appinitusecase_init",
       "source": "data_repository_sheetsrepository",
       "target": "domain_init_use_case_appinitusecase_init"
     },
@@ -19212,8 +19482,8 @@
       "source_file": "maria_cacau/features/auth/domain/init_use_case.py",
       "source_location": "L18",
       "weight": 1.0,
-      "_src": "domain_init_use_case_appinitusecase_initialize",
-      "_tgt": "data_repository_sheetsrepository_last_sheet_id_from_cache",
+      "_src": "data_repository_sheetsrepository_last_sheet_id_from_cache",
+      "_tgt": "domain_init_use_case_appinitusecase_initialize",
       "source": "data_repository_sheetsrepository_last_sheet_id_from_cache",
       "target": "domain_init_use_case_appinitusecase_initialize"
     },
@@ -19225,9 +19495,9 @@
       "weight": 0.8,
       "_src": "data_repository_rationale_78",
       "_tgt": "domain_models_sheetmodel",
+      "confidence_score": 0.5,
       "source": "data_repository_rationale_78",
-      "target": "domain_models_sheetmodel",
-      "confidence_score": 0.5
+      "target": "domain_models_sheetmodel"
     },
     {
       "relation": "imports_from",
@@ -19357,9 +19627,9 @@
       "weight": 0.8,
       "_src": "domain_use_case_sheetsusecase",
       "_tgt": "domain_models_sheetmodel",
+      "confidence_score": 0.5,
       "source": "domain_use_case_sheetsusecase",
-      "target": "domain_models_sheetmodel",
-      "confidence_score": 0.5
+      "target": "domain_models_sheetmodel"
     },
     {
       "relation": "uses",
@@ -19367,11 +19637,11 @@
       "source_file": "maria_cacau/features/sheets/presentation/viewmodel.py",
       "source_location": "L8",
       "weight": 0.8,
-      "_src": "presentation_viewmodel_sheetsviewmodel",
-      "_tgt": "domain_use_case_sheetsusecase",
+      "_src": "domain_use_case_sheetsusecase",
+      "_tgt": "presentation_viewmodel_sheetsviewmodel",
+      "confidence_score": 0.5,
       "source": "domain_use_case_sheetsusecase",
-      "target": "presentation_viewmodel_sheetsviewmodel",
-      "confidence_score": 0.5
+      "target": "presentation_viewmodel_sheetsviewmodel"
     },
     {
       "relation": "calls",
@@ -19380,8 +19650,8 @@
       "source_file": "maria_cacau/features/sheets/presentation/viewmodel.py",
       "source_location": "L13",
       "weight": 1.0,
-      "_src": "presentation_viewmodel_sheetsviewmodel_init",
-      "_tgt": "domain_use_case_sheetsusecase",
+      "_src": "domain_use_case_sheetsusecase",
+      "_tgt": "presentation_viewmodel_sheetsviewmodel_init",
       "source": "domain_use_case_sheetsusecase",
       "target": "presentation_viewmodel_sheetsviewmodel_init"
     },
@@ -19463,11 +19733,11 @@
       "source_file": "maria_cacau/features/sheets/presentation/controller.py",
       "source_location": "L11",
       "weight": 0.8,
-      "_src": "presentation_controller_sheetscontroller",
-      "_tgt": "domain_models_sheetmodel",
+      "_src": "domain_models_sheetmodel",
+      "_tgt": "presentation_controller_sheetscontroller",
+      "confidence_score": 0.5,
       "source": "domain_models_sheetmodel",
-      "target": "presentation_controller_sheetscontroller",
-      "confidence_score": 0.5
+      "target": "presentation_controller_sheetscontroller"
     },
     {
       "relation": "uses",
@@ -19475,11 +19745,11 @@
       "source_file": "maria_cacau/features/sheets/presentation/viewmodel.py",
       "source_location": "L6",
       "weight": 0.8,
-      "_src": "presentation_viewmodel_sheetsviewmodel",
-      "_tgt": "domain_models_sheetmodel",
+      "_src": "domain_models_sheetmodel",
+      "_tgt": "presentation_viewmodel_sheetsviewmodel",
+      "confidence_score": 0.5,
       "source": "domain_models_sheetmodel",
-      "target": "presentation_viewmodel_sheetsviewmodel",
-      "confidence_score": 0.5
+      "target": "presentation_viewmodel_sheetsviewmodel"
     },
     {
       "relation": "imports_from",
@@ -19717,9 +19987,9 @@
       "weight": 0.8,
       "_src": "presentation_controller_sheetscontroller",
       "_tgt": "presentation_viewmodel_sheetsviewmodel",
+      "confidence_score": 0.5,
       "source": "presentation_controller_sheetscontroller",
-      "target": "presentation_viewmodel_sheetsviewmodel",
-      "confidence_score": 0.5
+      "target": "presentation_viewmodel_sheetsviewmodel"
     },
     {
       "relation": "calls",
@@ -20076,8 +20346,8 @@
       "source_file": "maria_cacau/features/auth/domain/init_use_case.py",
       "source_location": "L31",
       "weight": 1.0,
-      "_src": "domain_init_use_case_appinitusecase_initialize",
-      "_tgt": "presentation_viewmodel_sheetsviewmodel_load_all",
+      "_src": "presentation_viewmodel_sheetsviewmodel_load_all",
+      "_tgt": "domain_init_use_case_appinitusecase_initialize",
       "source": "presentation_viewmodel_sheetsviewmodel_load_all",
       "target": "domain_init_use_case_appinitusecase_initialize"
     },
@@ -20555,11 +20825,11 @@
       "source_file": "maria_cacau/features/auth/data/repository.py",
       "source_location": "L8",
       "weight": 0.8,
-      "_src": "data_repository_authrepository",
-      "_tgt": "data_apis_connectauthapi",
+      "_src": "data_apis_connectauthapi",
+      "_tgt": "data_repository_authrepository",
+      "confidence_score": 0.5,
       "source": "data_apis_connectauthapi",
-      "target": "data_repository_authrepository",
-      "confidence_score": 0.5
+      "target": "data_repository_authrepository"
     },
     {
       "relation": "uses",
@@ -20567,11 +20837,11 @@
       "source_file": "maria_cacau/features/auth/data/repository.py",
       "source_location": "L8",
       "weight": 0.8,
-      "_src": "data_repository_rationale_16",
-      "_tgt": "data_apis_connectauthapi",
+      "_src": "data_apis_connectauthapi",
+      "_tgt": "data_repository_rationale_16",
+      "confidence_score": 0.5,
       "source": "data_apis_connectauthapi",
-      "target": "data_repository_rationale_16",
-      "confidence_score": 0.5
+      "target": "data_repository_rationale_16"
     },
     {
       "relation": "uses",
@@ -20579,11 +20849,11 @@
       "source_file": "maria_cacau/features/auth/data/repository.py",
       "source_location": "L8",
       "weight": 0.8,
-      "_src": "data_repository_rationale_23",
-      "_tgt": "data_apis_connectauthapi",
+      "_src": "data_apis_connectauthapi",
+      "_tgt": "data_repository_rationale_23",
+      "confidence_score": 0.5,
       "source": "data_apis_connectauthapi",
-      "target": "data_repository_rationale_23",
-      "confidence_score": 0.5
+      "target": "data_repository_rationale_23"
     },
     {
       "relation": "uses",
@@ -20591,11 +20861,11 @@
       "source_file": "maria_cacau/features/auth/data/repository.py",
       "source_location": "L8",
       "weight": 0.8,
-      "_src": "data_repository_rationale_30",
-      "_tgt": "data_apis_connectauthapi",
+      "_src": "data_apis_connectauthapi",
+      "_tgt": "data_repository_rationale_30",
+      "confidence_score": 0.5,
       "source": "data_apis_connectauthapi",
-      "target": "data_repository_rationale_30",
-      "confidence_score": 0.5
+      "target": "data_repository_rationale_30"
     },
     {
       "relation": "uses",
@@ -20603,11 +20873,11 @@
       "source_file": "maria_cacau/features/auth/data/repository.py",
       "source_location": "L8",
       "weight": 0.8,
-      "_src": "data_repository_rationale_35",
-      "_tgt": "data_apis_connectauthapi",
+      "_src": "data_apis_connectauthapi",
+      "_tgt": "data_repository_rationale_35",
+      "confidence_score": 0.5,
       "source": "data_apis_connectauthapi",
-      "target": "data_repository_rationale_35",
-      "confidence_score": 0.5
+      "target": "data_repository_rationale_35"
     },
     {
       "relation": "calls",
@@ -20616,8 +20886,8 @@
       "source_file": "maria_cacau/features/auth/data/repository.py",
       "source_location": "L19",
       "weight": 1.0,
-      "_src": "data_repository_authrepository_configure",
-      "_tgt": "data_apis_connectauthapi",
+      "_src": "data_apis_connectauthapi",
+      "_tgt": "data_repository_authrepository_configure",
       "source": "data_apis_connectauthapi",
       "target": "data_repository_authrepository_configure"
     },
@@ -20628,8 +20898,8 @@
       "source_file": "maria_cacau/features/auth/data/repository.py",
       "source_location": "L27",
       "weight": 1.0,
-      "_src": "data_repository_authrepository_pre_login",
-      "_tgt": "data_apis_connectauthapi",
+      "_src": "data_apis_connectauthapi",
+      "_tgt": "data_repository_authrepository_pre_login",
       "source": "data_apis_connectauthapi",
       "target": "data_repository_authrepository_pre_login"
     },
@@ -20652,8 +20922,8 @@
       "source_file": "maria_cacau/features/auth/data/repository.py",
       "source_location": "L19",
       "weight": 1.0,
-      "_src": "data_repository_authrepository_configure",
-      "_tgt": "data_apis_connectauthapi_with_credentials",
+      "_src": "data_apis_connectauthapi_with_credentials",
+      "_tgt": "data_repository_authrepository_configure",
       "source": "data_apis_connectauthapi_with_credentials",
       "target": "data_repository_authrepository_configure"
     },
@@ -20664,8 +20934,8 @@
       "source_file": "maria_cacau/features/auth/data/repository.py",
       "source_location": "L27",
       "weight": 1.0,
-      "_src": "data_repository_authrepository_pre_login",
-      "_tgt": "data_apis_connectauthapi_with_credentials",
+      "_src": "data_apis_connectauthapi_with_credentials",
+      "_tgt": "data_repository_authrepository_pre_login",
       "source": "data_apis_connectauthapi_with_credentials",
       "target": "data_repository_authrepository_pre_login"
     },
@@ -20687,11 +20957,11 @@
       "source_file": "maria_cacau/features/auth/data/repository.py",
       "source_location": "L8",
       "weight": 0.8,
-      "_src": "data_repository_authrepository",
-      "_tgt": "data_apis_disconnectauthapi",
+      "_src": "data_apis_disconnectauthapi",
+      "_tgt": "data_repository_authrepository",
+      "confidence_score": 0.5,
       "source": "data_apis_disconnectauthapi",
-      "target": "data_repository_authrepository",
-      "confidence_score": 0.5
+      "target": "data_repository_authrepository"
     },
     {
       "relation": "uses",
@@ -20699,11 +20969,11 @@
       "source_file": "maria_cacau/features/auth/data/repository.py",
       "source_location": "L8",
       "weight": 0.8,
-      "_src": "data_repository_rationale_16",
-      "_tgt": "data_apis_disconnectauthapi",
+      "_src": "data_apis_disconnectauthapi",
+      "_tgt": "data_repository_rationale_16",
+      "confidence_score": 0.5,
       "source": "data_apis_disconnectauthapi",
-      "target": "data_repository_rationale_16",
-      "confidence_score": 0.5
+      "target": "data_repository_rationale_16"
     },
     {
       "relation": "uses",
@@ -20711,11 +20981,11 @@
       "source_file": "maria_cacau/features/auth/data/repository.py",
       "source_location": "L8",
       "weight": 0.8,
-      "_src": "data_repository_rationale_23",
-      "_tgt": "data_apis_disconnectauthapi",
+      "_src": "data_apis_disconnectauthapi",
+      "_tgt": "data_repository_rationale_23",
+      "confidence_score": 0.5,
       "source": "data_apis_disconnectauthapi",
-      "target": "data_repository_rationale_23",
-      "confidence_score": 0.5
+      "target": "data_repository_rationale_23"
     },
     {
       "relation": "uses",
@@ -20723,11 +20993,11 @@
       "source_file": "maria_cacau/features/auth/data/repository.py",
       "source_location": "L8",
       "weight": 0.8,
-      "_src": "data_repository_rationale_30",
-      "_tgt": "data_apis_disconnectauthapi",
+      "_src": "data_apis_disconnectauthapi",
+      "_tgt": "data_repository_rationale_30",
+      "confidence_score": 0.5,
       "source": "data_apis_disconnectauthapi",
-      "target": "data_repository_rationale_30",
-      "confidence_score": 0.5
+      "target": "data_repository_rationale_30"
     },
     {
       "relation": "uses",
@@ -20735,11 +21005,11 @@
       "source_file": "maria_cacau/features/auth/data/repository.py",
       "source_location": "L8",
       "weight": 0.8,
-      "_src": "data_repository_rationale_35",
-      "_tgt": "data_apis_disconnectauthapi",
+      "_src": "data_apis_disconnectauthapi",
+      "_tgt": "data_repository_rationale_35",
+      "confidence_score": 0.5,
       "source": "data_apis_disconnectauthapi",
-      "target": "data_repository_rationale_35",
-      "confidence_score": 0.5
+      "target": "data_repository_rationale_35"
     },
     {
       "relation": "calls",
@@ -20748,8 +21018,8 @@
       "source_file": "maria_cacau/features/auth/data/repository.py",
       "source_location": "L38",
       "weight": 1.0,
-      "_src": "data_repository_authrepository_clear",
-      "_tgt": "data_apis_disconnectauthapi",
+      "_src": "data_apis_disconnectauthapi",
+      "_tgt": "data_repository_authrepository_clear",
       "source": "data_apis_disconnectauthapi",
       "target": "data_repository_authrepository_clear"
     },
@@ -20833,9 +21103,9 @@
       "weight": 0.8,
       "_src": "data_repository_authrepository",
       "_tgt": "domain_errors_nocachedcredentialserror",
+      "confidence_score": 0.5,
       "source": "data_repository_authrepository",
-      "target": "domain_errors_nocachedcredentialserror",
-      "confidence_score": 0.5
+      "target": "domain_errors_nocachedcredentialserror"
     },
     {
       "relation": "calls",
@@ -20844,8 +21114,8 @@
       "source_file": "maria_cacau/features/auth/domain/use_case.py",
       "source_location": "L10",
       "weight": 1.0,
-      "_src": "domain_use_case_authusecase_init",
-      "_tgt": "data_repository_authrepository",
+      "_src": "data_repository_authrepository",
+      "_tgt": "domain_use_case_authusecase_init",
       "source": "data_repository_authrepository",
       "target": "domain_use_case_authusecase_init"
     },
@@ -20856,8 +21126,8 @@
       "source_file": "maria_cacau/features/auth/domain/init_use_case.py",
       "source_location": "L9",
       "weight": 1.0,
-      "_src": "domain_init_use_case_appinitusecase_init",
-      "_tgt": "data_repository_authrepository",
+      "_src": "data_repository_authrepository",
+      "_tgt": "domain_init_use_case_appinitusecase_init",
       "source": "data_repository_authrepository",
       "target": "domain_init_use_case_appinitusecase_init"
     },
@@ -20916,8 +21186,8 @@
       "source_file": "maria_cacau/features/auth/domain/init_use_case.py",
       "source_location": "L22",
       "weight": 1.0,
-      "_src": "domain_init_use_case_appinitusecase_initialize",
-      "_tgt": "data_repository_authrepository_pre_login",
+      "_src": "data_repository_authrepository_pre_login",
+      "_tgt": "domain_init_use_case_appinitusecase_initialize",
       "source": "data_repository_authrepository_pre_login",
       "target": "domain_init_use_case_appinitusecase_initialize"
     },
@@ -20940,8 +21210,8 @@
       "source_file": "maria_cacau/features/auth/domain/init_use_case.py",
       "source_location": "L13",
       "weight": 1.0,
-      "_src": "domain_init_use_case_appinitusecase_initialize",
-      "_tgt": "data_repository_authrepository_read_credentials",
+      "_src": "data_repository_authrepository_read_credentials",
+      "_tgt": "domain_init_use_case_appinitusecase_initialize",
       "source": "data_repository_authrepository_read_credentials",
       "target": "domain_init_use_case_appinitusecase_initialize"
     },
@@ -20965,9 +21235,9 @@
       "weight": 0.8,
       "_src": "data_repository_rationale_16",
       "_tgt": "domain_errors_nocachedcredentialserror",
+      "confidence_score": 0.5,
       "source": "data_repository_rationale_16",
-      "target": "domain_errors_nocachedcredentialserror",
-      "confidence_score": 0.5
+      "target": "domain_errors_nocachedcredentialserror"
     },
     {
       "relation": "uses",
@@ -20977,9 +21247,9 @@
       "weight": 0.8,
       "_src": "data_repository_rationale_23",
       "_tgt": "domain_errors_nocachedcredentialserror",
+      "confidence_score": 0.5,
       "source": "data_repository_rationale_23",
-      "target": "domain_errors_nocachedcredentialserror",
-      "confidence_score": 0.5
+      "target": "domain_errors_nocachedcredentialserror"
     },
     {
       "relation": "uses",
@@ -20989,9 +21259,9 @@
       "weight": 0.8,
       "_src": "data_repository_rationale_30",
       "_tgt": "domain_errors_nocachedcredentialserror",
+      "confidence_score": 0.5,
       "source": "data_repository_rationale_30",
-      "target": "domain_errors_nocachedcredentialserror",
-      "confidence_score": 0.5
+      "target": "domain_errors_nocachedcredentialserror"
     },
     {
       "relation": "uses",
@@ -21001,9 +21271,9 @@
       "weight": 0.8,
       "_src": "data_repository_rationale_35",
       "_tgt": "domain_errors_nocachedcredentialserror",
+      "confidence_score": 0.5,
       "source": "data_repository_rationale_35",
-      "target": "domain_errors_nocachedcredentialserror",
-      "confidence_score": 0.5
+      "target": "domain_errors_nocachedcredentialserror"
     },
     {
       "relation": "contains",
@@ -21071,11 +21341,11 @@
       "source_file": "maria_cacau/features/auth/presentation/viewmodel.py",
       "source_location": "L9",
       "weight": 0.8,
-      "_src": "presentation_viewmodel_authviewmodel",
-      "_tgt": "domain_use_case_authusecase",
+      "_src": "domain_use_case_authusecase",
+      "_tgt": "presentation_viewmodel_authviewmodel",
+      "confidence_score": 0.5,
       "source": "domain_use_case_authusecase",
-      "target": "presentation_viewmodel_authviewmodel",
-      "confidence_score": 0.5
+      "target": "presentation_viewmodel_authviewmodel"
     },
     {
       "relation": "calls",
@@ -21084,8 +21354,8 @@
       "source_file": "maria_cacau/features/auth/presentation/viewmodel.py",
       "source_location": "L14",
       "weight": 1.0,
-      "_src": "presentation_viewmodel_authviewmodel_init",
-      "_tgt": "domain_use_case_authusecase",
+      "_src": "domain_use_case_authusecase",
+      "_tgt": "presentation_viewmodel_authviewmodel_init",
       "source": "domain_use_case_authusecase",
       "target": "presentation_viewmodel_authviewmodel_init"
     },
@@ -21373,9 +21643,9 @@
       "weight": 0.8,
       "_src": "presentation_controller_authcontroller",
       "_tgt": "presentation_view_authview",
+      "confidence_score": 0.5,
       "source": "presentation_controller_authcontroller",
-      "target": "presentation_view_authview",
-      "confidence_score": 0.5
+      "target": "presentation_view_authview"
     },
     {
       "relation": "uses",
@@ -21385,9 +21655,9 @@
       "weight": 0.8,
       "_src": "presentation_controller_authcontroller",
       "_tgt": "presentation_viewmodel_authviewmodel",
+      "confidence_score": 0.5,
       "source": "presentation_controller_authcontroller",
-      "target": "presentation_viewmodel_authviewmodel",
-      "confidence_score": 0.5
+      "target": "presentation_viewmodel_authviewmodel"
     },
     {
       "relation": "calls",
@@ -21673,9 +21943,9 @@
       "weight": 0.8,
       "_src": "domain_use_case_cpfvalidationusecase",
       "_tgt": "domain_models_cpfvalidationresult",
+      "confidence_score": 0.5,
       "source": "domain_use_case_cpfvalidationusecase",
-      "target": "domain_models_cpfvalidationresult",
-      "confidence_score": 0.5
+      "target": "domain_models_cpfvalidationresult"
     },
     {
       "relation": "uses",
@@ -21683,11 +21953,11 @@
       "source_file": "maria_cacau/features/cpf_validation/presentation/viewmodel.py",
       "source_location": "L4",
       "weight": 0.8,
-      "_src": "presentation_viewmodel_cpfvalidationviewmodel",
-      "_tgt": "domain_use_case_cpfvalidationusecase",
+      "_src": "domain_use_case_cpfvalidationusecase",
+      "_tgt": "presentation_viewmodel_cpfvalidationviewmodel",
+      "confidence_score": 0.5,
       "source": "domain_use_case_cpfvalidationusecase",
-      "target": "presentation_viewmodel_cpfvalidationviewmodel",
-      "confidence_score": 0.5
+      "target": "presentation_viewmodel_cpfvalidationviewmodel"
     },
     {
       "relation": "calls",
@@ -21696,8 +21966,8 @@
       "source_file": "maria_cacau/features/cpf_validation/presentation/viewmodel.py",
       "source_location": "L9",
       "weight": 1.0,
-      "_src": "presentation_viewmodel_cpfvalidationviewmodel_init",
-      "_tgt": "domain_use_case_cpfvalidationusecase",
+      "_src": "domain_use_case_cpfvalidationusecase",
+      "_tgt": "presentation_viewmodel_cpfvalidationviewmodel_init",
       "source": "domain_use_case_cpfvalidationusecase",
       "target": "presentation_viewmodel_cpfvalidationviewmodel_init"
     },
@@ -21720,8 +21990,8 @@
       "source_file": "maria_cacau/features/cpf_validation/presentation/viewmodel.py",
       "source_location": "L12",
       "weight": 1.0,
-      "_src": "presentation_viewmodel_cpfvalidationviewmodel_on_validate",
-      "_tgt": "domain_use_case_cpfvalidationusecase_validate",
+      "_src": "domain_use_case_cpfvalidationusecase_validate",
+      "_tgt": "presentation_viewmodel_cpfvalidationviewmodel_on_validate",
       "source": "domain_use_case_cpfvalidationusecase_validate",
       "target": "presentation_viewmodel_cpfvalidationviewmodel_on_validate"
     },
@@ -21733,9 +22003,9 @@
       "weight": 0.8,
       "_src": "domain_use_case_rationale_7",
       "_tgt": "domain_models_cpfvalidationresult",
+      "confidence_score": 0.5,
       "source": "domain_use_case_rationale_7",
-      "target": "domain_models_cpfvalidationresult",
-      "confidence_score": 0.5
+      "target": "domain_models_cpfvalidationresult"
     },
     {
       "relation": "contains",
@@ -21839,11 +22109,11 @@
       "source_file": "maria_cacau/features/cpf_validation/presentation/controller.py",
       "source_location": "L6",
       "weight": 0.8,
-      "_src": "presentation_controller_cpfvalidationcontroller",
-      "_tgt": "domain_models_cpfvalidationresult",
+      "_src": "domain_models_cpfvalidationresult",
+      "_tgt": "presentation_controller_cpfvalidationcontroller",
+      "confidence_score": 0.5,
       "source": "domain_models_cpfvalidationresult",
-      "target": "presentation_controller_cpfvalidationcontroller",
-      "confidence_score": 0.5
+      "target": "presentation_controller_cpfvalidationcontroller"
     },
     {
       "relation": "uses",
@@ -21851,11 +22121,11 @@
       "source_file": "maria_cacau/features/cpf_validation/presentation/view.py",
       "source_location": "L11",
       "weight": 0.8,
-      "_src": "presentation_view_cpfvalidationview",
-      "_tgt": "domain_models_cpfvalidationresult",
+      "_src": "domain_models_cpfvalidationresult",
+      "_tgt": "presentation_view_cpfvalidationview",
+      "confidence_score": 0.5,
       "source": "domain_models_cpfvalidationresult",
-      "target": "presentation_view_cpfvalidationview",
-      "confidence_score": 0.5
+      "target": "presentation_view_cpfvalidationview"
     },
     {
       "relation": "imports_from",
@@ -21985,9 +22255,9 @@
       "weight": 0.8,
       "_src": "presentation_controller_cpfvalidationcontroller",
       "_tgt": "presentation_view_cpfvalidationview",
+      "confidence_score": 0.5,
       "source": "presentation_controller_cpfvalidationcontroller",
-      "target": "presentation_view_cpfvalidationview",
-      "confidence_score": 0.5
+      "target": "presentation_view_cpfvalidationview"
     },
     {
       "relation": "uses",
@@ -21997,9 +22267,9 @@
       "weight": 0.8,
       "_src": "presentation_controller_cpfvalidationcontroller",
       "_tgt": "presentation_viewmodel_cpfvalidationviewmodel",
+      "confidence_score": 0.5,
       "source": "presentation_controller_cpfvalidationcontroller",
-      "target": "presentation_viewmodel_cpfvalidationviewmodel",
-      "confidence_score": 0.5
+      "target": "presentation_viewmodel_cpfvalidationviewmodel"
     },
     {
       "relation": "calls",
@@ -22319,11 +22589,11 @@
       "source_file": "maria_cacau/features/status_bar/presentation/controller.py",
       "source_location": "L5",
       "weight": 0.8,
-      "_src": "presentation_controller_statusbarcontroller",
-      "_tgt": "domain_state_statusbarstate",
+      "_src": "domain_state_statusbarstate",
+      "_tgt": "presentation_controller_statusbarcontroller",
+      "confidence_score": 0.5,
       "source": "domain_state_statusbarstate",
-      "target": "presentation_controller_statusbarcontroller",
-      "confidence_score": 0.5
+      "target": "presentation_controller_statusbarcontroller"
     },
     {
       "relation": "uses",
@@ -22331,11 +22601,11 @@
       "source_file": "maria_cacau/features/status_bar/presentation/view.py",
       "source_location": "L6",
       "weight": 0.8,
-      "_src": "presentation_view_statusbarview",
-      "_tgt": "domain_state_statusbarstate",
+      "_src": "domain_state_statusbarstate",
+      "_tgt": "presentation_view_statusbarview",
+      "confidence_score": 0.5,
       "source": "domain_state_statusbarstate",
-      "target": "presentation_view_statusbarview",
-      "confidence_score": 0.5
+      "target": "presentation_view_statusbarview"
     },
     {
       "relation": "imports_from",
@@ -22501,9 +22771,9 @@
       "weight": 0.8,
       "_src": "presentation_controller_statusbarcontroller",
       "_tgt": "presentation_view_statusbarview",
+      "confidence_score": 0.5,
       "source": "presentation_controller_statusbarcontroller",
-      "target": "presentation_view_statusbarview",
-      "confidence_score": 0.5
+      "target": "presentation_view_statusbarview"
     },
     {
       "relation": "calls",
@@ -23065,9 +23335,9 @@
       "weight": 0.8,
       "_src": "data_source_google_sheets_googlesheetsdatasource",
       "_tgt": "data_source_normalizer_sheetnormalizer",
+      "confidence_score": 0.5,
       "source": "data_source_google_sheets_googlesheetsdatasource",
-      "target": "data_source_normalizer_sheetnormalizer",
-      "confidence_score": 0.5
+      "target": "data_source_normalizer_sheetnormalizer"
     },
     {
       "relation": "calls",
@@ -23245,9 +23515,9 @@
       "weight": 0.8,
       "_src": "data_source_google_sheets_rationale_16",
       "_tgt": "data_source_normalizer_sheetnormalizer",
+      "confidence_score": 0.5,
       "source": "data_source_google_sheets_rationale_16",
-      "target": "data_source_normalizer_sheetnormalizer",
-      "confidence_score": 0.5
+      "target": "data_source_normalizer_sheetnormalizer"
     },
     {
       "relation": "imports_from",
@@ -23424,8 +23694,8 @@
       "source_file": "maria_cacau/backend/features/orders/__init__.py",
       "source_location": "L15",
       "weight": 1.0,
-      "_src": "orders_init_check_connection",
-      "_tgt": "data_source_protocol_datasourceprotocol_is_ready",
+      "_src": "data_source_protocol_datasourceprotocol_is_ready",
+      "_tgt": "orders_init_check_connection",
       "source": "data_source_protocol_datasourceprotocol_is_ready",
       "target": "orders_init_check_connection"
     },
@@ -23448,8 +23718,8 @@
       "source_file": "maria_cacau/backend/features/auth/service.py",
       "source_location": "L8",
       "weight": 1.0,
-      "_src": "auth_service_authservice_connect",
-      "_tgt": "data_source_protocol_datasourceprotocol_set_credentials",
+      "_src": "data_source_protocol_datasourceprotocol_set_credentials",
+      "_tgt": "auth_service_authservice_connect",
       "source": "data_source_protocol_datasourceprotocol_set_credentials",
       "target": "auth_service_authservice_connect"
     },
@@ -23472,8 +23742,8 @@
       "source_file": "maria_cacau/backend/features/auth/service.py",
       "source_location": "L13",
       "weight": 1.0,
-      "_src": "auth_service_authservice_disconnect",
-      "_tgt": "data_source_protocol_datasourceprotocol_clear_credentials",
+      "_src": "data_source_protocol_datasourceprotocol_clear_credentials",
+      "_tgt": "auth_service_authservice_disconnect",
       "source": "data_source_protocol_datasourceprotocol_clear_credentials",
       "target": "auth_service_authservice_disconnect"
     },
@@ -23496,8 +23766,8 @@
       "source_file": "maria_cacau/backend/features/sheet/service.py",
       "source_location": "L11",
       "weight": 1.0,
-      "_src": "sheet_service_sheetservice_remove",
-      "_tgt": "data_source_protocol_datasourceprotocol_clear_sheet",
+      "_src": "data_source_protocol_datasourceprotocol_clear_sheet",
+      "_tgt": "sheet_service_sheetservice_remove",
       "source": "data_source_protocol_datasourceprotocol_clear_sheet",
       "target": "sheet_service_sheetservice_remove"
     },
@@ -23520,8 +23790,8 @@
       "source_file": "maria_cacau/backend/features/auth/service.py",
       "source_location": "L10",
       "weight": 1.0,
-      "_src": "auth_service_authservice_connect",
-      "_tgt": "data_source_protocol_datasourceprotocol_set_sheet",
+      "_src": "data_source_protocol_datasourceprotocol_set_sheet",
+      "_tgt": "auth_service_authservice_connect",
       "source": "data_source_protocol_datasourceprotocol_set_sheet",
       "target": "auth_service_authservice_connect"
     },
@@ -23532,8 +23802,8 @@
       "source_file": "maria_cacau/backend/features/sheet/service.py",
       "source_location": "L8",
       "weight": 1.0,
-      "_src": "sheet_service_sheetservice_select",
-      "_tgt": "data_source_protocol_datasourceprotocol_set_sheet",
+      "_src": "data_source_protocol_datasourceprotocol_set_sheet",
+      "_tgt": "sheet_service_sheetservice_select",
       "source": "data_source_protocol_datasourceprotocol_set_sheet",
       "target": "sheet_service_sheetservice_select"
     },
@@ -23556,8 +23826,8 @@
       "source_file": "maria_cacau/backend/features/orders/subfeatures/payments/repository.py",
       "source_location": "L19",
       "weight": 1.0,
-      "_src": "payments_repository_paymentsrepository_get_by_date",
-      "_tgt": "data_source_protocol_datasourceprotocol_fetch_orders_by_date",
+      "_src": "data_source_protocol_datasourceprotocol_fetch_orders_by_date",
+      "_tgt": "payments_repository_paymentsrepository_get_by_date",
       "source": "data_source_protocol_datasourceprotocol_fetch_orders_by_date",
       "target": "payments_repository_paymentsrepository_get_by_date"
     },
@@ -23568,8 +23838,8 @@
       "source_file": "maria_cacau/backend/features/orders/subfeatures/deliveries/repository.py",
       "source_location": "L16",
       "weight": 1.0,
-      "_src": "deliveries_repository_deliveriesrepository_get_by_date",
-      "_tgt": "data_source_protocol_datasourceprotocol_fetch_orders_by_date",
+      "_src": "data_source_protocol_datasourceprotocol_fetch_orders_by_date",
+      "_tgt": "deliveries_repository_deliveriesrepository_get_by_date",
       "source": "data_source_protocol_datasourceprotocol_fetch_orders_by_date",
       "target": "deliveries_repository_deliveriesrepository_get_by_date"
     },
@@ -23592,8 +23862,8 @@
       "source_file": "maria_cacau/backend/features/orders/subfeatures/summary/repository.py",
       "source_location": "L19",
       "weight": 1.0,
-      "_src": "summary_repository_orderssummaryrepository_get_by_period",
-      "_tgt": "data_source_protocol_datasourceprotocol_fetch_orders_by_period",
+      "_src": "data_source_protocol_datasourceprotocol_fetch_orders_by_period",
+      "_tgt": "summary_repository_orderssummaryrepository_get_by_period",
       "source": "data_source_protocol_datasourceprotocol_fetch_orders_by_period",
       "target": "summary_repository_orderssummaryrepository_get_by_period"
     },
@@ -23687,11 +23957,11 @@
       "source_file": "maria_cacau/backend/data_source/_viewmodel.py",
       "source_location": "L6",
       "weight": 0.8,
-      "_src": "data_source_viewmodel_sheetsviewmodel",
-      "_tgt": "data_source_sheet_mapper_sheettabs",
+      "_src": "data_source_sheet_mapper_sheettabs",
+      "_tgt": "data_source_viewmodel_sheetsviewmodel",
+      "confidence_score": 0.5,
       "source": "data_source_sheet_mapper_sheettabs",
-      "target": "data_source_viewmodel_sheetsviewmodel",
-      "confidence_score": 0.5
+      "target": "data_source_viewmodel_sheetsviewmodel"
     },
     {
       "relation": "uses",
@@ -23699,11 +23969,11 @@
       "source_file": "maria_cacau/backend/data_source/_viewmodel.py",
       "source_location": "L6",
       "weight": 0.8,
-      "_src": "data_source_viewmodel_rationale_10",
-      "_tgt": "data_source_sheet_mapper_sheettabs",
+      "_src": "data_source_sheet_mapper_sheettabs",
+      "_tgt": "data_source_viewmodel_rationale_10",
+      "confidence_score": 0.5,
       "source": "data_source_sheet_mapper_sheettabs",
-      "target": "data_source_viewmodel_rationale_10",
-      "confidence_score": 0.5
+      "target": "data_source_viewmodel_rationale_10"
     },
     {
       "relation": "uses",
@@ -23711,11 +23981,11 @@
       "source_file": "maria_cacau/backend/data_source/_viewmodel.py",
       "source_location": "L6",
       "weight": 0.8,
-      "_src": "data_source_viewmodel_rationale_29",
-      "_tgt": "data_source_sheet_mapper_sheettabs",
+      "_src": "data_source_sheet_mapper_sheettabs",
+      "_tgt": "data_source_viewmodel_rationale_29",
+      "confidence_score": 0.5,
       "source": "data_source_sheet_mapper_sheettabs",
-      "target": "data_source_viewmodel_rationale_29",
-      "confidence_score": 0.5
+      "target": "data_source_viewmodel_rationale_29"
     },
     {
       "relation": "uses",
@@ -23723,11 +23993,11 @@
       "source_file": "maria_cacau/backend/data_source/_viewmodel.py",
       "source_location": "L6",
       "weight": 0.8,
-      "_src": "data_source_viewmodel_rationale_43",
-      "_tgt": "data_source_sheet_mapper_sheettabs",
+      "_src": "data_source_sheet_mapper_sheettabs",
+      "_tgt": "data_source_viewmodel_rationale_43",
+      "confidence_score": 0.5,
       "source": "data_source_sheet_mapper_sheettabs",
-      "target": "data_source_viewmodel_rationale_43",
-      "confidence_score": 0.5
+      "target": "data_source_viewmodel_rationale_43"
     },
     {
       "relation": "rationale_for",
@@ -23747,11 +24017,11 @@
       "source_file": "maria_cacau/backend/data_source/_viewmodel.py",
       "source_location": "L6",
       "weight": 0.8,
-      "_src": "data_source_viewmodel_sheetsviewmodel",
-      "_tgt": "data_source_sheet_mapper_sheetcols",
+      "_src": "data_source_sheet_mapper_sheetcols",
+      "_tgt": "data_source_viewmodel_sheetsviewmodel",
+      "confidence_score": 0.5,
       "source": "data_source_sheet_mapper_sheetcols",
-      "target": "data_source_viewmodel_sheetsviewmodel",
-      "confidence_score": 0.5
+      "target": "data_source_viewmodel_sheetsviewmodel"
     },
     {
       "relation": "uses",
@@ -23759,11 +24029,11 @@
       "source_file": "maria_cacau/backend/data_source/_viewmodel.py",
       "source_location": "L6",
       "weight": 0.8,
-      "_src": "data_source_viewmodel_rationale_10",
-      "_tgt": "data_source_sheet_mapper_sheetcols",
+      "_src": "data_source_sheet_mapper_sheetcols",
+      "_tgt": "data_source_viewmodel_rationale_10",
+      "confidence_score": 0.5,
       "source": "data_source_sheet_mapper_sheetcols",
-      "target": "data_source_viewmodel_rationale_10",
-      "confidence_score": 0.5
+      "target": "data_source_viewmodel_rationale_10"
     },
     {
       "relation": "uses",
@@ -23771,11 +24041,11 @@
       "source_file": "maria_cacau/backend/data_source/_viewmodel.py",
       "source_location": "L6",
       "weight": 0.8,
-      "_src": "data_source_viewmodel_rationale_29",
-      "_tgt": "data_source_sheet_mapper_sheetcols",
+      "_src": "data_source_sheet_mapper_sheetcols",
+      "_tgt": "data_source_viewmodel_rationale_29",
+      "confidence_score": 0.5,
       "source": "data_source_sheet_mapper_sheetcols",
-      "target": "data_source_viewmodel_rationale_29",
-      "confidence_score": 0.5
+      "target": "data_source_viewmodel_rationale_29"
     },
     {
       "relation": "uses",
@@ -23783,11 +24053,11 @@
       "source_file": "maria_cacau/backend/data_source/_viewmodel.py",
       "source_location": "L6",
       "weight": 0.8,
-      "_src": "data_source_viewmodel_rationale_43",
-      "_tgt": "data_source_sheet_mapper_sheetcols",
+      "_src": "data_source_sheet_mapper_sheetcols",
+      "_tgt": "data_source_viewmodel_rationale_43",
+      "confidence_score": 0.5,
       "source": "data_source_sheet_mapper_sheetcols",
-      "target": "data_source_viewmodel_rationale_43",
-      "confidence_score": 0.5
+      "target": "data_source_viewmodel_rationale_43"
     },
     {
       "relation": "method",
@@ -23819,11 +24089,11 @@
       "source_file": "maria_cacau/backend/data_source/_normalizer.py",
       "source_location": "L3",
       "weight": 0.8,
-      "_src": "data_source_normalizer_sheetnormalizer",
-      "_tgt": "data_source_sheet_mapper_productcols",
+      "_src": "data_source_sheet_mapper_productcols",
+      "_tgt": "data_source_normalizer_sheetnormalizer",
+      "confidence_score": 0.5,
       "source": "data_source_sheet_mapper_productcols",
-      "target": "data_source_normalizer_sheetnormalizer",
-      "confidence_score": 0.5
+      "target": "data_source_normalizer_sheetnormalizer"
     },
     {
       "relation": "uses",
@@ -23831,11 +24101,11 @@
       "source_file": "maria_cacau/backend/data_source/_normalizer.py",
       "source_location": "L3",
       "weight": 0.8,
-      "_src": "data_source_normalizer_rationale_1",
-      "_tgt": "data_source_sheet_mapper_productcols",
+      "_src": "data_source_sheet_mapper_productcols",
+      "_tgt": "data_source_normalizer_rationale_1",
+      "confidence_score": 0.5,
       "source": "data_source_sheet_mapper_productcols",
-      "target": "data_source_normalizer_rationale_1",
-      "confidence_score": 0.5
+      "target": "data_source_normalizer_rationale_1"
     },
     {
       "relation": "uses",
@@ -23843,11 +24113,11 @@
       "source_file": "maria_cacau/backend/data_source/_normalizer.py",
       "source_location": "L3",
       "weight": 0.8,
-      "_src": "data_source_normalizer_rationale_7",
-      "_tgt": "data_source_sheet_mapper_productcols",
+      "_src": "data_source_sheet_mapper_productcols",
+      "_tgt": "data_source_normalizer_rationale_7",
+      "confidence_score": 0.5,
       "source": "data_source_sheet_mapper_productcols",
-      "target": "data_source_normalizer_rationale_7",
-      "confidence_score": 0.5
+      "target": "data_source_normalizer_rationale_7"
     },
     {
       "relation": "uses",
@@ -23855,11 +24125,11 @@
       "source_file": "maria_cacau/backend/data_source/_normalizer.py",
       "source_location": "L3",
       "weight": 0.8,
-      "_src": "data_source_normalizer_rationale_33",
-      "_tgt": "data_source_sheet_mapper_productcols",
+      "_src": "data_source_sheet_mapper_productcols",
+      "_tgt": "data_source_normalizer_rationale_33",
+      "confidence_score": 0.5,
       "source": "data_source_sheet_mapper_productcols",
-      "target": "data_source_normalizer_rationale_33",
-      "confidence_score": 0.5
+      "target": "data_source_normalizer_rationale_33"
     },
     {
       "relation": "method",
@@ -23891,11 +24161,11 @@
       "source_file": "maria_cacau/backend/data_source/_normalizer.py",
       "source_location": "L3",
       "weight": 0.8,
-      "_src": "data_source_normalizer_sheetnormalizer",
-      "_tgt": "data_source_sheet_mapper_paymentcols",
+      "_src": "data_source_sheet_mapper_paymentcols",
+      "_tgt": "data_source_normalizer_sheetnormalizer",
+      "confidence_score": 0.5,
       "source": "data_source_sheet_mapper_paymentcols",
-      "target": "data_source_normalizer_sheetnormalizer",
-      "confidence_score": 0.5
+      "target": "data_source_normalizer_sheetnormalizer"
     },
     {
       "relation": "uses",
@@ -23903,11 +24173,11 @@
       "source_file": "maria_cacau/backend/data_source/_normalizer.py",
       "source_location": "L3",
       "weight": 0.8,
-      "_src": "data_source_normalizer_rationale_1",
-      "_tgt": "data_source_sheet_mapper_paymentcols",
+      "_src": "data_source_sheet_mapper_paymentcols",
+      "_tgt": "data_source_normalizer_rationale_1",
+      "confidence_score": 0.5,
       "source": "data_source_sheet_mapper_paymentcols",
-      "target": "data_source_normalizer_rationale_1",
-      "confidence_score": 0.5
+      "target": "data_source_normalizer_rationale_1"
     },
     {
       "relation": "uses",
@@ -23915,11 +24185,11 @@
       "source_file": "maria_cacau/backend/data_source/_normalizer.py",
       "source_location": "L3",
       "weight": 0.8,
-      "_src": "data_source_normalizer_rationale_7",
-      "_tgt": "data_source_sheet_mapper_paymentcols",
+      "_src": "data_source_sheet_mapper_paymentcols",
+      "_tgt": "data_source_normalizer_rationale_7",
+      "confidence_score": 0.5,
       "source": "data_source_sheet_mapper_paymentcols",
-      "target": "data_source_normalizer_rationale_7",
-      "confidence_score": 0.5
+      "target": "data_source_normalizer_rationale_7"
     },
     {
       "relation": "uses",
@@ -23927,11 +24197,11 @@
       "source_file": "maria_cacau/backend/data_source/_normalizer.py",
       "source_location": "L3",
       "weight": 0.8,
-      "_src": "data_source_normalizer_rationale_33",
-      "_tgt": "data_source_sheet_mapper_paymentcols",
+      "_src": "data_source_sheet_mapper_paymentcols",
+      "_tgt": "data_source_normalizer_rationale_33",
+      "confidence_score": 0.5,
       "source": "data_source_sheet_mapper_paymentcols",
-      "target": "data_source_normalizer_rationale_33",
-      "confidence_score": 0.5
+      "target": "data_source_normalizer_rationale_33"
     },
     {
       "relation": "calls",
@@ -23940,8 +24210,8 @@
       "source_file": "maria_cacau/backend/data_source/_normalizer.py",
       "source_location": "L41",
       "weight": 1.0,
-      "_src": "data_source_normalizer_fix_prod4",
-      "_tgt": "data_source_sheet_mapper_paymentcols_slot",
+      "_src": "data_source_sheet_mapper_paymentcols_slot",
+      "_tgt": "data_source_normalizer_fix_prod4",
       "source": "data_source_sheet_mapper_paymentcols_slot",
       "target": "data_source_normalizer_fix_prod4"
     },
@@ -23952,8 +24222,8 @@
       "source_file": "maria_cacau/backend/features/orders/shared/mapper.py",
       "source_location": "L65",
       "weight": 1.0,
-      "_src": "shared_mapper_products",
-      "_tgt": "data_source_sheet_mapper_paymentcols_slot",
+      "_src": "data_source_sheet_mapper_paymentcols_slot",
+      "_tgt": "shared_mapper_products",
       "source": "data_source_sheet_mapper_paymentcols_slot",
       "target": "shared_mapper_products"
     },
@@ -23964,8 +24234,8 @@
       "source_file": "maria_cacau/backend/features/orders/shared/mapper.py",
       "source_location": "L80",
       "weight": 1.0,
-      "_src": "shared_mapper_payments",
-      "_tgt": "data_source_sheet_mapper_paymentcols_slot",
+      "_src": "data_source_sheet_mapper_paymentcols_slot",
+      "_tgt": "shared_mapper_payments",
       "source": "data_source_sheet_mapper_paymentcols_slot",
       "target": "shared_mapper_payments"
     },
@@ -23976,8 +24246,8 @@
       "source_file": "maria_cacau/backend/features/orders/subfeatures/payments/repository.py",
       "source_location": "L41",
       "weight": 1.0,
-      "_src": "payments_repository_to_dataframe",
-      "_tgt": "data_source_sheet_mapper_paymentcols_slot",
+      "_src": "data_source_sheet_mapper_paymentcols_slot",
+      "_tgt": "payments_repository_to_dataframe",
       "source": "data_source_sheet_mapper_paymentcols_slot",
       "target": "payments_repository_to_dataframe"
     },
@@ -23988,8 +24258,8 @@
       "source_file": "maria_cacau/backend/features/orders/subfeatures/summary/repository.py",
       "source_location": "L40",
       "weight": 1.0,
-      "_src": "summary_repository_to_dataframe",
-      "_tgt": "data_source_sheet_mapper_paymentcols_slot",
+      "_src": "data_source_sheet_mapper_paymentcols_slot",
+      "_tgt": "summary_repository_to_dataframe",
       "source": "data_source_sheet_mapper_paymentcols_slot",
       "target": "summary_repository_to_dataframe"
     },
@@ -24229,9 +24499,9 @@
       "weight": 0.8,
       "_src": "data_source_viewmodel_sheetsviewmodel",
       "_tgt": "errors_errors_unexpectedsheetstructureerror",
+      "confidence_score": 0.5,
       "source": "data_source_viewmodel_sheetsviewmodel",
-      "target": "errors_errors_unexpectedsheetstructureerror",
-      "confidence_score": 0.5
+      "target": "errors_errors_unexpectedsheetstructureerror"
     },
     {
       "relation": "calls",
@@ -24325,9 +24595,9 @@
       "weight": 0.8,
       "_src": "data_source_viewmodel_rationale_10",
       "_tgt": "errors_errors_unexpectedsheetstructureerror",
+      "confidence_score": 0.5,
       "source": "data_source_viewmodel_rationale_10",
-      "target": "errors_errors_unexpectedsheetstructureerror",
-      "confidence_score": 0.5
+      "target": "errors_errors_unexpectedsheetstructureerror"
     },
     {
       "relation": "uses",
@@ -24337,9 +24607,9 @@
       "weight": 0.8,
       "_src": "data_source_viewmodel_rationale_29",
       "_tgt": "errors_errors_unexpectedsheetstructureerror",
+      "confidence_score": 0.5,
       "source": "data_source_viewmodel_rationale_29",
-      "target": "errors_errors_unexpectedsheetstructureerror",
-      "confidence_score": 0.5
+      "target": "errors_errors_unexpectedsheetstructureerror"
     },
     {
       "relation": "uses",
@@ -24349,9 +24619,9 @@
       "weight": 0.8,
       "_src": "data_source_viewmodel_rationale_43",
       "_tgt": "errors_errors_unexpectedsheetstructureerror",
+      "confidence_score": 0.5,
       "source": "data_source_viewmodel_rationale_43",
-      "target": "errors_errors_unexpectedsheetstructureerror",
-      "confidence_score": 0.5
+      "target": "errors_errors_unexpectedsheetstructureerror"
     },
     {
       "relation": "contains",
@@ -24432,8 +24702,8 @@
       "source_file": "maria_cacau/backend/data_source/errors/_handler.py",
       "source_location": "L15",
       "weight": 1.0,
-      "_src": "errors_handler_is_valid_date",
-      "_tgt": "data_source_utils_normalize_date",
+      "_src": "data_source_utils_normalize_date",
+      "_tgt": "errors_handler_is_valid_date",
       "source": "data_source_utils_normalize_date",
       "target": "errors_handler_is_valid_date"
     },
@@ -24444,8 +24714,8 @@
       "source_file": "maria_cacau/backend/data_source/errors/_handler.py",
       "source_location": "L19",
       "weight": 1.0,
-      "_src": "errors_handler_parse_date",
-      "_tgt": "data_source_utils_normalize_date",
+      "_src": "data_source_utils_normalize_date",
+      "_tgt": "errors_handler_parse_date",
       "source": "data_source_utils_normalize_date",
       "target": "errors_handler_parse_date"
     },
@@ -25680,8 +25950,8 @@
       "source_file": "maria_cacau/backend/features/orders/__init__.py",
       "source_location": "L16",
       "weight": 1.0,
-      "_src": "orders_init_check_connection",
-      "_tgt": "errors_errors_datasourcenotreadyerror",
+      "_src": "errors_errors_datasourcenotreadyerror",
+      "_tgt": "orders_init_check_connection",
       "source": "errors_errors_datasourcenotreadyerror",
       "target": "orders_init_check_connection"
     },
@@ -25751,11 +26021,11 @@
       "source_file": "maria_cacau/backend/features/auth/route.py",
       "source_location": "L5",
       "weight": 0.8,
-      "_src": "auth_route_rationale_1",
-      "_tgt": "auth_service_authservice",
+      "_src": "auth_service_authservice",
+      "_tgt": "auth_route_rationale_1",
+      "confidence_score": 0.5,
       "source": "auth_service_authservice",
-      "target": "auth_route_rationale_1",
-      "confidence_score": 0.5
+      "target": "auth_route_rationale_1"
     },
     {
       "relation": "contains",
@@ -25812,8 +26082,8 @@
       "source_file": "pocs/design-system/poc_date_picker.py",
       "source_location": "L108",
       "weight": 1.0,
-      "_src": "design_system_poc_date_picker_daterangepicker_init",
-      "_tgt": "auth_route_connect",
+      "_src": "auth_route_connect",
+      "_tgt": "design_system_poc_date_picker_daterangepicker_init",
       "source": "auth_route_connect",
       "target": "design_system_poc_date_picker_daterangepicker_init"
     },
@@ -25979,11 +26249,11 @@
       "source_file": "maria_cacau/backend/features/orders/shared/mapper.py",
       "source_location": "L7",
       "weight": 0.8,
-      "_src": "shared_mapper_ordermapper",
-      "_tgt": "shared_models_address",
+      "_src": "shared_models_address",
+      "_tgt": "shared_mapper_ordermapper",
+      "confidence_score": 0.5,
       "source": "shared_models_address",
-      "target": "shared_mapper_ordermapper",
-      "confidence_score": 0.5
+      "target": "shared_mapper_ordermapper"
     },
     {
       "relation": "uses",
@@ -25991,11 +26261,11 @@
       "source_file": "maria_cacau/backend/features/orders/shared/mapper.py",
       "source_location": "L7",
       "weight": 0.8,
-      "_src": "shared_mapper_rationale_1",
-      "_tgt": "shared_models_address",
+      "_src": "shared_models_address",
+      "_tgt": "shared_mapper_rationale_1",
+      "confidence_score": 0.5,
       "source": "shared_models_address",
-      "target": "shared_mapper_rationale_1",
-      "confidence_score": 0.5
+      "target": "shared_mapper_rationale_1"
     },
     {
       "relation": "uses",
@@ -26003,11 +26273,11 @@
       "source_file": "maria_cacau/backend/features/orders/shared/mapper.py",
       "source_location": "L7",
       "weight": 0.8,
-      "_src": "shared_mapper_rationale_12",
-      "_tgt": "shared_models_address",
+      "_src": "shared_models_address",
+      "_tgt": "shared_mapper_rationale_12",
+      "confidence_score": 0.5,
       "source": "shared_models_address",
-      "target": "shared_mapper_rationale_12",
-      "confidence_score": 0.5
+      "target": "shared_mapper_rationale_12"
     },
     {
       "relation": "uses",
@@ -26015,11 +26285,11 @@
       "source_file": "maria_cacau/backend/features/orders/shared/mapper.py",
       "source_location": "L7",
       "weight": 0.8,
-      "_src": "shared_mapper_rationale_16",
-      "_tgt": "shared_models_address",
+      "_src": "shared_models_address",
+      "_tgt": "shared_mapper_rationale_16",
+      "confidence_score": 0.5,
       "source": "shared_models_address",
-      "target": "shared_mapper_rationale_16",
-      "confidence_score": 0.5
+      "target": "shared_mapper_rationale_16"
     },
     {
       "relation": "calls",
@@ -26028,8 +26298,8 @@
       "source_file": "maria_cacau/backend/features/orders/shared/mapper.py",
       "source_location": "L109",
       "weight": 1.0,
-      "_src": "shared_mapper_delivery",
-      "_tgt": "shared_models_address",
+      "_src": "shared_models_address",
+      "_tgt": "shared_mapper_delivery",
       "source": "shared_models_address",
       "target": "shared_mapper_delivery"
     },
@@ -26039,11 +26309,11 @@
       "source_file": "maria_cacau/backend/features/orders/shared/mapper.py",
       "source_location": "L7",
       "weight": 0.8,
-      "_src": "shared_mapper_ordermapper",
-      "_tgt": "shared_models_event",
+      "_src": "shared_models_event",
+      "_tgt": "shared_mapper_ordermapper",
+      "confidence_score": 0.5,
       "source": "shared_models_event",
-      "target": "shared_mapper_ordermapper",
-      "confidence_score": 0.5
+      "target": "shared_mapper_ordermapper"
     },
     {
       "relation": "uses",
@@ -26051,11 +26321,11 @@
       "source_file": "maria_cacau/backend/features/orders/shared/mapper.py",
       "source_location": "L7",
       "weight": 0.8,
-      "_src": "shared_mapper_rationale_1",
-      "_tgt": "shared_models_event",
+      "_src": "shared_models_event",
+      "_tgt": "shared_mapper_rationale_1",
+      "confidence_score": 0.5,
       "source": "shared_models_event",
-      "target": "shared_mapper_rationale_1",
-      "confidence_score": 0.5
+      "target": "shared_mapper_rationale_1"
     },
     {
       "relation": "uses",
@@ -26063,11 +26333,11 @@
       "source_file": "maria_cacau/backend/features/orders/shared/mapper.py",
       "source_location": "L7",
       "weight": 0.8,
-      "_src": "shared_mapper_rationale_12",
-      "_tgt": "shared_models_event",
+      "_src": "shared_models_event",
+      "_tgt": "shared_mapper_rationale_12",
+      "confidence_score": 0.5,
       "source": "shared_models_event",
-      "target": "shared_mapper_rationale_12",
-      "confidence_score": 0.5
+      "target": "shared_mapper_rationale_12"
     },
     {
       "relation": "uses",
@@ -26075,11 +26345,11 @@
       "source_file": "maria_cacau/backend/features/orders/shared/mapper.py",
       "source_location": "L7",
       "weight": 0.8,
-      "_src": "shared_mapper_rationale_16",
-      "_tgt": "shared_models_event",
+      "_src": "shared_models_event",
+      "_tgt": "shared_mapper_rationale_16",
+      "confidence_score": 0.5,
       "source": "shared_models_event",
-      "target": "shared_mapper_rationale_16",
-      "confidence_score": 0.5
+      "target": "shared_mapper_rationale_16"
     },
     {
       "relation": "calls",
@@ -26088,8 +26358,8 @@
       "source_file": "maria_cacau/backend/features/orders/shared/mapper.py",
       "source_location": "L45",
       "weight": 1.0,
-      "_src": "shared_mapper_receiver",
-      "_tgt": "shared_models_event",
+      "_src": "shared_models_event",
+      "_tgt": "shared_mapper_receiver",
       "source": "shared_models_event",
       "target": "shared_mapper_receiver"
     },
@@ -26099,11 +26369,11 @@
       "source_file": "maria_cacau/backend/features/orders/shared/mapper.py",
       "source_location": "L7",
       "weight": 0.8,
-      "_src": "shared_mapper_ordermapper",
-      "_tgt": "shared_models_customer",
+      "_src": "shared_models_customer",
+      "_tgt": "shared_mapper_ordermapper",
+      "confidence_score": 0.5,
       "source": "shared_models_customer",
-      "target": "shared_mapper_ordermapper",
-      "confidence_score": 0.5
+      "target": "shared_mapper_ordermapper"
     },
     {
       "relation": "uses",
@@ -26111,11 +26381,11 @@
       "source_file": "maria_cacau/backend/features/orders/shared/mapper.py",
       "source_location": "L7",
       "weight": 0.8,
-      "_src": "shared_mapper_rationale_1",
-      "_tgt": "shared_models_customer",
+      "_src": "shared_models_customer",
+      "_tgt": "shared_mapper_rationale_1",
+      "confidence_score": 0.5,
       "source": "shared_models_customer",
-      "target": "shared_mapper_rationale_1",
-      "confidence_score": 0.5
+      "target": "shared_mapper_rationale_1"
     },
     {
       "relation": "uses",
@@ -26123,11 +26393,11 @@
       "source_file": "maria_cacau/backend/features/orders/shared/mapper.py",
       "source_location": "L7",
       "weight": 0.8,
-      "_src": "shared_mapper_rationale_12",
-      "_tgt": "shared_models_customer",
+      "_src": "shared_models_customer",
+      "_tgt": "shared_mapper_rationale_12",
+      "confidence_score": 0.5,
       "source": "shared_models_customer",
-      "target": "shared_mapper_rationale_12",
-      "confidence_score": 0.5
+      "target": "shared_mapper_rationale_12"
     },
     {
       "relation": "uses",
@@ -26135,11 +26405,11 @@
       "source_file": "maria_cacau/backend/features/orders/shared/mapper.py",
       "source_location": "L7",
       "weight": 0.8,
-      "_src": "shared_mapper_rationale_16",
-      "_tgt": "shared_models_customer",
+      "_src": "shared_models_customer",
+      "_tgt": "shared_mapper_rationale_16",
+      "confidence_score": 0.5,
       "source": "shared_models_customer",
-      "target": "shared_mapper_rationale_16",
-      "confidence_score": 0.5
+      "target": "shared_mapper_rationale_16"
     },
     {
       "relation": "calls",
@@ -26148,8 +26418,8 @@
       "source_file": "maria_cacau/backend/features/orders/shared/mapper.py",
       "source_location": "L33",
       "weight": 1.0,
-      "_src": "shared_mapper_customer",
-      "_tgt": "shared_models_customer",
+      "_src": "shared_models_customer",
+      "_tgt": "shared_mapper_customer",
       "source": "shared_models_customer",
       "target": "shared_mapper_customer"
     },
@@ -26159,11 +26429,11 @@
       "source_file": "maria_cacau/backend/features/orders/shared/mapper.py",
       "source_location": "L7",
       "weight": 0.8,
-      "_src": "shared_mapper_ordermapper",
-      "_tgt": "shared_models_receiver",
+      "_src": "shared_models_receiver",
+      "_tgt": "shared_mapper_ordermapper",
+      "confidence_score": 0.5,
       "source": "shared_models_receiver",
-      "target": "shared_mapper_ordermapper",
-      "confidence_score": 0.5
+      "target": "shared_mapper_ordermapper"
     },
     {
       "relation": "uses",
@@ -26171,11 +26441,11 @@
       "source_file": "maria_cacau/backend/features/orders/shared/mapper.py",
       "source_location": "L7",
       "weight": 0.8,
-      "_src": "shared_mapper_rationale_1",
-      "_tgt": "shared_models_receiver",
+      "_src": "shared_models_receiver",
+      "_tgt": "shared_mapper_rationale_1",
+      "confidence_score": 0.5,
       "source": "shared_models_receiver",
-      "target": "shared_mapper_rationale_1",
-      "confidence_score": 0.5
+      "target": "shared_mapper_rationale_1"
     },
     {
       "relation": "uses",
@@ -26183,11 +26453,11 @@
       "source_file": "maria_cacau/backend/features/orders/shared/mapper.py",
       "source_location": "L7",
       "weight": 0.8,
-      "_src": "shared_mapper_rationale_12",
-      "_tgt": "shared_models_receiver",
+      "_src": "shared_models_receiver",
+      "_tgt": "shared_mapper_rationale_12",
+      "confidence_score": 0.5,
       "source": "shared_models_receiver",
-      "target": "shared_mapper_rationale_12",
-      "confidence_score": 0.5
+      "target": "shared_mapper_rationale_12"
     },
     {
       "relation": "uses",
@@ -26195,11 +26465,11 @@
       "source_file": "maria_cacau/backend/features/orders/shared/mapper.py",
       "source_location": "L7",
       "weight": 0.8,
-      "_src": "shared_mapper_rationale_16",
-      "_tgt": "shared_models_receiver",
+      "_src": "shared_models_receiver",
+      "_tgt": "shared_mapper_rationale_16",
+      "confidence_score": 0.5,
       "source": "shared_models_receiver",
-      "target": "shared_mapper_rationale_16",
-      "confidence_score": 0.5
+      "target": "shared_mapper_rationale_16"
     },
     {
       "relation": "calls",
@@ -26208,8 +26478,8 @@
       "source_file": "maria_cacau/backend/features/orders/shared/mapper.py",
       "source_location": "L46",
       "weight": 1.0,
-      "_src": "shared_mapper_receiver",
-      "_tgt": "shared_models_receiver",
+      "_src": "shared_models_receiver",
+      "_tgt": "shared_mapper_receiver",
       "source": "shared_models_receiver",
       "target": "shared_mapper_receiver"
     },
@@ -26219,11 +26489,11 @@
       "source_file": "maria_cacau/backend/features/orders/shared/mapper.py",
       "source_location": "L7",
       "weight": 0.8,
-      "_src": "shared_mapper_ordermapper",
-      "_tgt": "shared_models_customization",
+      "_src": "shared_models_customization",
+      "_tgt": "shared_mapper_ordermapper",
+      "confidence_score": 0.5,
       "source": "shared_models_customization",
-      "target": "shared_mapper_ordermapper",
-      "confidence_score": 0.5
+      "target": "shared_mapper_ordermapper"
     },
     {
       "relation": "uses",
@@ -26231,11 +26501,11 @@
       "source_file": "maria_cacau/backend/features/orders/shared/mapper.py",
       "source_location": "L7",
       "weight": 0.8,
-      "_src": "shared_mapper_rationale_1",
-      "_tgt": "shared_models_customization",
+      "_src": "shared_models_customization",
+      "_tgt": "shared_mapper_rationale_1",
+      "confidence_score": 0.5,
       "source": "shared_models_customization",
-      "target": "shared_mapper_rationale_1",
-      "confidence_score": 0.5
+      "target": "shared_mapper_rationale_1"
     },
     {
       "relation": "uses",
@@ -26243,11 +26513,11 @@
       "source_file": "maria_cacau/backend/features/orders/shared/mapper.py",
       "source_location": "L7",
       "weight": 0.8,
-      "_src": "shared_mapper_rationale_12",
-      "_tgt": "shared_models_customization",
+      "_src": "shared_models_customization",
+      "_tgt": "shared_mapper_rationale_12",
+      "confidence_score": 0.5,
       "source": "shared_models_customization",
-      "target": "shared_mapper_rationale_12",
-      "confidence_score": 0.5
+      "target": "shared_mapper_rationale_12"
     },
     {
       "relation": "uses",
@@ -26255,11 +26525,11 @@
       "source_file": "maria_cacau/backend/features/orders/shared/mapper.py",
       "source_location": "L7",
       "weight": 0.8,
-      "_src": "shared_mapper_rationale_16",
-      "_tgt": "shared_models_customization",
+      "_src": "shared_models_customization",
+      "_tgt": "shared_mapper_rationale_16",
+      "confidence_score": 0.5,
       "source": "shared_models_customization",
-      "target": "shared_mapper_rationale_16",
-      "confidence_score": 0.5
+      "target": "shared_mapper_rationale_16"
     },
     {
       "relation": "calls",
@@ -26268,8 +26538,8 @@
       "source_file": "maria_cacau/backend/features/orders/shared/mapper.py",
       "source_location": "L54",
       "weight": 1.0,
-      "_src": "shared_mapper_customization",
-      "_tgt": "shared_models_customization",
+      "_src": "shared_models_customization",
+      "_tgt": "shared_mapper_customization",
       "source": "shared_models_customization",
       "target": "shared_mapper_customization"
     },
@@ -26279,11 +26549,11 @@
       "source_file": "maria_cacau/backend/features/orders/shared/mapper.py",
       "source_location": "L7",
       "weight": 0.8,
-      "_src": "shared_mapper_ordermapper",
-      "_tgt": "shared_models_productitem",
+      "_src": "shared_models_productitem",
+      "_tgt": "shared_mapper_ordermapper",
+      "confidence_score": 0.5,
       "source": "shared_models_productitem",
-      "target": "shared_mapper_ordermapper",
-      "confidence_score": 0.5
+      "target": "shared_mapper_ordermapper"
     },
     {
       "relation": "uses",
@@ -26291,11 +26561,11 @@
       "source_file": "maria_cacau/backend/features/orders/shared/mapper.py",
       "source_location": "L7",
       "weight": 0.8,
-      "_src": "shared_mapper_rationale_1",
-      "_tgt": "shared_models_productitem",
+      "_src": "shared_models_productitem",
+      "_tgt": "shared_mapper_rationale_1",
+      "confidence_score": 0.5,
       "source": "shared_models_productitem",
-      "target": "shared_mapper_rationale_1",
-      "confidence_score": 0.5
+      "target": "shared_mapper_rationale_1"
     },
     {
       "relation": "uses",
@@ -26303,11 +26573,11 @@
       "source_file": "maria_cacau/backend/features/orders/shared/mapper.py",
       "source_location": "L7",
       "weight": 0.8,
-      "_src": "shared_mapper_rationale_12",
-      "_tgt": "shared_models_productitem",
+      "_src": "shared_models_productitem",
+      "_tgt": "shared_mapper_rationale_12",
+      "confidence_score": 0.5,
       "source": "shared_models_productitem",
-      "target": "shared_mapper_rationale_12",
-      "confidence_score": 0.5
+      "target": "shared_mapper_rationale_12"
     },
     {
       "relation": "uses",
@@ -26315,11 +26585,11 @@
       "source_file": "maria_cacau/backend/features/orders/shared/mapper.py",
       "source_location": "L7",
       "weight": 0.8,
-      "_src": "shared_mapper_rationale_16",
-      "_tgt": "shared_models_productitem",
+      "_src": "shared_models_productitem",
+      "_tgt": "shared_mapper_rationale_16",
+      "confidence_score": 0.5,
       "source": "shared_models_productitem",
-      "target": "shared_mapper_rationale_16",
-      "confidence_score": 0.5
+      "target": "shared_mapper_rationale_16"
     },
     {
       "relation": "calls",
@@ -26328,8 +26598,8 @@
       "source_file": "maria_cacau/backend/features/orders/shared/mapper.py",
       "source_location": "L68",
       "weight": 1.0,
-      "_src": "shared_mapper_products",
-      "_tgt": "shared_models_productitem",
+      "_src": "shared_models_productitem",
+      "_tgt": "shared_mapper_products",
       "source": "shared_models_productitem",
       "target": "shared_mapper_products"
     },
@@ -26339,11 +26609,11 @@
       "source_file": "maria_cacau/backend/features/orders/shared/mapper.py",
       "source_location": "L7",
       "weight": 0.8,
-      "_src": "shared_mapper_ordermapper",
-      "_tgt": "shared_models_paymentitem",
+      "_src": "shared_models_paymentitem",
+      "_tgt": "shared_mapper_ordermapper",
+      "confidence_score": 0.5,
       "source": "shared_models_paymentitem",
-      "target": "shared_mapper_ordermapper",
-      "confidence_score": 0.5
+      "target": "shared_mapper_ordermapper"
     },
     {
       "relation": "uses",
@@ -26351,11 +26621,11 @@
       "source_file": "maria_cacau/backend/features/orders/shared/mapper.py",
       "source_location": "L7",
       "weight": 0.8,
-      "_src": "shared_mapper_rationale_1",
-      "_tgt": "shared_models_paymentitem",
+      "_src": "shared_models_paymentitem",
+      "_tgt": "shared_mapper_rationale_1",
+      "confidence_score": 0.5,
       "source": "shared_models_paymentitem",
-      "target": "shared_mapper_rationale_1",
-      "confidence_score": 0.5
+      "target": "shared_mapper_rationale_1"
     },
     {
       "relation": "uses",
@@ -26363,11 +26633,11 @@
       "source_file": "maria_cacau/backend/features/orders/shared/mapper.py",
       "source_location": "L7",
       "weight": 0.8,
-      "_src": "shared_mapper_rationale_12",
-      "_tgt": "shared_models_paymentitem",
+      "_src": "shared_models_paymentitem",
+      "_tgt": "shared_mapper_rationale_12",
+      "confidence_score": 0.5,
       "source": "shared_models_paymentitem",
-      "target": "shared_mapper_rationale_12",
-      "confidence_score": 0.5
+      "target": "shared_mapper_rationale_12"
     },
     {
       "relation": "uses",
@@ -26375,11 +26645,11 @@
       "source_file": "maria_cacau/backend/features/orders/shared/mapper.py",
       "source_location": "L7",
       "weight": 0.8,
-      "_src": "shared_mapper_rationale_16",
-      "_tgt": "shared_models_paymentitem",
+      "_src": "shared_models_paymentitem",
+      "_tgt": "shared_mapper_rationale_16",
+      "confidence_score": 0.5,
       "source": "shared_models_paymentitem",
-      "target": "shared_mapper_rationale_16",
-      "confidence_score": 0.5
+      "target": "shared_mapper_rationale_16"
     },
     {
       "relation": "calls",
@@ -26388,8 +26658,8 @@
       "source_file": "maria_cacau/backend/features/orders/shared/mapper.py",
       "source_location": "L84",
       "weight": 1.0,
-      "_src": "shared_mapper_payments",
-      "_tgt": "shared_models_paymentitem",
+      "_src": "shared_models_paymentitem",
+      "_tgt": "shared_mapper_payments",
       "source": "shared_models_paymentitem",
       "target": "shared_mapper_payments"
     },
@@ -26399,11 +26669,11 @@
       "source_file": "maria_cacau/backend/features/orders/shared/mapper.py",
       "source_location": "L7",
       "weight": 0.8,
-      "_src": "shared_mapper_ordermapper",
-      "_tgt": "shared_models_financial",
+      "_src": "shared_models_financial",
+      "_tgt": "shared_mapper_ordermapper",
+      "confidence_score": 0.5,
       "source": "shared_models_financial",
-      "target": "shared_mapper_ordermapper",
-      "confidence_score": 0.5
+      "target": "shared_mapper_ordermapper"
     },
     {
       "relation": "uses",
@@ -26411,11 +26681,11 @@
       "source_file": "maria_cacau/backend/features/orders/shared/mapper.py",
       "source_location": "L7",
       "weight": 0.8,
-      "_src": "shared_mapper_rationale_1",
-      "_tgt": "shared_models_financial",
+      "_src": "shared_models_financial",
+      "_tgt": "shared_mapper_rationale_1",
+      "confidence_score": 0.5,
       "source": "shared_models_financial",
-      "target": "shared_mapper_rationale_1",
-      "confidence_score": 0.5
+      "target": "shared_mapper_rationale_1"
     },
     {
       "relation": "uses",
@@ -26423,11 +26693,11 @@
       "source_file": "maria_cacau/backend/features/orders/shared/mapper.py",
       "source_location": "L7",
       "weight": 0.8,
-      "_src": "shared_mapper_rationale_12",
-      "_tgt": "shared_models_financial",
+      "_src": "shared_models_financial",
+      "_tgt": "shared_mapper_rationale_12",
+      "confidence_score": 0.5,
       "source": "shared_models_financial",
-      "target": "shared_mapper_rationale_12",
-      "confidence_score": 0.5
+      "target": "shared_mapper_rationale_12"
     },
     {
       "relation": "uses",
@@ -26435,11 +26705,11 @@
       "source_file": "maria_cacau/backend/features/orders/shared/mapper.py",
       "source_location": "L7",
       "weight": 0.8,
-      "_src": "shared_mapper_rationale_16",
-      "_tgt": "shared_models_financial",
+      "_src": "shared_models_financial",
+      "_tgt": "shared_mapper_rationale_16",
+      "confidence_score": 0.5,
       "source": "shared_models_financial",
-      "target": "shared_mapper_rationale_16",
-      "confidence_score": 0.5
+      "target": "shared_mapper_rationale_16"
     },
     {
       "relation": "calls",
@@ -26448,8 +26718,8 @@
       "source_file": "maria_cacau/backend/features/orders/shared/mapper.py",
       "source_location": "L95",
       "weight": 1.0,
-      "_src": "shared_mapper_financial",
-      "_tgt": "shared_models_financial",
+      "_src": "shared_models_financial",
+      "_tgt": "shared_mapper_financial",
       "source": "shared_models_financial",
       "target": "shared_mapper_financial"
     },
@@ -26459,11 +26729,11 @@
       "source_file": "maria_cacau/backend/features/orders/shared/mapper.py",
       "source_location": "L7",
       "weight": 0.8,
-      "_src": "shared_mapper_ordermapper",
-      "_tgt": "shared_models_delivery",
+      "_src": "shared_models_delivery",
+      "_tgt": "shared_mapper_ordermapper",
+      "confidence_score": 0.5,
       "source": "shared_models_delivery",
-      "target": "shared_mapper_ordermapper",
-      "confidence_score": 0.5
+      "target": "shared_mapper_ordermapper"
     },
     {
       "relation": "uses",
@@ -26471,11 +26741,11 @@
       "source_file": "maria_cacau/backend/features/orders/shared/mapper.py",
       "source_location": "L7",
       "weight": 0.8,
-      "_src": "shared_mapper_rationale_1",
-      "_tgt": "shared_models_delivery",
+      "_src": "shared_models_delivery",
+      "_tgt": "shared_mapper_rationale_1",
+      "confidence_score": 0.5,
       "source": "shared_models_delivery",
-      "target": "shared_mapper_rationale_1",
-      "confidence_score": 0.5
+      "target": "shared_mapper_rationale_1"
     },
     {
       "relation": "uses",
@@ -26483,11 +26753,11 @@
       "source_file": "maria_cacau/backend/features/orders/shared/mapper.py",
       "source_location": "L7",
       "weight": 0.8,
-      "_src": "shared_mapper_rationale_12",
-      "_tgt": "shared_models_delivery",
+      "_src": "shared_models_delivery",
+      "_tgt": "shared_mapper_rationale_12",
+      "confidence_score": 0.5,
       "source": "shared_models_delivery",
-      "target": "shared_mapper_rationale_12",
-      "confidence_score": 0.5
+      "target": "shared_mapper_rationale_12"
     },
     {
       "relation": "uses",
@@ -26495,11 +26765,11 @@
       "source_file": "maria_cacau/backend/features/orders/shared/mapper.py",
       "source_location": "L7",
       "weight": 0.8,
-      "_src": "shared_mapper_rationale_16",
-      "_tgt": "shared_models_delivery",
+      "_src": "shared_models_delivery",
+      "_tgt": "shared_mapper_rationale_16",
+      "confidence_score": 0.5,
       "source": "shared_models_delivery",
-      "target": "shared_mapper_rationale_16",
-      "confidence_score": 0.5
+      "target": "shared_mapper_rationale_16"
     },
     {
       "relation": "calls",
@@ -26508,8 +26778,8 @@
       "source_file": "maria_cacau/backend/features/orders/shared/mapper.py",
       "source_location": "L117",
       "weight": 1.0,
-      "_src": "shared_mapper_delivery",
-      "_tgt": "shared_models_delivery",
+      "_src": "shared_models_delivery",
+      "_tgt": "shared_mapper_delivery",
       "source": "shared_models_delivery",
       "target": "shared_mapper_delivery"
     },
@@ -26519,11 +26789,11 @@
       "source_file": "maria_cacau/backend/features/orders/shared/mapper.py",
       "source_location": "L7",
       "weight": 0.8,
-      "_src": "shared_mapper_ordermapper",
-      "_tgt": "shared_models_order",
+      "_src": "shared_models_order",
+      "_tgt": "shared_mapper_ordermapper",
+      "confidence_score": 0.5,
       "source": "shared_models_order",
-      "target": "shared_mapper_ordermapper",
-      "confidence_score": 0.5
+      "target": "shared_mapper_ordermapper"
     },
     {
       "relation": "uses",
@@ -26531,11 +26801,11 @@
       "source_file": "maria_cacau/backend/features/orders/shared/mapper.py",
       "source_location": "L7",
       "weight": 0.8,
-      "_src": "shared_mapper_rationale_1",
-      "_tgt": "shared_models_order",
+      "_src": "shared_models_order",
+      "_tgt": "shared_mapper_rationale_1",
+      "confidence_score": 0.5,
       "source": "shared_models_order",
-      "target": "shared_mapper_rationale_1",
-      "confidence_score": 0.5
+      "target": "shared_mapper_rationale_1"
     },
     {
       "relation": "uses",
@@ -26543,11 +26813,11 @@
       "source_file": "maria_cacau/backend/features/orders/shared/mapper.py",
       "source_location": "L7",
       "weight": 0.8,
-      "_src": "shared_mapper_rationale_12",
-      "_tgt": "shared_models_order",
+      "_src": "shared_models_order",
+      "_tgt": "shared_mapper_rationale_12",
+      "confidence_score": 0.5,
       "source": "shared_models_order",
-      "target": "shared_mapper_rationale_12",
-      "confidence_score": 0.5
+      "target": "shared_mapper_rationale_12"
     },
     {
       "relation": "uses",
@@ -26555,11 +26825,11 @@
       "source_file": "maria_cacau/backend/features/orders/shared/mapper.py",
       "source_location": "L7",
       "weight": 0.8,
-      "_src": "shared_mapper_rationale_16",
-      "_tgt": "shared_models_order",
+      "_src": "shared_models_order",
+      "_tgt": "shared_mapper_rationale_16",
+      "confidence_score": 0.5,
       "source": "shared_models_order",
-      "target": "shared_mapper_rationale_16",
-      "confidence_score": 0.5
+      "target": "shared_mapper_rationale_16"
     },
     {
       "relation": "calls",
@@ -26568,8 +26838,8 @@
       "source_file": "maria_cacau/backend/features/orders/shared/mapper.py",
       "source_location": "L18",
       "weight": 1.0,
-      "_src": "shared_mapper_to_model",
-      "_tgt": "shared_models_order",
+      "_src": "shared_models_order",
+      "_tgt": "shared_mapper_to_model",
       "source": "shared_models_order",
       "target": "shared_mapper_to_model"
     },
@@ -26796,8 +27066,8 @@
       "source_file": "maria_cacau/backend/features/orders/subfeatures/payments/service.py",
       "source_location": "L33",
       "weight": 1.0,
-      "_src": "payments_service_paymentsservice_get_pendent",
-      "_tgt": "shared_mapper_to_model",
+      "_src": "shared_mapper_to_model",
+      "_tgt": "payments_service_paymentsservice_get_pendent",
       "source": "shared_mapper_to_model",
       "target": "payments_service_paymentsservice_get_pendent"
     },
@@ -26808,8 +27078,8 @@
       "source_file": "maria_cacau/backend/features/orders/subfeatures/summary/service.py",
       "source_location": "L31",
       "weight": 1.0,
-      "_src": "summary_service_ordersservice_get_by_period",
-      "_tgt": "shared_mapper_to_model",
+      "_src": "shared_mapper_to_model",
+      "_tgt": "summary_service_ordersservice_get_by_period",
       "source": "shared_mapper_to_model",
       "target": "summary_service_ordersservice_get_by_period"
     },
@@ -26953,9 +27223,9 @@
       "weight": 0.8,
       "_src": "payments_service_paymentsmapper",
       "_tgt": "payments_repository_paymentsrepository",
+      "confidence_score": 0.5,
       "source": "payments_service_paymentsmapper",
-      "target": "payments_repository_paymentsrepository",
-      "confidence_score": 0.5
+      "target": "payments_repository_paymentsrepository"
     },
     {
       "relation": "uses",
@@ -26963,11 +27233,11 @@
       "source_file": "maria_cacau/backend/features/orders/subfeatures/payments/route.py",
       "source_location": "L5",
       "weight": 0.8,
-      "_src": "payments_route_rationale_1",
-      "_tgt": "payments_service_paymentsmapper",
+      "_src": "payments_service_paymentsmapper",
+      "_tgt": "payments_route_rationale_1",
+      "confidence_score": 0.5,
       "source": "payments_service_paymentsmapper",
-      "target": "payments_route_rationale_1",
-      "confidence_score": 0.5
+      "target": "payments_route_rationale_1"
     },
     {
       "relation": "method",
@@ -27013,9 +27283,9 @@
       "weight": 0.8,
       "_src": "payments_service_paymentsservice",
       "_tgt": "payments_repository_paymentsrepository",
+      "confidence_score": 0.5,
       "source": "payments_service_paymentsservice",
-      "target": "payments_repository_paymentsrepository",
-      "confidence_score": 0.5
+      "target": "payments_repository_paymentsrepository"
     },
     {
       "relation": "uses",
@@ -27023,11 +27293,11 @@
       "source_file": "maria_cacau/backend/features/orders/subfeatures/payments/route.py",
       "source_location": "L5",
       "weight": 0.8,
-      "_src": "payments_route_rationale_1",
-      "_tgt": "payments_service_paymentsservice",
+      "_src": "payments_service_paymentsservice",
+      "_tgt": "payments_route_rationale_1",
+      "confidence_score": 0.5,
       "source": "payments_service_paymentsservice",
-      "target": "payments_route_rationale_1",
-      "confidence_score": 0.5
+      "target": "payments_route_rationale_1"
     },
     {
       "relation": "calls",
@@ -27072,8 +27342,8 @@
       "source_file": "maria_cacau/backend/features/orders/subfeatures/payments/route.py",
       "source_location": "L14",
       "weight": 1.0,
-      "_src": "payments_route_get_payments_pendent",
-      "_tgt": "payments_service_paymentsservice_get_pendent",
+      "_src": "payments_service_paymentsservice_get_pendent",
+      "_tgt": "payments_route_get_payments_pendent",
       "source": "payments_service_paymentsservice_get_pendent",
       "target": "payments_route_get_payments_pendent"
     },
@@ -27085,9 +27355,9 @@
       "weight": 0.8,
       "_src": "payments_service_rationale_1",
       "_tgt": "payments_repository_paymentsrepository",
+      "confidence_score": 0.5,
       "source": "payments_service_rationale_1",
-      "target": "payments_repository_paymentsrepository",
-      "confidence_score": 0.5
+      "target": "payments_repository_paymentsrepository"
     },
     {
       "relation": "uses",
@@ -27097,9 +27367,9 @@
       "weight": 0.8,
       "_src": "payments_service_rationale_11",
       "_tgt": "payments_repository_paymentsrepository",
+      "confidence_score": 0.5,
       "source": "payments_service_rationale_11",
-      "target": "payments_repository_paymentsrepository",
-      "confidence_score": 0.5
+      "target": "payments_repository_paymentsrepository"
     },
     {
       "relation": "uses",
@@ -27109,9 +27379,9 @@
       "weight": 0.8,
       "_src": "payments_service_rationale_22",
       "_tgt": "payments_repository_paymentsrepository",
+      "confidence_score": 0.5,
       "source": "payments_service_rationale_22",
-      "target": "payments_repository_paymentsrepository",
-      "confidence_score": 0.5
+      "target": "payments_repository_paymentsrepository"
     },
     {
       "relation": "uses",
@@ -27121,9 +27391,9 @@
       "weight": 0.8,
       "_src": "payments_service_rationale_28",
       "_tgt": "payments_repository_paymentsrepository",
+      "confidence_score": 0.5,
       "source": "payments_service_rationale_28",
-      "target": "payments_repository_paymentsrepository",
-      "confidence_score": 0.5
+      "target": "payments_repository_paymentsrepository"
     },
     {
       "relation": "contains",
@@ -27361,9 +27631,9 @@
       "weight": 0.8,
       "_src": "summary_service_ordersmapper",
       "_tgt": "summary_repository_orderssummaryrepository",
+      "confidence_score": 0.5,
       "source": "summary_service_ordersmapper",
-      "target": "summary_repository_orderssummaryrepository",
-      "confidence_score": 0.5
+      "target": "summary_repository_orderssummaryrepository"
     },
     {
       "relation": "uses",
@@ -27371,11 +27641,11 @@
       "source_file": "maria_cacau/backend/features/orders/subfeatures/summary/route.py",
       "source_location": "L5",
       "weight": 0.8,
-      "_src": "summary_route_rationale_1",
-      "_tgt": "summary_service_ordersmapper",
+      "_src": "summary_service_ordersmapper",
+      "_tgt": "summary_route_rationale_1",
+      "confidence_score": 0.5,
       "source": "summary_service_ordersmapper",
-      "target": "summary_route_rationale_1",
-      "confidence_score": 0.5
+      "target": "summary_route_rationale_1"
     },
     {
       "relation": "method",
@@ -27421,9 +27691,9 @@
       "weight": 0.8,
       "_src": "summary_service_ordersservice",
       "_tgt": "summary_repository_orderssummaryrepository",
+      "confidence_score": 0.5,
       "source": "summary_service_ordersservice",
-      "target": "summary_repository_orderssummaryrepository",
-      "confidence_score": 0.5
+      "target": "summary_repository_orderssummaryrepository"
     },
     {
       "relation": "uses",
@@ -27431,11 +27701,11 @@
       "source_file": "maria_cacau/backend/features/orders/subfeatures/summary/route.py",
       "source_location": "L5",
       "weight": 0.8,
-      "_src": "summary_route_rationale_1",
-      "_tgt": "summary_service_ordersservice",
+      "_src": "summary_service_ordersservice",
+      "_tgt": "summary_route_rationale_1",
+      "confidence_score": 0.5,
       "source": "summary_service_ordersservice",
-      "target": "summary_route_rationale_1",
-      "confidence_score": 0.5
+      "target": "summary_route_rationale_1"
     },
     {
       "relation": "calls",
@@ -27469,9 +27739,9 @@
       "weight": 0.8,
       "_src": "summary_service_rationale_1",
       "_tgt": "summary_repository_orderssummaryrepository",
+      "confidence_score": 0.5,
       "source": "summary_service_rationale_1",
-      "target": "summary_repository_orderssummaryrepository",
-      "confidence_score": 0.5
+      "target": "summary_repository_orderssummaryrepository"
     },
     {
       "relation": "uses",
@@ -27481,9 +27751,9 @@
       "weight": 0.8,
       "_src": "summary_service_rationale_10",
       "_tgt": "summary_repository_orderssummaryrepository",
+      "confidence_score": 0.5,
       "source": "summary_service_rationale_10",
-      "target": "summary_repository_orderssummaryrepository",
-      "confidence_score": 0.5
+      "target": "summary_repository_orderssummaryrepository"
     },
     {
       "relation": "uses",
@@ -27493,9 +27763,9 @@
       "weight": 0.8,
       "_src": "summary_service_rationale_21",
       "_tgt": "summary_repository_orderssummaryrepository",
+      "confidence_score": 0.5,
       "source": "summary_service_rationale_21",
-      "target": "summary_repository_orderssummaryrepository",
-      "confidence_score": 0.5
+      "target": "summary_repository_orderssummaryrepository"
     },
     {
       "relation": "uses",
@@ -27505,9 +27775,9 @@
       "weight": 0.8,
       "_src": "summary_service_rationale_27",
       "_tgt": "summary_repository_orderssummaryrepository",
+      "confidence_score": 0.5,
       "source": "summary_service_rationale_27",
-      "target": "summary_repository_orderssummaryrepository",
-      "confidence_score": 0.5
+      "target": "summary_repository_orderssummaryrepository"
     },
     {
       "relation": "contains",
@@ -27769,9 +28039,9 @@
       "weight": 0.8,
       "_src": "deliveries_service_deliveriesmapper",
       "_tgt": "deliveries_models_deliveriessummary",
+      "confidence_score": 0.5,
       "source": "deliveries_service_deliveriesmapper",
-      "target": "deliveries_models_deliveriessummary",
-      "confidence_score": 0.5
+      "target": "deliveries_models_deliveriessummary"
     },
     {
       "relation": "uses",
@@ -27781,9 +28051,9 @@
       "weight": 0.8,
       "_src": "deliveries_service_deliveriesmapper",
       "_tgt": "deliveries_models_deliverytypecount",
+      "confidence_score": 0.5,
       "source": "deliveries_service_deliveriesmapper",
-      "target": "deliveries_models_deliverytypecount",
-      "confidence_score": 0.5
+      "target": "deliveries_models_deliverytypecount"
     },
     {
       "relation": "uses",
@@ -27793,9 +28063,9 @@
       "weight": 0.8,
       "_src": "deliveries_service_deliveriesmapper",
       "_tgt": "deliveries_repository_deliveriesrepository",
+      "confidence_score": 0.5,
       "source": "deliveries_service_deliveriesmapper",
-      "target": "deliveries_repository_deliveriesrepository",
-      "confidence_score": 0.5
+      "target": "deliveries_repository_deliveriesrepository"
     },
     {
       "relation": "uses",
@@ -27803,11 +28073,11 @@
       "source_file": "maria_cacau/backend/features/orders/subfeatures/deliveries/route.py",
       "source_location": "L5",
       "weight": 0.8,
-      "_src": "deliveries_route_rationale_1",
-      "_tgt": "deliveries_service_deliveriesmapper",
+      "_src": "deliveries_service_deliveriesmapper",
+      "_tgt": "deliveries_route_rationale_1",
+      "confidence_score": 0.5,
       "source": "deliveries_service_deliveriesmapper",
-      "target": "deliveries_route_rationale_1",
-      "confidence_score": 0.5
+      "target": "deliveries_route_rationale_1"
     },
     {
       "relation": "calls",
@@ -27816,8 +28086,8 @@
       "source_file": "maria_cacau/backend/features/orders/subfeatures/deliveries/route.py",
       "source_location": "L15",
       "weight": 1.0,
-      "_src": "deliveries_route_get_deliveries",
-      "_tgt": "deliveries_service_to_response",
+      "_src": "deliveries_service_to_response",
+      "_tgt": "deliveries_route_get_deliveries",
       "source": "deliveries_service_to_response",
       "target": "deliveries_route_get_deliveries"
     },
@@ -27865,9 +28135,9 @@
       "weight": 0.8,
       "_src": "deliveries_service_deliveriesservice",
       "_tgt": "deliveries_models_deliveriessummary",
+      "confidence_score": 0.5,
       "source": "deliveries_service_deliveriesservice",
-      "target": "deliveries_models_deliveriessummary",
-      "confidence_score": 0.5
+      "target": "deliveries_models_deliveriessummary"
     },
     {
       "relation": "uses",
@@ -27877,9 +28147,9 @@
       "weight": 0.8,
       "_src": "deliveries_service_deliveriesservice",
       "_tgt": "deliveries_models_deliverytypecount",
+      "confidence_score": 0.5,
       "source": "deliveries_service_deliveriesservice",
-      "target": "deliveries_models_deliverytypecount",
-      "confidence_score": 0.5
+      "target": "deliveries_models_deliverytypecount"
     },
     {
       "relation": "uses",
@@ -27889,9 +28159,9 @@
       "weight": 0.8,
       "_src": "deliveries_service_deliveriesservice",
       "_tgt": "deliveries_repository_deliveriesrepository",
+      "confidence_score": 0.5,
       "source": "deliveries_service_deliveriesservice",
-      "target": "deliveries_repository_deliveriesrepository",
-      "confidence_score": 0.5
+      "target": "deliveries_repository_deliveriesrepository"
     },
     {
       "relation": "uses",
@@ -27899,11 +28169,11 @@
       "source_file": "maria_cacau/backend/features/orders/subfeatures/deliveries/route.py",
       "source_location": "L5",
       "weight": 0.8,
-      "_src": "deliveries_route_rationale_1",
-      "_tgt": "deliveries_service_deliveriesservice",
+      "_src": "deliveries_service_deliveriesservice",
+      "_tgt": "deliveries_route_rationale_1",
+      "confidence_score": 0.5,
       "source": "deliveries_service_deliveriesservice",
-      "target": "deliveries_route_rationale_1",
-      "confidence_score": 0.5
+      "target": "deliveries_route_rationale_1"
     },
     {
       "relation": "calls",
@@ -27961,9 +28231,9 @@
       "weight": 0.8,
       "_src": "deliveries_service_rationale_1",
       "_tgt": "deliveries_models_deliveriessummary",
+      "confidence_score": 0.5,
       "source": "deliveries_service_rationale_1",
-      "target": "deliveries_models_deliveriessummary",
-      "confidence_score": 0.5
+      "target": "deliveries_models_deliveriessummary"
     },
     {
       "relation": "uses",
@@ -27973,9 +28243,9 @@
       "weight": 0.8,
       "_src": "deliveries_service_rationale_1",
       "_tgt": "deliveries_models_deliverytypecount",
+      "confidence_score": 0.5,
       "source": "deliveries_service_rationale_1",
-      "target": "deliveries_models_deliverytypecount",
-      "confidence_score": 0.5
+      "target": "deliveries_models_deliverytypecount"
     },
     {
       "relation": "uses",
@@ -27985,9 +28255,9 @@
       "weight": 0.8,
       "_src": "deliveries_service_rationale_1",
       "_tgt": "deliveries_repository_deliveriesrepository",
+      "confidence_score": 0.5,
       "source": "deliveries_service_rationale_1",
-      "target": "deliveries_repository_deliveriesrepository",
-      "confidence_score": 0.5
+      "target": "deliveries_repository_deliveriesrepository"
     },
     {
       "relation": "uses",
@@ -27997,9 +28267,9 @@
       "weight": 0.8,
       "_src": "deliveries_service_rationale_11",
       "_tgt": "deliveries_models_deliveriessummary",
+      "confidence_score": 0.5,
       "source": "deliveries_service_rationale_11",
-      "target": "deliveries_models_deliveriessummary",
-      "confidence_score": 0.5
+      "target": "deliveries_models_deliveriessummary"
     },
     {
       "relation": "uses",
@@ -28009,9 +28279,9 @@
       "weight": 0.8,
       "_src": "deliveries_service_rationale_11",
       "_tgt": "deliveries_models_deliverytypecount",
+      "confidence_score": 0.5,
       "source": "deliveries_service_rationale_11",
-      "target": "deliveries_models_deliverytypecount",
-      "confidence_score": 0.5
+      "target": "deliveries_models_deliverytypecount"
     },
     {
       "relation": "uses",
@@ -28021,9 +28291,9 @@
       "weight": 0.8,
       "_src": "deliveries_service_rationale_11",
       "_tgt": "deliveries_repository_deliveriesrepository",
+      "confidence_score": 0.5,
       "source": "deliveries_service_rationale_11",
-      "target": "deliveries_repository_deliveriesrepository",
-      "confidence_score": 0.5
+      "target": "deliveries_repository_deliveriesrepository"
     },
     {
       "relation": "uses",
@@ -28033,9 +28303,9 @@
       "weight": 0.8,
       "_src": "deliveries_service_rationale_19",
       "_tgt": "deliveries_models_deliveriessummary",
+      "confidence_score": 0.5,
       "source": "deliveries_service_rationale_19",
-      "target": "deliveries_models_deliveriessummary",
-      "confidence_score": 0.5
+      "target": "deliveries_models_deliveriessummary"
     },
     {
       "relation": "uses",
@@ -28045,9 +28315,9 @@
       "weight": 0.8,
       "_src": "deliveries_service_rationale_19",
       "_tgt": "deliveries_models_deliverytypecount",
+      "confidence_score": 0.5,
       "source": "deliveries_service_rationale_19",
-      "target": "deliveries_models_deliverytypecount",
-      "confidence_score": 0.5
+      "target": "deliveries_models_deliverytypecount"
     },
     {
       "relation": "uses",
@@ -28057,9 +28327,9 @@
       "weight": 0.8,
       "_src": "deliveries_service_rationale_19",
       "_tgt": "deliveries_repository_deliveriesrepository",
+      "confidence_score": 0.5,
       "source": "deliveries_service_rationale_19",
-      "target": "deliveries_repository_deliveriesrepository",
-      "confidence_score": 0.5
+      "target": "deliveries_repository_deliveriesrepository"
     },
     {
       "relation": "uses",
@@ -28069,9 +28339,9 @@
       "weight": 0.8,
       "_src": "deliveries_service_rationale_25",
       "_tgt": "deliveries_models_deliveriessummary",
+      "confidence_score": 0.5,
       "source": "deliveries_service_rationale_25",
-      "target": "deliveries_models_deliveriessummary",
-      "confidence_score": 0.5
+      "target": "deliveries_models_deliveriessummary"
     },
     {
       "relation": "uses",
@@ -28081,9 +28351,9 @@
       "weight": 0.8,
       "_src": "deliveries_service_rationale_25",
       "_tgt": "deliveries_models_deliverytypecount",
+      "confidence_score": 0.5,
       "source": "deliveries_service_rationale_25",
-      "target": "deliveries_models_deliverytypecount",
-      "confidence_score": 0.5
+      "target": "deliveries_models_deliverytypecount"
     },
     {
       "relation": "uses",
@@ -28093,9 +28363,9 @@
       "weight": 0.8,
       "_src": "deliveries_service_rationale_25",
       "_tgt": "deliveries_repository_deliveriesrepository",
+      "confidence_score": 0.5,
       "source": "deliveries_service_rationale_25",
-      "target": "deliveries_repository_deliveriesrepository",
-      "confidence_score": 0.5
+      "target": "deliveries_repository_deliveriesrepository"
     },
     {
       "relation": "contains",
@@ -28296,8 +28566,8 @@
       "source_file": "maria_cacau/backend/features/sheet/route.py",
       "source_location": "L13",
       "weight": 1.0,
-      "_src": "sheet_route_select_sheet",
-      "_tgt": "sheet_service_sheetservice_select",
+      "_src": "sheet_service_sheetservice_select",
+      "_tgt": "sheet_route_select_sheet",
       "source": "sheet_service_sheetservice_select",
       "target": "sheet_route_select_sheet"
     },
@@ -28308,8 +28578,8 @@
       "source_file": "maria_cacau/backend/features/sheet/route.py",
       "source_location": "L19",
       "weight": 1.0,
-      "_src": "sheet_route_remove_sheet",
-      "_tgt": "sheet_service_sheetservice_remove",
+      "_src": "sheet_service_sheetservice_remove",
+      "_tgt": "sheet_route_remove_sheet",
       "source": "sheet_service_sheetservice_remove",
       "target": "sheet_route_remove_sheet"
     },
@@ -28320,8 +28590,8 @@
       "source_file": "pocs/prototipacao/figma/figma-plugin.js",
       "source_location": "L66",
       "weight": 1.0,
-      "_src": "figma_figma_plugin_main",
-      "_tgt": "sheet_service_sheetservice_remove",
+      "_src": "sheet_service_sheetservice_remove",
+      "_tgt": "figma_figma_plugin_main",
       "source": "sheet_service_sheetservice_remove",
       "target": "figma_figma_plugin_main"
     },
@@ -28332,8 +28602,8 @@
       "source_file": "pocs/prototipacao/figma/figma-vetorial-14estados.js",
       "source_location": "L13",
       "weight": 1.0,
-      "_src": "figma_figma_vetorial_14estados_main",
-      "_tgt": "sheet_service_sheetservice_remove",
+      "_src": "sheet_service_sheetservice_remove",
+      "_tgt": "figma_figma_vetorial_14estados_main",
       "source": "sheet_service_sheetservice_remove",
       "target": "figma_figma_vetorial_14estados_main"
     },
@@ -28344,8 +28614,8 @@
       "source_file": "pocs/prototipacao/figma/figma-14estados-generated.js",
       "source_location": "L22",
       "weight": 1.0,
-      "_src": "figma_figma_14estados_generated_main",
-      "_tgt": "sheet_service_sheetservice_remove",
+      "_src": "sheet_service_sheetservice_remove",
+      "_tgt": "figma_figma_14estados_generated_main",
       "source": "sheet_service_sheetservice_remove",
       "target": "figma_figma_14estados_generated_main"
     },
@@ -28356,8 +28626,8 @@
       "source_file": "pocs/prototipacao/figma/figma-vetorial-mc-frames-f0.js",
       "source_location": "L13",
       "weight": 1.0,
-      "_src": "figma_figma_vetorial_mc_frames_f0_main",
-      "_tgt": "sheet_service_sheetservice_remove",
+      "_src": "sheet_service_sheetservice_remove",
+      "_tgt": "figma_figma_vetorial_mc_frames_f0_main",
       "source": "sheet_service_sheetservice_remove",
       "target": "figma_figma_vetorial_mc_frames_f0_main"
     },
@@ -28500,8 +28770,8 @@
       "source_file": "maria_cacau/backend/errors/_mapper.py",
       "source_location": "L27",
       "weight": 1.0,
-      "_src": "errors_mapper_translate",
-      "_tgt": "errors_errors_backenderror",
+      "_src": "errors_errors_backenderror",
+      "_tgt": "errors_mapper_translate",
       "source": "errors_errors_backenderror",
       "target": "errors_mapper_translate"
     },
@@ -28512,8 +28782,8 @@
       "source_file": "maria_cacau/backend/errors/_mapper.py",
       "source_location": "L36",
       "weight": 1.0,
-      "_src": "errors_mapper_generic_mapper",
-      "_tgt": "errors_errors_backenderror",
+      "_src": "errors_errors_backenderror",
+      "_tgt": "errors_mapper_generic_mapper",
       "source": "errors_errors_backenderror",
       "target": "errors_mapper_generic_mapper"
     },

--- a/maria_cacau/app/coordinator.py
+++ b/maria_cacau/app/coordinator.py
@@ -36,12 +36,12 @@ class AppCoordinator:
         self._executor.submit(self._initialize)
 
     def _initialize(self) -> None:
+        observability.log(AppEvent.APP_START)
         try:
             AppInitUseCase().initialize()
         except Exception:
             pass
         bus.app_init_finished.emit()
-        observability.log(AppEvent.APP_START)
 
     def _on_quit(self) -> None:
         observability.log(AppEvent.APP_CLOSE)

--- a/maria_cacau/core/network/_client.py
+++ b/maria_cacau/core/network/_client.py
@@ -3,6 +3,7 @@
 from typing import Protocol
 
 import _observability as observability
+
 from ._request import HTTPRequest
 from ._response import HTTPResponse
 

--- a/maria_cacau/core/network/_client.py
+++ b/maria_cacau/core/network/_client.py
@@ -2,6 +2,7 @@
 
 from typing import Protocol
 
+import _observability as observability
 from ._request import HTTPRequest
 from ._response import HTTPResponse
 
@@ -24,4 +25,4 @@ class LocalClient:
         self._backend = backend
 
     def execute(self, request: HTTPRequest) -> HTTPResponse:
-        return self._backend.execute(request)
+        return observability.track(request, lambda: self._backend.execute(request))

--- a/maria_cacau/core/network/_observability.py
+++ b/maria_cacau/core/network/_observability.py
@@ -1,0 +1,32 @@
+"""Observabilidade da camada de network."""
+
+import time
+from enum import Enum
+from typing import Callable, TypeVar
+
+from ..observability import observability
+from ._request import HTTPRequest
+from ._response import HTTPResponse
+
+
+class NetworkEvent(Enum):
+    HTTP_REQUEST = 'HTTP_REQUEST'   # extra: path=, method=, status=, duration_s=
+
+
+T = TypeVar('T', bound=HTTPResponse)
+
+
+def track(request: HTTPRequest, action: Callable[[], T]) -> T:
+    start = time.perf_counter()
+
+    response = action()
+    
+    duration_s = round(time.perf_counter() - start, 3)
+    observability.log(
+        NetworkEvent.HTTP_REQUEST,
+        path=request.path,
+        method=request.method,
+        status=response.status_code,
+        duration_s=duration_s,
+    )
+    return response

--- a/maria_cacau/core/observability.py
+++ b/maria_cacau/core/observability.py
@@ -11,18 +11,8 @@ _DATE_FMT = '%Y-%m-%d %H:%M:%S'
 
 
 class AppEvent(Enum):
-    APP_START      = 'APP_START'
-    APP_CLOSE      = 'APP_CLOSE'
-    QUERY_ENTREGAS = 'QUERY  feature=entregas'
-    QUERY_PRODUTOS = 'QUERY  feature=produtos'
-    CERT_SET       = 'CERT_SET'
-    CERT_CLEAR     = 'CERT_CLEAR'
-    SHEET_ADD      = 'SHEET_ADD'    # extra: name=, sheet_id=
-    SHEET_SELECT   = 'SHEET_SELECT' # extra: name=, sheet_id=
-    BTN_COPY       = 'BTN_COPY'     # extra: feature=
-    PREWARM_DONE   = 'PREWARM_DONE' # extra: duration_s=
-    CACHE_CLEAR    = 'CACHE_CLEAR'
-    ERROR          = 'ERROR'        # extra: msg=, where= (optional)
+    APP_START = 'APP_START'
+    APP_CLOSE = 'APP_CLOSE'
 
 
 class _Observability:
@@ -35,7 +25,7 @@ class _Observability:
             handler.setFormatter(logging.Formatter(_FMT, _DATE_FMT))
             self._log.addHandler(handler)
 
-    def log(self, event: AppEvent, **extra) -> None:
+    def log(self, event: Enum, **extra) -> None:
         msg = event.value
         if extra:
             parts = '  '.join(
@@ -43,10 +33,7 @@ class _Observability:
                 for k, v in extra.items()
             )
             msg += f'  {parts}'
-        if event is AppEvent.ERROR:
-            self._log.error(msg)
-        else:
-            self._log.info(msg)
+        self._log.info(msg)
 
 
 observability = _Observability()

--- a/pocs/architecture/session-context.md
+++ b/pocs/architecture/session-context.md
@@ -97,7 +97,7 @@ O backend está completo.
 
 ## Próximas sessões
 
-> Nenhuma fase pendente para a v5.0. Fase 4 (refinamentos adicionais do DS) ficará para a v6.0.
+> Nenhuma fase pendente. Fase 4 (refinamentos adicionais do DS) ficará para a v6.0.
 
 ---
 
@@ -114,6 +114,7 @@ O backend está completo.
 | Report + Design System | Cache removido dos repositories; tela limpa ao gerar novo relatório (`clear_content()`); `DSButton` com `DSButtonState` (DEFAULT/DISABLED/LOADING) + `DSLoadingHandler` mixin em `design_system/components/` e `design_system/handlers/`; `bts()` e `aux_frames.py` removidos |
 | Redesign + Fase 2 | Removidas features `nota_fiscal` e `shipping_rate`; `delivery` e `summary` lado a lado na home; `cpf_validation` migrada para `features/` como feature independente e virou `QDialog`; criado menu "Funcionalidades" (`features/funcionalidades/`) com sub-item "Validador de CPF" que abre o dialog via `show()` |
 | Fase 3 — Design System | `AuxWidgets`, `gui_popup.py` e `core/charts.py` removidos; Design System expandido com 7 novos componentes em pastas próprias (`alerts/`, `chart/`, `combo_box/`, `containers/`, `inputs/`, `label/`, `text_view/`); views e controllers migrados para consumir somente componentes DS; `features/funcionalidades/` removida — `MenuHandler` cria o menu inline e instancia `CpfValidationController` diretamente; `menu_title` exposto como property em `CpfValidationView` |
+| Observabilidade — Network layer | `AppEvent` limpo (só `APP_START`/`APP_CLOSE`); `log()` aceita qualquer `Enum`; novo `core/network/_observability.py` com `NetworkEvent` próprio e função `track()` — loga automaticamente `path`, `method`, `status` e `duration_s` de toda request via `LocalClient` |
 
 ---
 


### PR DESCRIPTION
## Overview

A feature adiciona observabilidade automática na camada de network do app. Antes, nenhuma chamada ao backend era registrada — era impossível saber quais endpoints foram acessados, qual foi o status HTTP ou quanto tempo cada request levou. Agora toda request passa pelo`track()` e gera uma linha de log com essas informações, sem nenhuma alteração nas features que fazem chamadas.

Aproveita para limpar o `AppEvent` global, que acumulava eventos obsoletos de sessões anteriores. O módulo de observabilidade passou a aceitar qualquer `Enum`, permitindo que cada módulo defina seus próprios eventos sem depender do enum central.

## Ajustes feitos

- Novo `core/network/_observability.py` com `NetworkEvent` próprio e função `track()` — recebe a request e um lambda, executa, mede o tempo e loga `path`, `method`, `status` e `duration_s` automaticamente
- `LocalClient.execute()` usa `track()` em uma linha — toda request passa pela observabilidade sem poluir o client
- `AppEvent` reduzido a `APP_START` e `APP_CLOSE`; `log()` aceita `Enum` genérico para suportar eventos de qualquer módulo
- Docs e grafo atualizados
