### PR TITLE
Limpeza de código

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,3 @@
-# Wiki - Docs
-files/wiki/*
-
 # AI
 *.claude
 
@@ -9,9 +6,6 @@ files/wiki/*
 
 # Planilha com dados (usada para teste)
 arquivos/zTestes/
-
-# Configuração do VSCode
-# *.vscode/
 
 # Arquivos da Interface Gráfica
 arquivos/gui
@@ -94,7 +88,7 @@ graphify-out/manifest.json
 # local token tracking, not useful to share
 graphify-out/cost.json
 
+graphify-out/graph.html
 
 # Obsidian
 */obsidian
-graphify-out/graph.html

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,11 +1,11 @@
 # Graph Report - Maria-Cacau-App  (2026-05-21)
 
 ## Corpus Check
-- 174 files · ~18,968 words
+- 174 files · ~18,918 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 848 nodes · 1393 edges · 28 communities detected
+- 848 nodes · 1383 edges · 31 communities detected
 - Extraction: 76% EXTRACTED · 24% INFERRED · 0% AMBIGUOUS · INFERRED: 332 edges (avg confidence: 0.79)
 - Token cost: 0 input · 0 output
 
@@ -30,14 +30,17 @@
 - [[_COMMUNITY_Community 17|Community 17]]
 - [[_COMMUNITY_Community 18|Community 18]]
 - [[_COMMUNITY_Community 19|Community 19]]
-- [[_COMMUNITY_Community 28|Community 28]]
-- [[_COMMUNITY_Community 39|Community 39]]
-- [[_COMMUNITY_Community 40|Community 40]]
-- [[_COMMUNITY_Community 42|Community 42]]
+- [[_COMMUNITY_Community 20|Community 20]]
+- [[_COMMUNITY_Community 21|Community 21]]
+- [[_COMMUNITY_Community 22|Community 22]]
+- [[_COMMUNITY_Community 31|Community 31]]
 - [[_COMMUNITY_Community 44|Community 44]]
 - [[_COMMUNITY_Community 45|Community 45]]
 - [[_COMMUNITY_Community 47|Community 47]]
-- [[_COMMUNITY_Community 48|Community 48]]
+- [[_COMMUNITY_Community 49|Community 49]]
+- [[_COMMUNITY_Community 50|Community 50]]
+- [[_COMMUNITY_Community 52|Community 52]]
+- [[_COMMUNITY_Community 53|Community 53]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `DataSourceError` - 20 edges
@@ -52,66 +55,66 @@
 10. `unexpected_error()` - 11 edges
 
 ## Surprising Connections (you probably didn't know these)
-- `SheetsController` --uses--> `FeatureEvents`  [INFERRED]
-  features/sheets/presentation/controller.py → /Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/domain/events.py
-- `SheetsController` --uses--> `SheetModel`  [INFERRED]
-  features/sheets/presentation/controller.py → /Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/domain/models.py
-- `HTTPClientContract` --uses--> `HTTPResponse`  [INFERRED]
-  core/network/_client.py → /Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/_response.py
-- `LocalClient` --uses--> `HTTPResponse`  [INFERRED]
-  core/network/_client.py → /Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/_response.py
-- `Realiza as request de fato` --uses--> `HTTPResponse`  [INFERRED]
-  core/network/_client.py → /Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/_response.py
+- `FeatureEvents` --uses--> `SheetsController`  [INFERRED]
+  /Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/domain/events.py → features/sheets/presentation/controller.py
+- `SheetModel` --uses--> `SheetsController`  [INFERRED]
+  /Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/domain/models.py → features/sheets/presentation/controller.py
+- `HTTPResponse` --uses--> `HTTPClientContract`  [INFERRED]
+  /Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/_response.py → core/network/_client.py
+- `HTTPResponse` --uses--> `LocalClient`  [INFERRED]
+  /Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/_response.py → core/network/_client.py
+- `HTTPResponse` --uses--> `Realiza as request de fato`  [INFERRED]
+  /Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/_response.py → core/network/_client.py
 
 ## Communities
 
 ### Community 0 - "Community 0"
 Cohesion: 0.03
-Nodes (58): GoogleSheetsDataSource, Implementação de DataSourceProtocol para Google Sheets via gspread., _fix_prod4(), normalize(), Normaliza headers inconsistentes da planilha para os valores canônicos dos enums, Traduz headers reais da planilha para os nomes canônicos definidos nos enums., _rename_at(), _rename_keys() (+50 more)
+Nodes (57): GoogleSheetsDataSource, Implementação de DataSourceProtocol para Google Sheets via gspread., _fix_prod4(), normalize(), Normaliza headers inconsistentes da planilha para os valores canônicos dos enums, Traduz headers reais da planilha para os nomes canônicos definidos nos enums., _rename_at(), _rename_keys() (+49 more)
 
 ### Community 1 - "Community 1"
-Cohesion: 0.03
-Nodes (58): Retorna pedidos da data informada (DD/MM/YYYY)., Retorna pedidos no intervalo de datas informado (DD/MM/YYYY)., Retorna todos os pedidos de uma data como DataFrame bruto., get_deliveries(), Rota de entregas — GET /orders/deliveries., to_response(), DeliveryViewData, _cast_numeric() (+50 more)
+Cohesion: 0.04
+Nodes (40): _EventBus, DeliveriesMapper, ErrorMapper, from_response(), OrdersSummaryMapper, PaymentsMapper, Mappers de HTTPResponse para domain models e de HTTPResponseError para ErrorMode, SummaryRepository (+32 more)
 
 ### Community 2 - "Community 2"
-Cohesion: 0.04
-Nodes (41): _EventBus, DeliveriesMapper, ErrorMapper, from_response(), OrdersSummaryMapper, PaymentsMapper, Mappers de HTTPResponse para domain models e de HTTPResponseError para ErrorMode, SummaryRepository (+33 more)
-
-### Community 3 - "Community 3"
 Cohesion: 0.05
 Nodes (26): API, ConnectAuthAPI, DeliveriesAPI, DisconnectAuthAPI, OrdersSummaryAPI, path(), PaymentsPendentAPI, Endpoints do backend consumidos pela feature Auth. (+18 more)
 
-### Community 4 - "Community 4"
+### Community 3 - "Community 3"
 Cohesion: 0.05
-Nodes (16): DSDialog, DSDialogIcon, DSDialogModel, DSComboBox, asset(), Metadados centralizados do pacote maria-cacau., Resolve um path relativo à pasta assets, funciona em dev e no .exe compilado., AuthController (+8 more)
+Nodes (35): ABC, API, entity(), Comunicação alto nivel para chamadas de api, HTTPClientContract, LocalClient, Realiza as request de fato, Contrato que qualquer client precisa cumprir. (+27 more)
+
+### Community 4 - "Community 4"
+Cohesion: 0.06
+Nodes (14): DSDialog, DSDialogIcon, DSDialogModel, DSComboBox, asset(), Metadados centralizados do pacote maria-cacau., Resolve um path relativo à pasta assets, funciona em dev e no .exe compilado., DeliveryController (+6 more)
 
 ### Community 5 - "Community 5"
-Cohesion: 0.05
-Nodes (36): ABC, API, entity(), Comunicação alto nivel para chamadas de api, HTTPClientContract, LocalClient, Realiza as request de fato, Contrato que qualquer client precisa cumprir. (+28 more)
-
-### Community 6 - "Community 6"
 Cohesion: 0.06
 Nodes (10): MenuHandler, connect(), SheetsUseCase, Erro genérico para exceções não tratadas., unexpected_error(), SheetsController, AuthView, SheetsViewModel (+2 more)
 
-### Community 7 - "Community 7"
+### Community 6 - "Community 6"
 Cohesion: 0.06
-Nodes (14): CpfValidationResult, Models utilizados no módulo, CpfValidationUseCase, _is_valid_cpf(), Valida um CPF pela regra dos dois dígitos verificadores (algoritmo da Receita Fe, DSDateInput, DSTextInput, CpfValidationController (+6 more)
+Nodes (14): DSButton, DSGroupBox, DSLoadingHandler, DSLoadingHandler, Deve ser chamado no __init__ do componente, após o super().__init__()., Implementar no componente: o que fazer com cada frame do spinner., Mixin que adiciona comportamento de loading animado a qualquer componente QObjec, DSDateInput (+6 more)
+
+### Community 7 - "Community 7"
+Cohesion: 0.07
+Nodes (34): Retorna pedidos no intervalo de datas informado (DD/MM/YYYY)., _customer(), _customization(), _delivery(), _financial(), OrderMapper, _payments(), _products() (+26 more)
 
 ### Community 8 - "Community 8"
-Cohesion: 0.09
-Nodes (14): DSButtonState, DSChartType, DSChart, Widget de gráfico reutilizável (barras ou pizza) usando seaborn + matplotlib., _short_label(), AppEvent, _Observability, Observabilidade centralizada do app. (+6 more)
+Cohesion: 0.07
+Nodes (13): CpfValidationResult, Models utilizados no módulo, CpfValidationUseCase, _is_valid_cpf(), Valida um CPF pela regra dos dois dígitos verificadores (algoritmo da Receita Fe, DSTextInput, CpfValidationController, CpfValidationView (+5 more)
 
 ### Community 9 - "Community 9"
 Cohesion: 0.07
-Nodes (12): DSButton, DSGroupBox, DSLoadingHandler, DSLoadingHandler, Deve ser chamado no __init__ do componente, após o super().__init__()., Implementar no componente: o que fazer com cada frame do spinner., Mixin que adiciona comportamento de loading animado a qualquer componente QObjec, DeliveryView (+4 more)
+Nodes (26): DeliveriesSummary, DeliveryTypeCount, Models de domínio da feature de entregas., DeliveriesRepository, Repositório de entregas — busca e prepara dados da planilha para o DeliveriesSer, Acessa o data source e entrega um DataFrame para o DeliveriesService.      Não f, DeliveriesMapper, DeliveriesService (+18 more)
 
 ### Community 10 - "Community 10"
 Cohesion: 0.07
-Nodes (26): DeliveriesSummary, DeliveryTypeCount, Models de domínio da feature de entregas., DeliveriesRepository, Repositório de entregas — busca e prepara dados da planilha para o DeliveriesSer, Acessa o data source e entrega um DataFrame para o DeliveriesService.      Não f, DeliveriesMapper, DeliveriesService (+18 more)
+Nodes (15): Rotas de autenticação, AuthService, Service de autenticação — gerencia o estado de conexão do DataSource., DataSourceProtocol, Autentica com o dict da service account e guarda o client em memória., Remove o client autenticado da memória. Mantém o sheet_id., Remove a planilha ativa da memória. Mantém as credenciais., Define a planilha ativa e dispara prewarm em background. (+7 more)
 
 ### Community 11 - "Community 11"
-Cohesion: 0.07
-Nodes (14): Rotas de autenticação, AuthService, Service de autenticação — gerencia o estado de conexão do DataSource., DataSourceProtocol, Autentica com o dict da service account e guarda o client em memória., Remove o client autenticado da memória. Mantém o sheet_id., Remove a planilha ativa da memória. Mantém as credenciais., Define a planilha ativa e dispara prewarm em background. (+6 more)
+Cohesion: 0.08
+Nodes (21): Retorna pedidos da data informada (DD/MM/YYYY)., Retorna todos os pedidos de uma data como DataFrame bruto., get_deliveries(), Rota de entregas — GET /orders/deliveries., to_response(), _cast_numeric(), PaymentsRepository, Repositório de pagamentos — busca e prepara dados da planilha para o PaymentsSer (+13 more)
 
 ### Community 12 - "Community 12"
 Cohesion: 0.1
@@ -122,97 +125,109 @@ Cohesion: 0.1
 Nodes (9): AppCoordinator, MainWindow, main(), Entry point da aplicação. Execute com: python -m maria_cacau, QMainWindow, QWidget, HomeController, HomeFeaturesModel (+1 more)
 
 ### Community 14 - "Community 14"
+Cohesion: 0.13
+Nodes (11): DSButtonState, AppEvent, _Observability, Observabilidade centralizada do app., Services, FeatureEvents, Eventos de observabilidade da feature CPF Validation., Enum (+3 more)
+
+### Community 15 - "Community 15"
+Cohesion: 0.13
+Nodes (5): AuthUseCase, Lê o arquivo JSON, salva em storage seguro e autentica o backend., Remove credenciais do storage e desautentica o backend., AuthController, AuthViewModel
+
+### Community 16 - "Community 16"
+Cohesion: 0.21
+Nodes (4): DSChartType, DSChart, Widget de gráfico reutilizável (barras ou pizza) usando seaborn + matplotlib., _short_label()
+
+### Community 17 - "Community 17"
 Cohesion: 0.24
 Nodes (7): BackendServer, handle_backend_error(), handle_data_source_error(), handle_unexpected_error(), BackendError, generic_mapper(), translate()
 
-### Community 15 - "Community 15"
+### Community 18 - "Community 18"
 Cohesion: 0.31
 Nodes (2): Backend de armazenamento seguro via arquivo protegido no diretório do usuário., SecurityStorage
 
-### Community 16 - "Community 16"
+### Community 19 - "Community 19"
 Cohesion: 0.4
 Nodes (3): normalize_decimal(), Utilitários de formatação numérica., Converte número no formato brasileiro para o formato inglês.      Remove o separ
 
-### Community 17 - "Community 17"
+### Community 20 - "Community 20"
 Cohesion: 0.5
 Nodes (1): AppSession
 
-### Community 18 - "Community 18"
+### Community 21 - "Community 21"
 Cohesion: 1.0
 Nodes (1): r"""Indica se a resposta foi bem sucedida (status code 2xx).
 
-### Community 19 - "Community 19"
+### Community 22 - "Community 22"
 Cohesion: 1.0
 Nodes (1): O tipo precisa aceitar **kwargs (dataclass ou similar).
 
-### Community 28 - "Community 28"
+### Community 31 - "Community 31"
 Cohesion: 1.0
 Nodes (1): Lê o JSON do backend; cai em http_error genérico se o corpo não for JSON válido.
 
-### Community 39 - "Community 39"
+### Community 44 - "Community 44"
 Cohesion: 1.0
 Nodes (1): Renomeia a coluna que segue prod3 para prod4, independente do header atual.
 
-### Community 40 - "Community 40"
+### Community 45 - "Community 45"
 Cohesion: 1.0
 Nodes (1): Busca pedidos por datas usando dois passes para minimizar chamadas à API.
 
-### Community 42 - "Community 42"
+### Community 47 - "Community 47"
 Cohesion: 1.0
 Nodes (1): Monta um Order completo a partir de uma linha do DataFrame.
 
-### Community 44 - "Community 44"
+### Community 49 - "Community 49"
 Cohesion: 1.0
 Nodes (1): Converte list[dict] em DataFrame com cast numérico de todas as colunas de valor.
 
-### Community 45 - "Community 45"
+### Community 50 - "Community 50"
 Cohesion: 1.0
 Nodes (1): Faz cast numérico de uma coluna se ela existir no DataFrame.
 
-### Community 47 - "Community 47"
+### Community 52 - "Community 52"
 Cohesion: 1.0
 Nodes (1): Converte list[dict] em DataFrame com cast numérico de todas as colunas de valor.
 
-### Community 48 - "Community 48"
+### Community 53 - "Community 53"
 Cohesion: 1.0
 Nodes (1): Faz cast numérico de uma coluna se ela existir no DataFrame.
 
 ## Knowledge Gaps
 - **113 isolated node(s):** `Metadados centralizados do pacote maria-cacau.`, `Resolve um path relativo à pasta assets, funciona em dev e no .exe compilado.`, `Entry point da aplicação. Execute com: python -m maria_cacau`, `Observabilidade centralizada do app.`, `Erros mapeados usados no módulo` (+108 more)
   These have ≤1 connection - possible missing edges or undocumented components.
-- **Thin community `Community 15`** (9 nodes): `Backend de armazenamento seguro via arquivo protegido no diretório do usuário.`, `SecurityStorage`, `.clean_all()`, `.delete()`, `.__init__()`, `._path()`, `.retrieve()`, `.save()`, `security.py`
+- **Thin community `Community 18`** (9 nodes): `Backend de armazenamento seguro via arquivo protegido no diretório do usuário.`, `SecurityStorage`, `.clean_all()`, `.delete()`, `.__init__()`, `._path()`, `.retrieve()`, `.save()`, `security.py`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 17`** (4 nodes): `AppSession`, `.__init__()`, `__init__.py`, `session.py`
+- **Thin community `Community 20`** (4 nodes): `AppSession`, `.__init__()`, `__init__.py`, `session.py`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 18`** (1 nodes): `r"""Indica se a resposta foi bem sucedida (status code 2xx).`
+- **Thin community `Community 21`** (1 nodes): `r"""Indica se a resposta foi bem sucedida (status code 2xx).`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 19`** (1 nodes): `O tipo precisa aceitar **kwargs (dataclass ou similar).`
+- **Thin community `Community 22`** (1 nodes): `O tipo precisa aceitar **kwargs (dataclass ou similar).`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 28`** (1 nodes): `Lê o JSON do backend; cai em http_error genérico se o corpo não for JSON válido.`
+- **Thin community `Community 31`** (1 nodes): `Lê o JSON do backend; cai em http_error genérico se o corpo não for JSON válido.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 39`** (1 nodes): `Renomeia a coluna que segue prod3 para prod4, independente do header atual.`
+- **Thin community `Community 44`** (1 nodes): `Renomeia a coluna que segue prod3 para prod4, independente do header atual.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 40`** (1 nodes): `Busca pedidos por datas usando dois passes para minimizar chamadas à API.`
+- **Thin community `Community 45`** (1 nodes): `Busca pedidos por datas usando dois passes para minimizar chamadas à API.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 42`** (1 nodes): `Monta um Order completo a partir de uma linha do DataFrame.`
+- **Thin community `Community 47`** (1 nodes): `Monta um Order completo a partir de uma linha do DataFrame.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 44`** (1 nodes): `Converte list[dict] em DataFrame com cast numérico de todas as colunas de valor.`
+- **Thin community `Community 49`** (1 nodes): `Converte list[dict] em DataFrame com cast numérico de todas as colunas de valor.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 45`** (1 nodes): `Faz cast numérico de uma coluna se ela existir no DataFrame.`
+- **Thin community `Community 50`** (1 nodes): `Faz cast numérico de uma coluna se ela existir no DataFrame.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 47`** (1 nodes): `Converte list[dict] em DataFrame com cast numérico de todas as colunas de valor.`
+- **Thin community `Community 52`** (1 nodes): `Converte list[dict] em DataFrame com cast numérico de todas as colunas de valor.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 48`** (1 nodes): `Faz cast numérico de uma coluna se ela existir no DataFrame.`
+- **Thin community `Community 53`** (1 nodes): `Faz cast numérico de uma coluna se ela existir no DataFrame.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions
 _Questions this graph is uniquely positioned to answer:_
 
-- **Why does `SheetsController` connect `Community 6` to `Community 3`, `Community 4`, `Community 7`, `Community 8`, `Community 11`?**
-  _High betweenness centrality (0.106) - this node is a cross-community bridge._
-- **Why does `connect()` connect `Community 6` to `Community 4`, `Community 7`, `Community 9`, `Community 11`, `Community 12`, `Community 13`?**
-  _High betweenness centrality (0.099) - this node is a cross-community bridge._
-- **Why does `call()` connect `Community 3` to `Community 5`, `Community 14`?**
+- **Why does `SheetsController` connect `Community 5` to `Community 1`, `Community 2`, `Community 4`, `Community 8`, `Community 10`, `Community 14`?**
+  _High betweenness centrality (0.108) - this node is a cross-community bridge._
+- **Why does `connect()` connect `Community 5` to `Community 4`, `Community 6`, `Community 8`, `Community 10`, `Community 12`, `Community 13`, `Community 15`?**
+  _High betweenness centrality (0.100) - this node is a cross-community bridge._
+- **Why does `call()` connect `Community 2` to `Community 17`, `Community 3`?**
   _High betweenness centrality (0.080) - this node is a cross-community bridge._
 - **Are the 4 inferred relationships involving `SheetsController` (e.g. with `FeatureEvents` and `SheetModel`) actually correct?**
   _`SheetsController` has 4 INFERRED edges - model-reasoned connections that need verification._

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -26,18 +26,18 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/__init__.py",
       "source_location": "L1",
-      "id": "maria_cacau_init_rationale_1",
       "community": 4,
-      "norm_label": "metadados centralizados do pacote maria-cacau."
+      "norm_label": "metadados centralizados do pacote maria-cacau.",
+      "id": "maria_cacau_init_rationale_1"
     },
     {
       "label": "Resolve um path relativo \u00e0 pasta assets, funciona em dev e no .exe compilado.",
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/__init__.py",
       "source_location": "L18",
-      "id": "maria_cacau_init_rationale_18",
       "community": 4,
-      "norm_label": "resolve um path relativo a pasta assets, funciona em dev e no .exe compilado."
+      "norm_label": "resolve um path relativo a pasta assets, funciona em dev e no .exe compilado.",
+      "id": "maria_cacau_init_rationale_18"
     },
     {
       "label": "__main__.py",
@@ -62,9 +62,9 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/__main__.py",
       "source_location": "L1",
-      "id": "maria_cacau_main_rationale_1",
       "community": 13,
-      "norm_label": "entry point da aplicacao. execute com: python -m maria_cacau"
+      "norm_label": "entry point da aplicacao. execute com: python -m maria_cacau",
+      "id": "maria_cacau_main_rationale_1"
     },
     {
       "label": "services.py",
@@ -72,7 +72,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/services.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_core_services_py",
-      "community": 8,
+      "community": 14,
       "norm_label": "services.py"
     },
     {
@@ -81,7 +81,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/services.py",
       "source_location": "L4",
       "id": "core_services_services",
-      "community": 8,
+      "community": 14,
       "norm_label": "services"
     },
     {
@@ -90,7 +90,7 @@
       "source_file": "",
       "source_location": "",
       "id": "enum",
-      "community": 8,
+      "community": 14,
       "norm_label": "enum"
     },
     {
@@ -99,7 +99,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/session.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_core_session_py",
-      "community": 17,
+      "community": 20,
       "norm_label": "session.py"
     },
     {
@@ -108,7 +108,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/session.py",
       "source_location": "L1",
       "id": "core_session_appsession",
-      "community": 17,
+      "community": 20,
       "norm_label": "appsession"
     },
     {
@@ -117,7 +117,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/session.py",
       "source_location": "L2",
       "id": "core_session_appsession_init",
-      "community": 17,
+      "community": 20,
       "norm_label": ".__init__()"
     },
     {
@@ -126,7 +126,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_core_init_py",
-      "community": 17,
+      "community": 20,
       "norm_label": "__init__.py"
     },
     {
@@ -135,7 +135,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/observability.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_core_observability_py",
-      "community": 8,
+      "community": 14,
       "norm_label": "observability.py"
     },
     {
@@ -144,7 +144,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/observability.py",
       "source_location": "L13",
       "id": "core_observability_appevent",
-      "community": 8,
+      "community": 14,
       "norm_label": "appevent"
     },
     {
@@ -153,7 +153,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/observability.py",
       "source_location": "L18",
       "id": "core_observability_observability",
-      "community": 8,
+      "community": 14,
       "norm_label": "_observability"
     },
     {
@@ -162,7 +162,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/observability.py",
       "source_location": "L19",
       "id": "core_observability_observability_init",
-      "community": 8,
+      "community": 14,
       "norm_label": ".__init__()"
     },
     {
@@ -179,9 +179,9 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/observability.py",
       "source_location": "L1",
-      "id": "core_observability_rationale_1",
-      "community": 8,
-      "norm_label": "observabilidade centralizada do app."
+      "community": 14,
+      "norm_label": "observabilidade centralizada do app.",
+      "id": "core_observability_rationale_1"
     },
     {
       "label": "bus.py",
@@ -189,7 +189,7 @@
       "source_file": "core/bus.py",
       "source_location": "L1",
       "id": "core_bus_py",
-      "community": 2,
+      "community": 1,
       "norm_label": "bus.py"
     },
     {
@@ -198,7 +198,7 @@
       "source_file": "core/bus.py",
       "source_location": "L4",
       "id": "core_bus_eventbus",
-      "community": 2,
+      "community": 1,
       "norm_label": "_eventbus"
     },
     {
@@ -207,7 +207,7 @@
       "source_file": "",
       "source_location": "",
       "id": "qobject",
-      "community": 2,
+      "community": 1,
       "norm_label": "qobject"
     },
     {
@@ -216,7 +216,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/_errors.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_core_network_errors_py",
-      "community": 5,
+      "community": 3,
       "norm_label": "_errors.py"
     },
     {
@@ -225,7 +225,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/_errors.py",
       "source_location": "L9",
       "id": "network_errors_networkerror",
-      "community": 5,
+      "community": 3,
       "norm_label": "networkerror"
     },
     {
@@ -234,7 +234,7 @@
       "source_file": "",
       "source_location": "",
       "id": "exception",
-      "community": 10,
+      "community": 9,
       "norm_label": "exception"
     },
     {
@@ -243,7 +243,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/_errors.py",
       "source_location": "L14",
       "id": "network_errors_networknotconfigurederror",
-      "community": 5,
+      "community": 3,
       "norm_label": "networknotconfigurederror"
     },
     {
@@ -252,7 +252,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/_errors.py",
       "source_location": "L16",
       "id": "network_errors_networknotconfigurederror_init",
-      "community": 5,
+      "community": 3,
       "norm_label": ".__init__()"
     },
     {
@@ -261,7 +261,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/_errors.py",
       "source_location": "L19",
       "id": "network_errors_httprequesterror",
-      "community": 5,
+      "community": 3,
       "norm_label": "httprequesterror"
     },
     {
@@ -270,7 +270,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/_errors.py",
       "source_location": "L21",
       "id": "network_errors_httprequesterror_init",
-      "community": 5,
+      "community": 3,
       "norm_label": ".__init__()"
     },
     {
@@ -279,7 +279,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/_errors.py",
       "source_location": "L25",
       "id": "network_errors_httpresponseerror",
-      "community": 5,
+      "community": 3,
       "norm_label": "httpresponseerror"
     },
     {
@@ -288,7 +288,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/_errors.py",
       "source_location": "L27",
       "id": "network_errors_httpresponseerror_init",
-      "community": 5,
+      "community": 3,
       "norm_label": ".__init__()"
     },
     {
@@ -314,45 +314,45 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/_errors.py",
       "source_location": "L1",
-      "id": "network_errors_rationale_1",
-      "community": 5,
-      "norm_label": "erros mapeados usados no modulo"
+      "community": 3,
+      "norm_label": "erros mapeados usados no modulo",
+      "id": "network_errors_rationale_1"
     },
     {
       "label": "r\"\"\"Erro base da camada de network.",
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/_errors.py",
       "source_location": "L10",
-      "id": "network_errors_rationale_10",
-      "community": 5,
-      "norm_label": "r\"\"\"erro base da camada de network."
+      "community": 3,
+      "norm_label": "r\"\"\"erro base da camada de network.",
+      "id": "network_errors_rationale_10"
     },
     {
       "label": "configure() n\u00e3o foi chamado antes de usar a lib.",
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/_errors.py",
       "source_location": "L15",
-      "id": "network_errors_rationale_15",
-      "community": 5,
-      "norm_label": "configure() nao foi chamado antes de usar a lib."
+      "community": 3,
+      "norm_label": "configure() nao foi chamado antes de usar a lib.",
+      "id": "network_errors_rationale_15"
     },
     {
       "label": "Erro antes de receber resposta (conectividade, timeout, URL inv\u00e1lida).",
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/_errors.py",
       "source_location": "L20",
-      "id": "network_errors_rationale_20",
-      "community": 5,
-      "norm_label": "erro antes de receber resposta (conectividade, timeout, url invalida)."
+      "community": 3,
+      "norm_label": "erro antes de receber resposta (conectividade, timeout, url invalida).",
+      "id": "network_errors_rationale_20"
     },
     {
       "label": "Resposta recebida com status de erro (4xx, 5xx).",
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/_errors.py",
       "source_location": "L26",
-      "id": "network_errors_rationale_26",
-      "community": 5,
-      "norm_label": "resposta recebida com status de erro (4xx, 5xx)."
+      "community": 3,
+      "norm_label": "resposta recebida com status de erro (4xx, 5xx).",
+      "id": "network_errors_rationale_26"
     },
     {
       "label": "_method.py",
@@ -360,7 +360,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/_method.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_core_network_method_py",
-      "community": 5,
+      "community": 3,
       "norm_label": "_method.py"
     },
     {
@@ -369,7 +369,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/_method.py",
       "source_location": "L6",
       "id": "network_method_httpmethod",
-      "community": 5,
+      "community": 3,
       "norm_label": "httpmethod"
     },
     {
@@ -377,9 +377,9 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/_method.py",
       "source_location": "L1",
-      "id": "network_method_rationale_1",
-      "community": 5,
-      "norm_label": "http metodos disponiveis para uso"
+      "community": 3,
+      "norm_label": "http metodos disponiveis para uso",
+      "id": "network_method_rationale_1"
     },
     {
       "label": "_response.py",
@@ -387,7 +387,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/_response.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_core_network_response_py",
-      "community": 5,
+      "community": 3,
       "norm_label": "_response.py"
     },
     {
@@ -396,7 +396,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/_response.py",
       "source_location": "L6",
       "id": "network_response_httpresponse",
-      "community": 5,
+      "community": 3,
       "norm_label": "httpresponse"
     },
     {
@@ -405,7 +405,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/_response.py",
       "source_location": "L11",
       "id": "network_response_httpresponse_json",
-      "community": 5,
+      "community": 3,
       "norm_label": ".json()"
     },
     {
@@ -414,7 +414,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/_response.py",
       "source_location": "L16",
       "id": "network_response_is_success",
-      "community": 5,
+      "community": 3,
       "norm_label": "is_success()"
     },
     {
@@ -422,18 +422,18 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/_response.py",
       "source_location": "L12",
-      "id": "network_response_rationale_12",
-      "community": 5,
-      "norm_label": "r\"\"\"decodifica o body para um objeto."
+      "community": 3,
+      "norm_label": "r\"\"\"decodifica o body para um objeto.",
+      "id": "network_response_rationale_12"
     },
     {
       "label": "r\"\"\"Indica se a resposta foi bem sucedida (status code 2xx).",
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/_response.py",
       "source_location": "L17",
-      "id": "network_response_rationale_17",
-      "community": 18,
-      "norm_label": "r\"\"\"indica se a resposta foi bem sucedida (status code 2xx)."
+      "community": 21,
+      "norm_label": "r\"\"\"indica se a resposta foi bem sucedida (status code 2xx).",
+      "id": "network_response_rationale_17"
     },
     {
       "label": "__init__.py",
@@ -441,7 +441,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_core_network_init_py",
-      "community": 5,
+      "community": 3,
       "norm_label": "__init__.py"
     },
     {
@@ -450,7 +450,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/_request.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_core_network_request_py",
-      "community": 5,
+      "community": 3,
       "norm_label": "_request.py"
     },
     {
@@ -459,7 +459,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/_request.py",
       "source_location": "L9",
       "id": "network_request_httprequest",
-      "community": 5,
+      "community": 3,
       "norm_label": "httprequest"
     },
     {
@@ -467,9 +467,9 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/_request.py",
       "source_location": "L1",
-      "id": "network_request_rationale_1",
-      "community": 5,
-      "norm_label": "dados e parametros de uma request"
+      "community": 3,
+      "norm_label": "dados e parametros de uma request",
+      "id": "network_request_rationale_1"
     },
     {
       "label": "api.py",
@@ -477,7 +477,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/api.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_core_network_api_py",
-      "community": 5,
+      "community": 3,
       "norm_label": "api.py"
     },
     {
@@ -486,7 +486,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/api.py",
       "source_location": "L14",
       "id": "network_api_api",
-      "community": 5,
+      "community": 3,
       "norm_label": "api"
     },
     {
@@ -495,7 +495,7 @@
       "source_file": "",
       "source_location": "",
       "id": "abc",
-      "community": 5,
+      "community": 3,
       "norm_label": "abc"
     },
     {
@@ -504,7 +504,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/api.py",
       "source_location": "L15",
       "id": "network_api_api_init",
-      "community": 5,
+      "community": 3,
       "norm_label": ".__init__()"
     },
     {
@@ -513,7 +513,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/api.py",
       "source_location": "L21",
       "id": "network_api_path",
-      "community": 5,
+      "community": 3,
       "norm_label": "path()"
     },
     {
@@ -522,7 +522,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/api.py",
       "source_location": "L25",
       "id": "network_api_call",
-      "community": 3,
+      "community": 2,
       "norm_label": "call()"
     },
     {
@@ -531,7 +531,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/api.py",
       "source_location": "L33",
       "id": "network_api_entity",
-      "community": 5,
+      "community": 3,
       "norm_label": "entity()"
     },
     {
@@ -539,18 +539,18 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/api.py",
       "source_location": "L1",
-      "id": "network_api_rationale_1",
-      "community": 5,
-      "norm_label": "comunicacao alto nivel para chamadas de api"
+      "community": 3,
+      "norm_label": "comunicacao alto nivel para chamadas de api",
+      "id": "network_api_rationale_1"
     },
     {
       "label": "O tipo precisa aceitar **kwargs (dataclass ou similar).",
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/api.py",
       "source_location": "L34",
-      "id": "network_api_rationale_34",
-      "community": 19,
-      "norm_label": "o tipo precisa aceitar **kwargs (dataclass ou similar)."
+      "community": 22,
+      "norm_label": "o tipo precisa aceitar **kwargs (dataclass ou similar).",
+      "id": "network_api_rationale_34"
     },
     {
       "label": "_client.py",
@@ -558,7 +558,7 @@
       "source_file": "core/network/_client.py",
       "source_location": "L1",
       "id": "core_network_client_py",
-      "community": 5,
+      "community": 3,
       "norm_label": "_client.py"
     },
     {
@@ -567,7 +567,7 @@
       "source_file": "core/network/_client.py",
       "source_location": "L13",
       "id": "network_client_httpclientcontract",
-      "community": 5,
+      "community": 3,
       "norm_label": "httpclientcontract"
     },
     {
@@ -576,7 +576,7 @@
       "source_file": "",
       "source_location": "",
       "id": "protocol",
-      "community": 11,
+      "community": 10,
       "norm_label": "protocol"
     },
     {
@@ -585,7 +585,7 @@
       "source_file": "core/network/_client.py",
       "source_location": "L15",
       "id": "network_client_httpclientcontract_execute",
-      "community": 5,
+      "community": 3,
       "norm_label": ".execute()"
     },
     {
@@ -594,7 +594,7 @@
       "source_file": "core/network/_client.py",
       "source_location": "L20",
       "id": "network_client_localclient",
-      "community": 5,
+      "community": 3,
       "norm_label": "localclient"
     },
     {
@@ -603,7 +603,7 @@
       "source_file": "core/network/_client.py",
       "source_location": "L25",
       "id": "network_client_localclient_init",
-      "community": 5,
+      "community": 3,
       "norm_label": ".__init__()"
     },
     {
@@ -612,7 +612,7 @@
       "source_file": "core/network/_client.py",
       "source_location": "L28",
       "id": "network_client_localclient_execute",
-      "community": 5,
+      "community": 14,
       "norm_label": ".execute()"
     },
     {
@@ -620,27 +620,27 @@
       "file_type": "rationale",
       "source_file": "core/network/_client.py",
       "source_location": "L1",
-      "id": "network_client_rationale_1",
-      "community": 5,
-      "norm_label": "realiza as request de fato"
+      "community": 3,
+      "norm_label": "realiza as request de fato",
+      "id": "network_client_rationale_1"
     },
     {
       "label": "Contrato que qualquer client precisa cumprir.",
       "file_type": "rationale",
       "source_file": "core/network/_client.py",
       "source_location": "L14",
-      "id": "network_client_rationale_14",
-      "community": 5,
-      "norm_label": "contrato que qualquer client precisa cumprir."
+      "community": 3,
+      "norm_label": "contrato que qualquer client precisa cumprir.",
+      "id": "network_client_rationale_14"
     },
     {
       "label": "Roteia requests para o backend local (in-process).     Nenhuma rede envolvida \u2014",
       "file_type": "rationale",
       "source_file": "core/network/_client.py",
       "source_location": "L21",
-      "id": "network_client_rationale_21",
-      "community": 5,
-      "norm_label": "roteia requests para o backend local (in-process).     nenhuma rede envolvida \u2014"
+      "community": 3,
+      "norm_label": "roteia requests para o backend local (in-process).     nenhuma rede envolvida \u2014",
+      "id": "network_client_rationale_21"
     },
     {
       "label": "_observability.py",
@@ -648,7 +648,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/_observability.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_core_network_observability_py",
-      "community": 8,
+      "community": 14,
       "norm_label": "_observability.py"
     },
     {
@@ -657,7 +657,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/_observability.py",
       "source_location": "L12",
       "id": "network_observability_networkevent",
-      "community": 8,
+      "community": 14,
       "norm_label": "networkevent"
     },
     {
@@ -666,7 +666,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/_observability.py",
       "source_location": "L19",
       "id": "network_observability_track",
-      "community": 5,
+      "community": 14,
       "norm_label": "track()"
     },
     {
@@ -674,9 +674,9 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/_observability.py",
       "source_location": "L1",
-      "id": "network_observability_rationale_1",
-      "community": 8,
-      "norm_label": "observabilidade da camada de network."
+      "community": 14,
+      "norm_label": "observabilidade da camada de network.",
+      "id": "network_observability_rationale_1"
     },
     {
       "label": "_config.py",
@@ -684,7 +684,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/_config.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_core_network_config_py",
-      "community": 5,
+      "community": 3,
       "norm_label": "_config.py"
     },
     {
@@ -693,7 +693,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/_config.py",
       "source_location": "L15",
       "id": "network_config_configure",
-      "community": 5,
+      "community": 3,
       "norm_label": "configure()"
     },
     {
@@ -702,7 +702,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/_config.py",
       "source_location": "L20",
       "id": "network_config_override",
-      "community": 5,
+      "community": 3,
       "norm_label": "override()"
     },
     {
@@ -711,7 +711,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/_config.py",
       "source_location": "L25",
       "id": "network_config_clear_override",
-      "community": 5,
+      "community": 3,
       "norm_label": "clear_override()"
     },
     {
@@ -720,7 +720,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/_config.py",
       "source_location": "L30",
       "id": "network_config_get_client",
-      "community": 5,
+      "community": 3,
       "norm_label": "get_client()"
     },
     {
@@ -728,45 +728,45 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/_config.py",
       "source_location": "L1",
-      "id": "network_config_rationale_1",
-      "community": 5,
-      "norm_label": "configuracoes globais para uso do modulo"
+      "community": 3,
+      "norm_label": "configuracoes globais para uso do modulo",
+      "id": "network_config_rationale_1"
     },
     {
       "label": "Configura o client ativo.",
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/_config.py",
       "source_location": "L16",
-      "id": "network_config_rationale_16",
-      "community": 5,
-      "norm_label": "configura o client ativo."
+      "community": 3,
+      "norm_label": "configura o client ativo.",
+      "id": "network_config_rationale_16"
     },
     {
       "label": "Substitui o client \u2014 \u00fatil para testes ou WireMock.",
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/_config.py",
       "source_location": "L21",
-      "id": "network_config_rationale_21",
-      "community": 5,
-      "norm_label": "substitui o client \u2014 util para testes ou wiremock."
+      "community": 3,
+      "norm_label": "substitui o client \u2014 util para testes ou wiremock.",
+      "id": "network_config_rationale_21"
     },
     {
       "label": "Remove o override. Volta ao client padr\u00e3o.",
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/_config.py",
       "source_location": "L26",
-      "id": "network_config_rationale_26",
-      "community": 5,
-      "norm_label": "remove o override. volta ao client padrao."
+      "community": 3,
+      "norm_label": "remove o override. volta ao client padrao.",
+      "id": "network_config_rationale_26"
     },
     {
       "label": "Retorna o client ativo (override se existir, padr\u00e3o caso contr\u00e1rio).",
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/_config.py",
       "source_location": "L31",
-      "id": "network_config_rationale_31",
-      "community": 5,
-      "norm_label": "retorna o client ativo (override se existir, padrao caso contrario)."
+      "community": 3,
+      "norm_label": "retorna o client ativo (override se existir, padrao caso contrario).",
+      "id": "network_config_rationale_31"
     },
     {
       "label": "handler.py",
@@ -774,7 +774,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/storage/handler.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_core_storage_handler_py",
-      "community": 5,
+      "community": 3,
       "norm_label": "handler.py"
     },
     {
@@ -783,7 +783,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/storage/handler.py",
       "source_location": "L9",
       "id": "storage_handler_storagehandler",
-      "community": 5,
+      "community": 3,
       "norm_label": "storagehandler"
     },
     {
@@ -792,7 +792,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/storage/handler.py",
       "source_location": "L11",
       "id": "storage_handler_save",
-      "community": 5,
+      "community": 3,
       "norm_label": "save()"
     },
     {
@@ -801,7 +801,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/storage/handler.py",
       "source_location": "L14",
       "id": "storage_handler_retrieve",
-      "community": 5,
+      "community": 3,
       "norm_label": "retrieve()"
     },
     {
@@ -810,7 +810,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/storage/handler.py",
       "source_location": "L17",
       "id": "storage_handler_delete",
-      "community": 5,
+      "community": 3,
       "norm_label": "delete()"
     },
     {
@@ -819,7 +819,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/storage/handler.py",
       "source_location": "L20",
       "id": "storage_handler_clean_all",
-      "community": 5,
+      "community": 3,
       "norm_label": "clean_all()"
     },
     {
@@ -827,9 +827,9 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/storage/handler.py",
       "source_location": "L1",
-      "id": "storage_handler_rationale_1",
-      "community": 5,
-      "norm_label": "contrato base para todos os backends de armazenamento."
+      "community": 3,
+      "norm_label": "contrato base para todos os backends de armazenamento.",
+      "id": "storage_handler_rationale_1"
     },
     {
       "label": "security.py",
@@ -837,7 +837,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/storage/security.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_core_storage_security_py",
-      "community": 15,
+      "community": 18,
       "norm_label": "security.py"
     },
     {
@@ -846,7 +846,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/storage/security.py",
       "source_location": "L10",
       "id": "storage_security_securitystorage",
-      "community": 15,
+      "community": 18,
       "norm_label": "securitystorage"
     },
     {
@@ -855,7 +855,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/storage/security.py",
       "source_location": "L11",
       "id": "storage_security_securitystorage_init",
-      "community": 15,
+      "community": 18,
       "norm_label": ".__init__()"
     },
     {
@@ -864,7 +864,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/storage/security.py",
       "source_location": "L15",
       "id": "storage_security_securitystorage_save",
-      "community": 15,
+      "community": 18,
       "norm_label": ".save()"
     },
     {
@@ -873,7 +873,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/storage/security.py",
       "source_location": "L23",
       "id": "storage_security_securitystorage_retrieve",
-      "community": 15,
+      "community": 18,
       "norm_label": ".retrieve()"
     },
     {
@@ -882,7 +882,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/storage/security.py",
       "source_location": "L29",
       "id": "storage_security_securitystorage_delete",
-      "community": 15,
+      "community": 18,
       "norm_label": ".delete()"
     },
     {
@@ -891,7 +891,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/storage/security.py",
       "source_location": "L36",
       "id": "storage_security_securitystorage_clean_all",
-      "community": 15,
+      "community": 18,
       "norm_label": ".clean_all()"
     },
     {
@@ -900,7 +900,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/storage/security.py",
       "source_location": "L40",
       "id": "storage_security_securitystorage_path",
-      "community": 15,
+      "community": 18,
       "norm_label": "._path()"
     },
     {
@@ -908,9 +908,9 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/storage/security.py",
       "source_location": "L1",
-      "id": "storage_security_rationale_1",
-      "community": 15,
-      "norm_label": "backend de armazenamento seguro via arquivo protegido no diretorio do usuario."
+      "community": 18,
+      "norm_label": "backend de armazenamento seguro via arquivo protegido no diretorio do usuario.",
+      "id": "storage_security_rationale_1"
     },
     {
       "label": "cache.py",
@@ -918,7 +918,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/storage/cache.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_core_storage_cache_py",
-      "community": 3,
+      "community": 2,
       "norm_label": "cache.py"
     },
     {
@@ -927,7 +927,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/storage/cache.py",
       "source_location": "L10",
       "id": "storage_cache_cachestorage",
-      "community": 3,
+      "community": 2,
       "norm_label": "cachestorage"
     },
     {
@@ -936,7 +936,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/storage/cache.py",
       "source_location": "L11",
       "id": "storage_cache_cachestorage_init",
-      "community": 3,
+      "community": 2,
       "norm_label": ".__init__()"
     },
     {
@@ -945,7 +945,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/storage/cache.py",
       "source_location": "L15",
       "id": "storage_cache_cachestorage_save",
-      "community": 3,
+      "community": 2,
       "norm_label": ".save()"
     },
     {
@@ -954,7 +954,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/storage/cache.py",
       "source_location": "L21",
       "id": "storage_cache_cachestorage_retrieve",
-      "community": 3,
+      "community": 2,
       "norm_label": ".retrieve()"
     },
     {
@@ -963,7 +963,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/storage/cache.py",
       "source_location": "L30",
       "id": "storage_cache_cachestorage_delete",
-      "community": 3,
+      "community": 2,
       "norm_label": ".delete()"
     },
     {
@@ -972,7 +972,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/storage/cache.py",
       "source_location": "L37",
       "id": "storage_cache_cachestorage_clean_all",
-      "community": 3,
+      "community": 2,
       "norm_label": ".clean_all()"
     },
     {
@@ -981,7 +981,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/storage/cache.py",
       "source_location": "L41",
       "id": "storage_cache_cachestorage_path",
-      "community": 3,
+      "community": 2,
       "norm_label": "._path()"
     },
     {
@@ -989,9 +989,9 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/storage/cache.py",
       "source_location": "L1",
-      "id": "storage_cache_rationale_1",
-      "community": 3,
-      "norm_label": "backend de cache em arquivo json no diretorio do usuario."
+      "community": 2,
+      "norm_label": "backend de cache em arquivo json no diretorio do usuario.",
+      "id": "storage_cache_rationale_1"
     },
     {
       "label": "__init__.py",
@@ -999,7 +999,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/storage/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_core_storage_init_py",
-      "community": 20,
+      "community": 23,
       "norm_label": "__init__.py"
     },
     {
@@ -1008,7 +1008,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/error/models.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_core_error_models_py",
-      "community": 10,
+      "community": 9,
       "norm_label": "models.py"
     },
     {
@@ -1017,7 +1017,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/error/models.py",
       "source_location": "L7",
       "id": "error_models_errormodel",
-      "community": 10,
+      "community": 9,
       "norm_label": "errormodel"
     },
     {
@@ -1026,7 +1026,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/error/models.py",
       "source_location": "L12",
       "id": "error_models_errormodel_post_init",
-      "community": 10,
+      "community": 9,
       "norm_label": ".__post_init__()"
     },
     {
@@ -1035,7 +1035,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/error/models.py",
       "source_location": "L16",
       "id": "error_models_from_error",
-      "community": 10,
+      "community": 9,
       "norm_label": "from_error()"
     },
     {
@@ -1053,7 +1053,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/error/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_core_error_init_py",
-      "community": 10,
+      "community": 9,
       "norm_label": "__init__.py"
     },
     {
@@ -1062,7 +1062,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/error/errors.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_core_error_errors_py",
-      "community": 10,
+      "community": 9,
       "norm_label": "errors.py"
     },
     {
@@ -1071,7 +1071,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/error/errors.py",
       "source_location": "L8",
       "id": "error_errors_apperror",
-      "community": 10,
+      "community": 9,
       "norm_label": "apperror"
     },
     {
@@ -1080,7 +1080,7 @@
       "source_file": "",
       "source_location": "",
       "id": "namedtuple",
-      "community": 10,
+      "community": 9,
       "norm_label": "namedtuple"
     },
     {
@@ -1089,7 +1089,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/error/errors.py",
       "source_location": "L104",
       "id": "error_errors_certificado_ok",
-      "community": 10,
+      "community": 9,
       "norm_label": "certificado_ok()"
     },
     {
@@ -1098,7 +1098,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/error/errors.py",
       "source_location": "L113",
       "id": "error_errors_certificado_limpo",
-      "community": 10,
+      "community": 9,
       "norm_label": "certificado_limpo()"
     },
     {
@@ -1107,7 +1107,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/error/errors.py",
       "source_location": "L122",
       "id": "error_errors_planilha_conectada",
-      "community": 10,
+      "community": 9,
       "norm_label": "planilha_conectada()"
     },
     {
@@ -1116,7 +1116,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/error/errors.py",
       "source_location": "L131",
       "id": "error_errors_unexpected_error",
-      "community": 6,
+      "community": 5,
       "norm_label": "unexpected_error()"
     },
     {
@@ -1125,7 +1125,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/error/errors.py",
       "source_location": "L140",
       "id": "error_errors_http_error",
-      "community": 2,
+      "community": 1,
       "norm_label": "http_error()"
     },
     {
@@ -1134,7 +1134,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/error/errors.py",
       "source_location": "L149",
       "id": "error_errors_planilha_ok",
-      "community": 10,
+      "community": 9,
       "norm_label": "planilha_ok()"
     },
     {
@@ -1142,72 +1142,72 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/error/errors.py",
       "source_location": "L1",
-      "id": "error_errors_rationale_1",
-      "community": 10,
-      "norm_label": "codigos de erro da aplicacao com estrutura apperror."
+      "community": 9,
+      "norm_label": "codigos de erro da aplicacao com estrutura apperror.",
+      "id": "error_errors_rationale_1"
     },
     {
       "label": "Estrutura de uma mensagem de erro/info para exibi\u00e7\u00e3o no PopUp.",
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/error/errors.py",
       "source_location": "L9",
-      "id": "error_errors_rationale_9",
-      "community": 10,
-      "norm_label": "estrutura de uma mensagem de erro/info para exibicao no popup."
+      "community": 9,
+      "norm_label": "estrutura de uma mensagem de erro/info para exibicao no popup.",
+      "id": "error_errors_rationale_9"
     },
     {
       "label": "Confirma\u00e7\u00e3o de certificado configurado com sucesso.",
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/error/errors.py",
       "source_location": "L105",
-      "id": "error_errors_rationale_105",
-      "community": 10,
-      "norm_label": "confirmacao de certificado configurado com sucesso."
+      "community": 9,
+      "norm_label": "confirmacao de certificado configurado com sucesso.",
+      "id": "error_errors_rationale_105"
     },
     {
       "label": "Confirma\u00e7\u00e3o de credenciais removidas com sucesso.",
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/error/errors.py",
       "source_location": "L114",
-      "id": "error_errors_rationale_114",
-      "community": 10,
-      "norm_label": "confirmacao de credenciais removidas com sucesso."
+      "community": 9,
+      "norm_label": "confirmacao de credenciais removidas com sucesso.",
+      "id": "error_errors_rationale_114"
     },
     {
       "label": "Confirma\u00e7\u00e3o de planilha selecionada com sucesso.",
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/error/errors.py",
       "source_location": "L123",
-      "id": "error_errors_rationale_123",
-      "community": 10,
-      "norm_label": "confirmacao de planilha selecionada com sucesso."
+      "community": 9,
+      "norm_label": "confirmacao de planilha selecionada com sucesso.",
+      "id": "error_errors_rationale_123"
     },
     {
       "label": "Erro gen\u00e9rico para exce\u00e7\u00f5es n\u00e3o tratadas.",
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/error/errors.py",
       "source_location": "L132",
-      "id": "error_errors_rationale_132",
-      "community": 6,
-      "norm_label": "erro generico para excecoes nao tratadas."
+      "community": 5,
+      "norm_label": "erro generico para excecoes nao tratadas.",
+      "id": "error_errors_rationale_132"
     },
     {
       "label": "Erro HTTP sem body JSON \u2014 resposta de erro n\u00e3o estruturada do servidor.",
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/error/errors.py",
       "source_location": "L141",
-      "id": "error_errors_rationale_141",
-      "community": 2,
-      "norm_label": "erro http sem body json \u2014 resposta de erro nao estruturada do servidor."
+      "community": 1,
+      "norm_label": "erro http sem body json \u2014 resposta de erro nao estruturada do servidor.",
+      "id": "error_errors_rationale_141"
     },
     {
       "label": "Confirma\u00e7\u00e3o de leitura bem-sucedida da planilha.",
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/error/errors.py",
       "source_location": "L150",
-      "id": "error_errors_rationale_150",
-      "community": 10,
-      "norm_label": "confirmacao de leitura bem-sucedida da planilha."
+      "community": 9,
+      "norm_label": "confirmacao de leitura bem-sucedida da planilha.",
+      "id": "error_errors_rationale_150"
     },
     {
       "label": "coordinator.py",
@@ -1269,7 +1269,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/app/coordinator.py",
       "source_location": "L38",
       "id": "app_coordinator_appcoordinator_initialize",
-      "community": 3,
+      "community": 2,
       "norm_label": "._initialize()"
     },
     {
@@ -1287,7 +1287,7 @@
       "source_file": "app/handler.py",
       "source_location": "L1",
       "id": "app_handler_py",
-      "community": 6,
+      "community": 5,
       "norm_label": "handler.py"
     },
     {
@@ -1296,7 +1296,7 @@
       "source_file": "app/handler.py",
       "source_location": "L10",
       "id": "app_handler_menuhandler",
-      "community": 6,
+      "community": 5,
       "norm_label": "menuhandler"
     },
     {
@@ -1305,7 +1305,7 @@
       "source_file": "app/handler.py",
       "source_location": "L11",
       "id": "app_handler_menuhandler_init",
-      "community": 7,
+      "community": 8,
       "norm_label": ".__init__()"
     },
     {
@@ -1314,7 +1314,7 @@
       "source_file": "app/handler.py",
       "source_location": "L16",
       "id": "app_handler_menuhandler_setup_menus",
-      "community": 6,
+      "community": 5,
       "norm_label": ".setup_menus()"
     },
     {
@@ -1323,7 +1323,7 @@
       "source_file": "app/handler.py",
       "source_location": "L22",
       "id": "app_handler_menuhandler_create_features_menu",
-      "community": 6,
+      "community": 5,
       "norm_label": "._create_features_menu()"
     },
     {
@@ -1332,7 +1332,7 @@
       "source_file": "app/handler.py",
       "source_location": "L31",
       "id": "app_handler_menuhandler_create_help_menu",
-      "community": 6,
+      "community": 5,
       "norm_label": "._create_help_menu()"
     },
     {
@@ -1404,7 +1404,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/constants.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_design_system_constants_py",
-      "community": 21,
+      "community": 24,
       "norm_label": "constants.py"
     },
     {
@@ -1413,7 +1413,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_design_system_init_py",
-      "community": 22,
+      "community": 25,
       "norm_label": "__init__.py"
     },
     {
@@ -1422,7 +1422,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_design_system_components_init_py",
-      "community": 23,
+      "community": 26,
       "norm_label": "__init__.py"
     },
     {
@@ -1431,7 +1431,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/buttons/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_design_system_components_buttons_init_py",
-      "community": 8,
+      "community": 14,
       "norm_label": "__init__.py"
     },
     {
@@ -1440,7 +1440,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/buttons/button.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_design_system_components_buttons_button_py",
-      "community": 8,
+      "community": 14,
       "norm_label": "button.py"
     },
     {
@@ -1449,7 +1449,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/buttons/button.py",
       "source_location": "L9",
       "id": "buttons_button_dsbutton",
-      "community": 9,
+      "community": 6,
       "norm_label": "dsbutton"
     },
     {
@@ -1458,7 +1458,7 @@
       "source_file": "",
       "source_location": "",
       "id": "qpushbutton",
-      "community": 9,
+      "community": 6,
       "norm_label": "qpushbutton"
     },
     {
@@ -1467,7 +1467,7 @@
       "source_file": "",
       "source_location": "",
       "id": "dsloadinghandler",
-      "community": 9,
+      "community": 6,
       "norm_label": "dsloadinghandler"
     },
     {
@@ -1476,7 +1476,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/buttons/button.py",
       "source_location": "L11",
       "id": "buttons_button_dsbutton_init",
-      "community": 9,
+      "community": 6,
       "norm_label": ".__init__()"
     },
     {
@@ -1485,7 +1485,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/buttons/button.py",
       "source_location": "L22",
       "id": "buttons_button_dsbutton_update_state",
-      "community": 9,
+      "community": 6,
       "norm_label": ".update_state()"
     },
     {
@@ -1494,7 +1494,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/buttons/button.py",
       "source_location": "L40",
       "id": "buttons_button_dsbutton_on_loading_tick",
-      "community": 9,
+      "community": 6,
       "norm_label": "._on_loading_tick()"
     },
     {
@@ -1503,7 +1503,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/buttons/button.py",
       "source_location": "L45",
       "id": "buttons_button_dsbutton_mousepressevent",
-      "community": 9,
+      "community": 6,
       "norm_label": ".mousepressevent()"
     },
     {
@@ -1512,7 +1512,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/buttons/states.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_design_system_components_buttons_states_py",
-      "community": 8,
+      "community": 14,
       "norm_label": "states.py"
     },
     {
@@ -1521,7 +1521,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/buttons/states.py",
       "source_location": "L4",
       "id": "buttons_states_dsbuttonstate",
-      "community": 8,
+      "community": 14,
       "norm_label": "dsbuttonstate"
     },
     {
@@ -1530,7 +1530,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/chart/chart_type.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_design_system_components_chart_chart_type_py",
-      "community": 8,
+      "community": 16,
       "norm_label": "chart_type.py"
     },
     {
@@ -1539,7 +1539,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/chart/chart_type.py",
       "source_location": "L4",
       "id": "chart_chart_type_dscharttype",
-      "community": 8,
+      "community": 16,
       "norm_label": "dscharttype"
     },
     {
@@ -1548,7 +1548,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/chart/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_design_system_components_chart_init_py",
-      "community": 8,
+      "community": 16,
       "norm_label": "__init__.py"
     },
     {
@@ -1557,7 +1557,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/chart/chart_widget.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_design_system_components_chart_chart_widget_py",
-      "community": 8,
+      "community": 16,
       "norm_label": "chart_widget.py"
     },
     {
@@ -1566,7 +1566,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/chart/chart_widget.py",
       "source_location": "L18",
       "id": "chart_chart_widget_short_label",
-      "community": 8,
+      "community": 16,
       "norm_label": "_short_label()"
     },
     {
@@ -1575,7 +1575,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/chart/chart_widget.py",
       "source_location": "L26",
       "id": "chart_chart_widget_dschart",
-      "community": 8,
+      "community": 16,
       "norm_label": "dschart"
     },
     {
@@ -1593,7 +1593,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/chart/chart_widget.py",
       "source_location": "L27",
       "id": "chart_chart_widget_dschart_init",
-      "community": 8,
+      "community": 16,
       "norm_label": ".__init__()"
     },
     {
@@ -1602,7 +1602,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/chart/chart_widget.py",
       "source_location": "L64",
       "id": "chart_chart_widget_dschart_update_data",
-      "community": 8,
+      "community": 16,
       "norm_label": ".update_data()"
     },
     {
@@ -1611,7 +1611,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/chart/chart_widget.py",
       "source_location": "L69",
       "id": "chart_chart_widget_dschart_clear",
-      "community": 8,
+      "community": 16,
       "norm_label": ".clear()"
     },
     {
@@ -1620,7 +1620,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/chart/chart_widget.py",
       "source_location": "L76",
       "id": "chart_chart_widget_dschart_set_type",
-      "community": 8,
+      "community": 16,
       "norm_label": ".set_type()"
     },
     {
@@ -1629,7 +1629,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/chart/chart_widget.py",
       "source_location": "L81",
       "id": "chart_chart_widget_dschart_copy_to_clipboard",
-      "community": 8,
+      "community": 16,
       "norm_label": ".copy_to_clipboard()"
     },
     {
@@ -1638,7 +1638,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/chart/chart_widget.py",
       "source_location": "L91",
       "id": "chart_chart_widget_dschart_save_to_file",
-      "community": 8,
+      "community": 16,
       "norm_label": ".save_to_file()"
     },
     {
@@ -1647,7 +1647,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/chart/chart_widget.py",
       "source_location": "L101",
       "id": "chart_chart_widget_dschart_canvas_dims",
-      "community": 8,
+      "community": 16,
       "norm_label": "._canvas_dims()"
     },
     {
@@ -1656,7 +1656,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/chart/chart_widget.py",
       "source_location": "L109",
       "id": "chart_chart_widget_dschart_render",
-      "community": 8,
+      "community": 16,
       "norm_label": "._render()"
     },
     {
@@ -1665,7 +1665,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/chart/chart_widget.py",
       "source_location": "L115",
       "id": "chart_chart_widget_dschart_render_bar",
-      "community": 8,
+      "community": 16,
       "norm_label": "._render_bar()"
     },
     {
@@ -1674,7 +1674,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/chart/chart_widget.py",
       "source_location": "L153",
       "id": "chart_chart_widget_dschart_render_pie",
-      "community": 8,
+      "community": 16,
       "norm_label": "._render_pie()"
     },
     {
@@ -1683,7 +1683,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/chart/chart_widget.py",
       "source_location": "L196",
       "id": "chart_chart_widget_dschart_empty",
-      "community": 8,
+      "community": 16,
       "norm_label": "._empty()"
     },
     {
@@ -1691,9 +1691,9 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/chart/chart_widget.py",
       "source_location": "L1",
-      "id": "chart_chart_widget_rationale_1",
-      "community": 8,
-      "norm_label": "widget de grafico reutilizavel (barras ou pizza) usando seaborn + matplotlib."
+      "community": 16,
+      "norm_label": "widget de grafico reutilizavel (barras ou pizza) usando seaborn + matplotlib.",
+      "id": "chart_chart_widget_rationale_1"
     },
     {
       "label": "__init__.py",
@@ -1881,7 +1881,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/text_view/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_design_system_components_text_view_init_py",
-      "community": 9,
+      "community": 6,
       "norm_label": "__init__.py"
     },
     {
@@ -1890,7 +1890,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/text_view/text_view.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_design_system_components_text_view_text_view_py",
-      "community": 9,
+      "community": 6,
       "norm_label": "text_view.py"
     },
     {
@@ -1899,7 +1899,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/text_view/text_view.py",
       "source_location": "L5",
       "id": "text_view_text_view_dstextview",
-      "community": 9,
+      "community": 6,
       "norm_label": "dstextview"
     },
     {
@@ -1908,7 +1908,7 @@
       "source_file": "",
       "source_location": "",
       "id": "qtextbrowser",
-      "community": 9,
+      "community": 6,
       "norm_label": "qtextbrowser"
     },
     {
@@ -1917,7 +1917,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/text_view/text_view.py",
       "source_location": "L7",
       "id": "text_view_text_view_dstextview_init",
-      "community": 9,
+      "community": 6,
       "norm_label": ".__init__()"
     },
     {
@@ -1926,7 +1926,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/text_view/text_view.py",
       "source_location": "L11",
       "id": "text_view_text_view_dstextview_copy_to_clipboard",
-      "community": 9,
+      "community": 6,
       "norm_label": ".copy_to_clipboard()"
     },
     {
@@ -1935,7 +1935,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/containers/group_box.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_design_system_components_containers_group_box_py",
-      "community": 9,
+      "community": 6,
       "norm_label": "group_box.py"
     },
     {
@@ -1944,7 +1944,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/containers/group_box.py",
       "source_location": "L5",
       "id": "containers_group_box_dsgroupbox",
-      "community": 9,
+      "community": 6,
       "norm_label": "dsgroupbox"
     },
     {
@@ -1953,7 +1953,7 @@
       "source_file": "",
       "source_location": "",
       "id": "qgroupbox",
-      "community": 9,
+      "community": 6,
       "norm_label": "qgroupbox"
     },
     {
@@ -1962,7 +1962,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/containers/group_box.py",
       "source_location": "L7",
       "id": "containers_group_box_dsgroupbox_init",
-      "community": 9,
+      "community": 6,
       "norm_label": ".__init__()"
     },
     {
@@ -1971,7 +1971,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/containers/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_design_system_components_containers_init_py",
-      "community": 9,
+      "community": 6,
       "norm_label": "__init__.py"
     },
     {
@@ -1980,7 +1980,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/inputs/text_input.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_design_system_components_inputs_text_input_py",
-      "community": 7,
+      "community": 6,
       "norm_label": "text_input.py"
     },
     {
@@ -1989,7 +1989,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/inputs/text_input.py",
       "source_location": "L5",
       "id": "inputs_text_input_dstextinput",
-      "community": 7,
+      "community": 8,
       "norm_label": "dstextinput"
     },
     {
@@ -1998,7 +1998,7 @@
       "source_file": "",
       "source_location": "",
       "id": "qlineedit",
-      "community": 7,
+      "community": 8,
       "norm_label": "qlineedit"
     },
     {
@@ -2007,7 +2007,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/inputs/text_input.py",
       "source_location": "L7",
       "id": "inputs_text_input_dstextinput_init",
-      "community": 7,
+      "community": 8,
       "norm_label": ".__init__()"
     },
     {
@@ -2016,7 +2016,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/inputs/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_design_system_components_inputs_init_py",
-      "community": 7,
+      "community": 6,
       "norm_label": "__init__.py"
     },
     {
@@ -2025,7 +2025,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/inputs/date_input.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_design_system_components_inputs_date_input_py",
-      "community": 7,
+      "community": 6,
       "norm_label": "date_input.py"
     },
     {
@@ -2034,7 +2034,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/inputs/date_input.py",
       "source_location": "L5",
       "id": "inputs_date_input_dsdateinput",
-      "community": 7,
+      "community": 6,
       "norm_label": "dsdateinput"
     },
     {
@@ -2043,7 +2043,7 @@
       "source_file": "",
       "source_location": "",
       "id": "qdateedit",
-      "community": 7,
+      "community": 6,
       "norm_label": "qdateedit"
     },
     {
@@ -2052,7 +2052,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/inputs/date_input.py",
       "source_location": "L7",
       "id": "inputs_date_input_dsdateinput_init",
-      "community": 7,
+      "community": 6,
       "norm_label": ".__init__()"
     },
     {
@@ -2061,7 +2061,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/handlers/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_design_system_handlers_init_py",
-      "community": 9,
+      "community": 6,
       "norm_label": "__init__.py"
     },
     {
@@ -2070,7 +2070,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/handlers/loading_handler.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_design_system_handlers_loading_handler_py",
-      "community": 9,
+      "community": 6,
       "norm_label": "loading_handler.py"
     },
     {
@@ -2079,7 +2079,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/handlers/loading_handler.py",
       "source_location": "L4",
       "id": "handlers_loading_handler_dsloadinghandler",
-      "community": 9,
+      "community": 6,
       "norm_label": "dsloadinghandler"
     },
     {
@@ -2088,7 +2088,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/handlers/loading_handler.py",
       "source_location": "L9",
       "id": "handlers_loading_handler_dsloadinghandler_setup_loading",
-      "community": 9,
+      "community": 6,
       "norm_label": "._setup_loading()"
     },
     {
@@ -2097,7 +2097,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/handlers/loading_handler.py",
       "source_location": "L16",
       "id": "handlers_loading_handler_dsloadinghandler_start_loading",
-      "community": 9,
+      "community": 6,
       "norm_label": "._start_loading()"
     },
     {
@@ -2106,7 +2106,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/handlers/loading_handler.py",
       "source_location": "L20",
       "id": "handlers_loading_handler_dsloadinghandler_stop_loading",
-      "community": 9,
+      "community": 6,
       "norm_label": "._stop_loading()"
     },
     {
@@ -2115,7 +2115,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/handlers/loading_handler.py",
       "source_location": "L23",
       "id": "handlers_loading_handler_dsloadinghandler_loading_tick",
-      "community": 9,
+      "community": 6,
       "norm_label": "._loading_tick()"
     },
     {
@@ -2124,7 +2124,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/handlers/loading_handler.py",
       "source_location": "L28",
       "id": "handlers_loading_handler_dsloadinghandler_on_loading_tick",
-      "community": 9,
+      "community": 6,
       "norm_label": "._on_loading_tick()"
     },
     {
@@ -2132,27 +2132,27 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/handlers/loading_handler.py",
       "source_location": "L5",
-      "id": "handlers_loading_handler_rationale_5",
-      "community": 9,
-      "norm_label": "mixin que adiciona comportamento de loading animado a qualquer componente qobjec"
+      "community": 6,
+      "norm_label": "mixin que adiciona comportamento de loading animado a qualquer componente qobjec",
+      "id": "handlers_loading_handler_rationale_5"
     },
     {
       "label": "Deve ser chamado no __init__ do componente, ap\u00f3s o super().__init__().",
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/handlers/loading_handler.py",
       "source_location": "L10",
-      "id": "handlers_loading_handler_rationale_10",
-      "community": 9,
-      "norm_label": "deve ser chamado no __init__ do componente, apos o super().__init__()."
+      "community": 6,
+      "norm_label": "deve ser chamado no __init__ do componente, apos o super().__init__().",
+      "id": "handlers_loading_handler_rationale_10"
     },
     {
       "label": "Implementar no componente: o que fazer com cada frame do spinner.",
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/handlers/loading_handler.py",
       "source_location": "L29",
-      "id": "handlers_loading_handler_rationale_29",
-      "community": 9,
-      "norm_label": "implementar no componente: o que fazer com cada frame do spinner."
+      "community": 6,
+      "norm_label": "implementar no componente: o que fazer com cada frame do spinner.",
+      "id": "handlers_loading_handler_rationale_29"
     },
     {
       "label": "__init__.py",
@@ -2160,7 +2160,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_init_py",
-      "community": 3,
+      "community": 2,
       "norm_label": "__init__.py"
     },
     {
@@ -2169,7 +2169,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_init_py",
-      "community": 24,
+      "community": 27,
       "norm_label": "__init__.py"
     },
     {
@@ -2232,7 +2232,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/source/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_source_init_py",
-      "community": 25,
+      "community": 28,
       "norm_label": "__init__.py"
     },
     {
@@ -2286,7 +2286,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_sub_features_init_py",
-      "community": 26,
+      "community": 29,
       "norm_label": "__init__.py"
     },
     {
@@ -2295,7 +2295,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_sub_features_delivery_init_py",
-      "community": 27,
+      "community": 30,
       "norm_label": "__init__.py"
     },
     {
@@ -2304,7 +2304,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/data/mapper.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_sub_features_delivery_data_mapper_py",
-      "community": 2,
+      "community": 1,
       "norm_label": "mapper.py"
     },
     {
@@ -2313,7 +2313,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/data/mapper.py",
       "source_location": "L9",
       "id": "data_mapper_errormapper",
-      "community": 2,
+      "community": 1,
       "norm_label": "errormapper"
     },
     {
@@ -2322,7 +2322,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/data/mapper.py",
       "source_location": "L11",
       "id": "data_mapper_from_response",
-      "community": 2,
+      "community": 1,
       "norm_label": "from_response()"
     },
     {
@@ -2331,7 +2331,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/data/mapper.py",
       "source_location": "L24",
       "id": "data_mapper_deliveriesmapper",
-      "community": 2,
+      "community": 1,
       "norm_label": "deliveriesmapper"
     },
     {
@@ -2340,7 +2340,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/data/mapper.py",
       "source_location": "L36",
       "id": "data_mapper_paymentsmapper",
-      "community": 2,
+      "community": 1,
       "norm_label": "paymentsmapper"
     },
     {
@@ -2348,18 +2348,18 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/data/mapper.py",
       "source_location": "L1",
-      "id": "data_mapper_rationale_1",
-      "community": 2,
-      "norm_label": "mappers de httpresponse para domain models e de httpresponseerror para errormode"
+      "community": 1,
+      "norm_label": "mappers de httpresponse para domain models e de httpresponseerror para errormode",
+      "id": "data_mapper_rationale_1"
     },
     {
       "label": "L\u00ea o JSON do backend; cai em http_error gen\u00e9rico se o corpo n\u00e3o for JSON v\u00e1lido.",
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/data/mapper.py",
       "source_location": "L12",
-      "id": "data_mapper_rationale_12",
-      "community": 28,
-      "norm_label": "le o json do backend; cai em http_error generico se o corpo nao for json valido."
+      "community": 31,
+      "norm_label": "le o json do backend; cai em http_error generico se o corpo nao for json valido.",
+      "id": "data_mapper_rationale_12"
     },
     {
       "label": "__init__.py",
@@ -2367,7 +2367,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/data/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_sub_features_delivery_data_init_py",
-      "community": 3,
+      "community": 2,
       "norm_label": "__init__.py"
     },
     {
@@ -2376,7 +2376,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/data/apis.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_sub_features_delivery_data_apis_py",
-      "community": 3,
+      "community": 2,
       "norm_label": "apis.py"
     },
     {
@@ -2385,7 +2385,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/data/apis.py",
       "source_location": "L6",
       "id": "data_apis_deliveriesapi",
-      "community": 3,
+      "community": 2,
       "norm_label": "deliveriesapi"
     },
     {
@@ -2394,7 +2394,7 @@
       "source_file": "",
       "source_location": "",
       "id": "api",
-      "community": 3,
+      "community": 2,
       "norm_label": "api"
     },
     {
@@ -2403,7 +2403,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/data/apis.py",
       "source_location": "L13",
       "id": "data_apis_path",
-      "community": 3,
+      "community": 2,
       "norm_label": "path()"
     },
     {
@@ -2412,7 +2412,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/data/apis.py",
       "source_location": "L11",
       "id": "data_apis_deliveriesapi_for_date",
-      "community": 3,
+      "community": 2,
       "norm_label": ".for_date()"
     },
     {
@@ -2421,7 +2421,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/data/apis.py",
       "source_location": "L16",
       "id": "data_apis_paymentspendentapi",
-      "community": 3,
+      "community": 2,
       "norm_label": "paymentspendentapi"
     },
     {
@@ -2430,7 +2430,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/data/apis.py",
       "source_location": "L21",
       "id": "data_apis_paymentspendentapi_for_date",
-      "community": 3,
+      "community": 2,
       "norm_label": ".for_date()"
     },
     {
@@ -2438,9 +2438,9 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/data/apis.py",
       "source_location": "L1",
-      "id": "data_apis_rationale_1",
-      "community": 3,
-      "norm_label": "endpoints do backend consumidos pela feature auth."
+      "community": 2,
+      "norm_label": "endpoints do backend consumidos pela feature auth.",
+      "id": "data_apis_rationale_1"
     },
     {
       "label": "repository.py",
@@ -2448,7 +2448,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/data/repository.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_sub_features_delivery_data_repository_py",
-      "community": 3,
+      "community": 2,
       "norm_label": "repository.py"
     },
     {
@@ -2457,7 +2457,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/data/repository.py",
       "source_location": "L12",
       "id": "data_repository_ordersrepository",
-      "community": 3,
+      "community": 2,
       "norm_label": "ordersrepository"
     },
     {
@@ -2466,7 +2466,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/data/repository.py",
       "source_location": "L13",
       "id": "data_repository_ordersrepository_get_deliveries",
-      "community": 3,
+      "community": 2,
       "norm_label": ".get_deliveries()"
     },
     {
@@ -2475,7 +2475,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/data/repository.py",
       "source_location": "L23",
       "id": "data_repository_ordersrepository_get_pendent_payments",
-      "community": 3,
+      "community": 2,
       "norm_label": ".get_pendent_payments()"
     },
     {
@@ -2483,9 +2483,9 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/data/repository.py",
       "source_location": "L1",
-      "id": "data_repository_rationale_1",
-      "community": 3,
-      "norm_label": "repository da feature auth: gerencia storage seguro e chamadas ao backend."
+      "community": 2,
+      "norm_label": "repository da feature auth: gerencia storage seguro e chamadas ao backend.",
+      "id": "data_repository_rationale_1"
     },
     {
       "label": "use_case.py",
@@ -2493,7 +2493,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/domain/use_case.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_sub_features_delivery_domain_use_case_py",
-      "community": 2,
+      "community": 1,
       "norm_label": "use_case.py"
     },
     {
@@ -2502,7 +2502,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/domain/use_case.py",
       "source_location": "L9",
       "id": "domain_use_case_deliveryusecase",
-      "community": 2,
+      "community": 1,
       "norm_label": "deliveryusecase"
     },
     {
@@ -2511,7 +2511,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/domain/use_case.py",
       "source_location": "L10",
       "id": "domain_use_case_deliveryusecase_init",
-      "community": 2,
+      "community": 1,
       "norm_label": ".__init__()"
     },
     {
@@ -2520,7 +2520,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/domain/use_case.py",
       "source_location": "L13",
       "id": "domain_use_case_deliveryusecase_get_orders",
-      "community": 2,
+      "community": 1,
       "norm_label": ".get_orders()"
     },
     {
@@ -2528,18 +2528,18 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/domain/use_case.py",
       "source_location": "L1",
-      "id": "domain_use_case_rationale_1",
-      "community": 2,
-      "norm_label": "regra de negocios: validacao matematica de cpf."
+      "community": 1,
+      "norm_label": "regra de negocios: validacao matematica de cpf.",
+      "id": "domain_use_case_rationale_1"
     },
     {
       "label": "Busca deliveries e payments em paralelo e retorna o modelo consolidado.",
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/domain/use_case.py",
       "source_location": "L14",
-      "id": "domain_use_case_rationale_14",
-      "community": 2,
-      "norm_label": "busca deliveries e payments em paralelo e retorna o modelo consolidado."
+      "community": 1,
+      "norm_label": "busca deliveries e payments em paralelo e retorna o modelo consolidado.",
+      "id": "domain_use_case_rationale_14"
     },
     {
       "label": "signals.py",
@@ -2547,7 +2547,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/domain/signals.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_sub_features_delivery_domain_signals_py",
-      "community": 2,
+      "community": 1,
       "norm_label": "signals.py"
     },
     {
@@ -2556,7 +2556,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/domain/signals.py",
       "source_location": "L8",
       "id": "domain_signals_deliverysignals",
-      "community": 2,
+      "community": 1,
       "norm_label": "deliverysignals"
     },
     {
@@ -2564,9 +2564,9 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/domain/signals.py",
       "source_location": "L1",
-      "id": "domain_signals_rationale_1",
-      "community": 2,
-      "norm_label": "canal de comunicacao entre o viewmodel e o controller."
+      "community": 1,
+      "norm_label": "canal de comunicacao entre o viewmodel e o controller.",
+      "id": "domain_signals_rationale_1"
     },
     {
       "label": "models.py",
@@ -2574,7 +2574,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/domain/models.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_sub_features_delivery_domain_models_py",
-      "community": 2,
+      "community": 1,
       "norm_label": "models.py"
     },
     {
@@ -2583,7 +2583,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/domain/models.py",
       "source_location": "L7",
       "id": "domain_models_deliverycount",
-      "community": 2,
+      "community": 1,
       "norm_label": "deliverycount"
     },
     {
@@ -2592,7 +2592,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/domain/models.py",
       "source_location": "L13",
       "id": "domain_models_deliveriessummary",
-      "community": 2,
+      "community": 1,
       "norm_label": "deliveriessummary"
     },
     {
@@ -2601,7 +2601,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/domain/models.py",
       "source_location": "L20",
       "id": "domain_models_pendentorder",
-      "community": 2,
+      "community": 1,
       "norm_label": "pendentorder"
     },
     {
@@ -2610,7 +2610,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/domain/models.py",
       "source_location": "L29",
       "id": "domain_models_deliverymodel",
-      "community": 2,
+      "community": 1,
       "norm_label": "deliverymodel"
     },
     {
@@ -2627,9 +2627,9 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/domain/models.py",
       "source_location": "L1",
-      "id": "domain_models_rationale_1",
-      "community": 7,
-      "norm_label": "models utilizados no modulo"
+      "community": 8,
+      "norm_label": "models utilizados no modulo",
+      "id": "domain_models_rationale_1"
     },
     {
       "label": "events.py",
@@ -2637,7 +2637,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/domain/events.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_sub_features_delivery_domain_events_py",
-      "community": 8,
+      "community": 14,
       "norm_label": "events.py"
     },
     {
@@ -2646,7 +2646,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/domain/events.py",
       "source_location": "L6",
       "id": "domain_events_featureevents",
-      "community": 8,
+      "community": 14,
       "norm_label": "featureevents"
     },
     {
@@ -2654,17 +2654,17 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/domain/events.py",
       "source_location": "L1",
-      "id": "domain_events_rationale_1",
-      "community": 8,
-      "norm_label": "eventos de observabilidade da feature cpf validation."
+      "community": 14,
+      "norm_label": "eventos de observabilidade da feature cpf validation.",
+      "id": "domain_events_rationale_1"
     },
     {
       "label": "__init__.py",
       "file_type": "code",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/domain/__init__.py",
+      "source_file": "features/home/sub_features/delivery/domain/__init__.py",
       "source_location": "L1",
-      "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_sub_features_delivery_domain_init_py",
-      "community": 2,
+      "id": "features_home_sub_features_delivery_domain_init_py",
+      "community": 32,
       "norm_label": "__init__.py"
     },
     {
@@ -2673,7 +2673,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/presentation/controller.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_sub_features_delivery_presentation_controller_py",
-      "community": 2,
+      "community": 1,
       "norm_label": "controller.py"
     },
     {
@@ -2762,27 +2762,27 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/presentation/controller.py",
       "source_location": "L1",
-      "id": "presentation_controller_rationale_1",
-      "community": 2,
-      "norm_label": "controller da feature cpf validation: conecta signals da view ao viewmodel e tra"
+      "community": 1,
+      "norm_label": "controller da feature cpf validation: conecta signals da view ao viewmodel e tra",
+      "id": "presentation_controller_rationale_1"
     },
     {
       "label": "Inicia a consulta: trava a view, dispara o ViewModel e registra o timestamp para",
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/presentation/controller.py",
       "source_location": "L34",
-      "id": "presentation_controller_rationale_34",
       "community": 4,
-      "norm_label": "inicia a consulta: trava a view, dispara o viewmodel e registra o timestamp para"
+      "norm_label": "inicia a consulta: trava a view, dispara o viewmodel e registra o timestamp para",
+      "id": "presentation_controller_rationale_34"
     },
     {
       "label": "Recebe o resultado do ViewModel, atualiza a view e loga a dura\u00e7\u00e3o da consulta.",
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/presentation/controller.py",
       "source_location": "L58",
-      "id": "presentation_controller_rationale_58",
       "community": 4,
-      "norm_label": "recebe o resultado do viewmodel, atualiza a view e loga a duracao da consulta."
+      "norm_label": "recebe o resultado do viewmodel, atualiza a view e loga a duracao da consulta.",
+      "id": "presentation_controller_rationale_58"
     },
     {
       "label": "__init__.py",
@@ -2790,7 +2790,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/presentation/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_sub_features_delivery_presentation_init_py",
-      "community": 2,
+      "community": 1,
       "norm_label": "__init__.py"
     },
     {
@@ -2799,7 +2799,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/presentation/viewmodel.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_sub_features_delivery_presentation_viewmodel_py",
-      "community": 2,
+      "community": 1,
       "norm_label": "viewmodel.py"
     },
     {
@@ -2817,7 +2817,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/presentation/viewmodel.py",
       "source_location": "L13",
       "id": "presentation_viewmodel_deliveryviewmodel_init",
-      "community": 2,
+      "community": 1,
       "norm_label": ".__init__()"
     },
     {
@@ -2861,18 +2861,18 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/presentation/viewmodel.py",
       "source_location": "L1",
-      "id": "presentation_viewmodel_rationale_1",
-      "community": 2,
-      "norm_label": "viewmodel da feature cpf validation: executa o usecase e emite resultado via sig"
+      "community": 8,
+      "norm_label": "viewmodel da feature cpf validation: executa o usecase e emite resultado via sig",
+      "id": "presentation_viewmodel_rationale_1"
     },
     {
       "label": "Roda o UseCase, monta o ViewData e emite sucesso ou erro \u2014 sempre via signal par",
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/presentation/viewmodel.py",
       "source_location": "L21",
-      "id": "presentation_viewmodel_rationale_21",
       "community": 1,
-      "norm_label": "roda o usecase, monta o viewdata e emite sucesso ou erro \u2014 sempre via signal par"
+      "norm_label": "roda o usecase, monta o viewdata e emite sucesso ou erro \u2014 sempre via signal par",
+      "id": "presentation_viewmodel_rationale_21"
     },
     {
       "label": "view.py",
@@ -2880,7 +2880,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/presentation/view.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_sub_features_delivery_presentation_view_py",
-      "community": 2,
+      "community": 1,
       "norm_label": "view.py"
     },
     {
@@ -2889,7 +2889,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/presentation/view.py",
       "source_location": "L15",
       "id": "presentation_view_deliveryview",
-      "community": 9,
+      "community": 6,
       "norm_label": "deliveryview"
     },
     {
@@ -2898,7 +2898,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/presentation/view.py",
       "source_location": "L21",
       "id": "presentation_view_deliveryview_init",
-      "community": 9,
+      "community": 6,
       "norm_label": ".__init__()"
     },
     {
@@ -2907,7 +2907,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/presentation/view.py",
       "source_location": "L19",
       "id": "presentation_view_view_title",
-      "community": 2,
+      "community": 1,
       "norm_label": "view_title()"
     },
     {
@@ -2916,7 +2916,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/presentation/view.py",
       "source_location": "L31",
       "id": "presentation_view_deliveryview_setup_ui",
-      "community": 9,
+      "community": 6,
       "norm_label": "._setup_ui()"
     },
     {
@@ -2925,7 +2925,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/presentation/view.py",
       "source_location": "L36",
       "id": "presentation_view_deliveryview_setup_components",
-      "community": 9,
+      "community": 6,
       "norm_label": "._setup_components()"
     },
     {
@@ -2934,7 +2934,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/presentation/view.py",
       "source_location": "L61",
       "id": "presentation_view_deliveryview_setup_layout",
-      "community": 9,
+      "community": 6,
       "norm_label": "._setup_layout()"
     },
     {
@@ -2943,7 +2943,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/presentation/view.py",
       "source_location": "L84",
       "id": "presentation_view_deliveryview_update_buttons_state",
-      "community": 9,
+      "community": 6,
       "norm_label": "._update_buttons_state()"
     },
     {
@@ -2961,7 +2961,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/presentation/view.py",
       "source_location": "L94",
       "id": "presentation_view_deliveryview_update_data",
-      "community": 9,
+      "community": 6,
       "norm_label": ".update_data()"
     },
     {
@@ -2970,7 +2970,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/presentation/view.py",
       "source_location": "L100",
       "id": "presentation_view_deliveryview_activate_button_state",
-      "community": 9,
+      "community": 6,
       "norm_label": ".activate_button_state()"
     },
     {
@@ -2979,7 +2979,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/presentation/view.py",
       "source_location": "L103",
       "id": "presentation_view_deliveryview_clear_content",
-      "community": 9,
+      "community": 6,
       "norm_label": ".clear_content()"
     },
     {
@@ -2988,7 +2988,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/presentation/view.py",
       "source_location": "L108",
       "id": "presentation_view_deliveryview_prepare_to_fetch",
-      "community": 9,
+      "community": 6,
       "norm_label": ".prepare_to_fetch()"
     },
     {
@@ -2996,9 +2996,9 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/presentation/view.py",
       "source_location": "L1",
-      "id": "presentation_view_rationale_1",
-      "community": 2,
-      "norm_label": "view da feature cpf validation: dialog para validacao de cpf."
+      "community": 1,
+      "norm_label": "view da feature cpf validation: dialog para validacao de cpf.",
+      "id": "presentation_view_rationale_1"
     },
     {
       "label": "__init__.py",
@@ -3006,7 +3006,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_sub_features_summary_init_py",
-      "community": 2,
+      "community": 1,
       "norm_label": "__init__.py"
     },
     {
@@ -3015,7 +3015,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/data/mapper.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_sub_features_summary_data_mapper_py",
-      "community": 2,
+      "community": 1,
       "norm_label": "mapper.py"
     },
     {
@@ -3024,7 +3024,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/data/mapper.py",
       "source_location": "L23",
       "id": "data_mapper_orderssummarymapper",
-      "community": 2,
+      "community": 1,
       "norm_label": "orderssummarymapper"
     },
     {
@@ -3033,7 +3033,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/data/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_sub_features_summary_data_init_py",
-      "community": 2,
+      "community": 1,
       "norm_label": "__init__.py"
     },
     {
@@ -3042,7 +3042,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/data/apis.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_sub_features_summary_data_apis_py",
-      "community": 3,
+      "community": 2,
       "norm_label": "apis.py"
     },
     {
@@ -3051,7 +3051,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/data/apis.py",
       "source_location": "L6",
       "id": "data_apis_orderssummaryapi",
-      "community": 3,
+      "community": 2,
       "norm_label": "orderssummaryapi"
     },
     {
@@ -3060,7 +3060,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/data/apis.py",
       "source_location": "L11",
       "id": "data_apis_orderssummaryapi_for_period",
-      "community": 3,
+      "community": 2,
       "norm_label": ".for_period()"
     },
     {
@@ -3069,7 +3069,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/data/repository.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_sub_features_summary_data_repository_py",
-      "community": 2,
+      "community": 1,
       "norm_label": "repository.py"
     },
     {
@@ -3078,7 +3078,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/data/repository.py",
       "source_location": "L12",
       "id": "data_repository_summaryrepository",
-      "community": 2,
+      "community": 1,
       "norm_label": "summaryrepository"
     },
     {
@@ -3087,7 +3087,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/data/repository.py",
       "source_location": "L13",
       "id": "data_repository_summaryrepository_get_by_period",
-      "community": 3,
+      "community": 2,
       "norm_label": ".get_by_period()"
     },
     {
@@ -3096,7 +3096,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/domain/use_case.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_sub_features_summary_domain_use_case_py",
-      "community": 2,
+      "community": 1,
       "norm_label": "use_case.py"
     },
     {
@@ -3105,7 +3105,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/domain/use_case.py",
       "source_location": "L9",
       "id": "domain_use_case_summaryusecase",
-      "community": 2,
+      "community": 1,
       "norm_label": "summaryusecase"
     },
     {
@@ -3114,7 +3114,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/domain/use_case.py",
       "source_location": "L10",
       "id": "domain_use_case_summaryusecase_init",
-      "community": 2,
+      "community": 1,
       "norm_label": ".__init__()"
     },
     {
@@ -3123,7 +3123,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/domain/use_case.py",
       "source_location": "L13",
       "id": "domain_use_case_summaryusecase_get_summary",
-      "community": 2,
+      "community": 1,
       "norm_label": ".get_summary()"
     },
     {
@@ -3132,7 +3132,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/domain/use_case.py",
       "source_location": "L17",
       "id": "domain_use_case_summaryusecase_build_summary",
-      "community": 2,
+      "community": 1,
       "norm_label": "._build_summary()"
     },
     {
@@ -3141,7 +3141,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/domain/use_case.py",
       "source_location": "L51",
       "id": "domain_use_case_to_sorted_counts",
-      "community": 2,
+      "community": 1,
       "norm_label": "_to_sorted_counts()"
     },
     {
@@ -3150,7 +3150,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/domain/signals.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_sub_features_summary_domain_signals_py",
-      "community": 2,
+      "community": 1,
       "norm_label": "signals.py"
     },
     {
@@ -3159,7 +3159,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/domain/signals.py",
       "source_location": "L8",
       "id": "domain_signals_summarysignals",
-      "community": 2,
+      "community": 1,
       "norm_label": "summarysignals"
     },
     {
@@ -3168,7 +3168,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/domain/models.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_sub_features_summary_domain_models_py",
-      "community": 2,
+      "community": 1,
       "norm_label": "models.py"
     },
     {
@@ -3177,7 +3177,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/domain/models.py",
       "source_location": "L7",
       "id": "domain_models_productcount",
-      "community": 2,
+      "community": 1,
       "norm_label": "productcount"
     },
     {
@@ -3186,7 +3186,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/domain/models.py",
       "source_location": "L13",
       "id": "domain_models_orderdetail",
-      "community": 2,
+      "community": 1,
       "norm_label": "orderdetail"
     },
     {
@@ -3195,7 +3195,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/domain/models.py",
       "source_location": "L22",
       "id": "domain_models_daysummary",
-      "community": 2,
+      "community": 1,
       "norm_label": "daysummary"
     },
     {
@@ -3204,7 +3204,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/domain/models.py",
       "source_location": "L29",
       "id": "domain_models_productssummary",
-      "community": 2,
+      "community": 1,
       "norm_label": "productssummary"
     },
     {
@@ -3213,7 +3213,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/domain/models.py",
       "source_location": "L38",
       "id": "domain_models_productsviewdata",
-      "community": 2,
+      "community": 1,
       "norm_label": "productsviewdata"
     },
     {
@@ -3222,7 +3222,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/domain/events.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_sub_features_summary_domain_events_py",
-      "community": 8,
+      "community": 14,
       "norm_label": "events.py"
     },
     {
@@ -3231,7 +3231,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/domain/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_sub_features_summary_domain_init_py",
-      "community": 29,
+      "community": 33,
       "norm_label": "__init__.py"
     },
     {
@@ -3240,7 +3240,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/presentation/controller.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_sub_features_summary_presentation_controller_py",
-      "community": 2,
+      "community": 1,
       "norm_label": "controller.py"
     },
     {
@@ -3339,7 +3339,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/presentation/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_sub_features_summary_presentation_init_py",
-      "community": 30,
+      "community": 34,
       "norm_label": "__init__.py"
     },
     {
@@ -3348,7 +3348,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/presentation/viewmodel.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_sub_features_summary_presentation_viewmodel_py",
-      "community": 2,
+      "community": 1,
       "norm_label": "viewmodel.py"
     },
     {
@@ -3357,7 +3357,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/presentation/viewmodel.py",
       "source_location": "L14",
       "id": "presentation_viewmodel_summaryviewmodel",
-      "community": 2,
+      "community": 1,
       "norm_label": "summaryviewmodel"
     },
     {
@@ -3366,7 +3366,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/presentation/viewmodel.py",
       "source_location": "L15",
       "id": "presentation_viewmodel_summaryviewmodel_init",
-      "community": 2,
+      "community": 1,
       "norm_label": ".__init__()"
     },
     {
@@ -3375,7 +3375,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/presentation/viewmodel.py",
       "source_location": "L19",
       "id": "presentation_viewmodel_summaryviewmodel_on_generate",
-      "community": 2,
+      "community": 1,
       "norm_label": ".on_generate()"
     },
     {
@@ -3384,7 +3384,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/presentation/viewmodel.py",
       "source_location": "L22",
       "id": "presentation_viewmodel_summaryviewmodel_fetch",
-      "community": 2,
+      "community": 1,
       "norm_label": "._fetch()"
     },
     {
@@ -3393,7 +3393,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/presentation/viewmodel.py",
       "source_location": "L32",
       "id": "presentation_viewmodel_summaryviewmodel_build_view_data",
-      "community": 2,
+      "community": 1,
       "norm_label": "._build_view_data()"
     },
     {
@@ -3402,7 +3402,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/presentation/viewmodel.py",
       "source_location": "L38",
       "id": "presentation_viewmodel_summaryviewmodel_build_report",
-      "community": 2,
+      "community": 1,
       "norm_label": "._build_report()"
     },
     {
@@ -3411,7 +3411,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/presentation/viewmodel.py",
       "source_location": "L61",
       "id": "presentation_viewmodel_products_lines",
-      "community": 2,
+      "community": 1,
       "norm_label": "_products_lines()"
     },
     {
@@ -3420,7 +3420,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/presentation/view.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_sub_features_summary_presentation_view_py",
-      "community": 2,
+      "community": 1,
       "norm_label": "view.py"
     },
     {
@@ -3537,7 +3537,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_sheets_init_py",
-      "community": 31,
+      "community": 35,
       "norm_label": "__init__.py"
     },
     {
@@ -3546,7 +3546,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/data/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_sheets_data_init_py",
-      "community": 3,
+      "community": 2,
       "norm_label": "__init__.py"
     },
     {
@@ -3555,7 +3555,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/data/apis.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_sheets_data_apis_py",
-      "community": 3,
+      "community": 2,
       "norm_label": "apis.py"
     },
     {
@@ -3564,7 +3564,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/data/apis.py",
       "source_location": "L5",
       "id": "data_apis_selectsheetapi",
-      "community": 3,
+      "community": 2,
       "norm_label": "selectsheetapi"
     },
     {
@@ -3573,7 +3573,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/data/apis.py",
       "source_location": "L6",
       "id": "data_apis_selectsheetapi_init",
-      "community": 3,
+      "community": 2,
       "norm_label": ".__init__()"
     },
     {
@@ -3582,7 +3582,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/data/apis.py",
       "source_location": "L16",
       "id": "data_apis_removesheetapi",
-      "community": 3,
+      "community": 2,
       "norm_label": "removesheetapi"
     },
     {
@@ -3591,7 +3591,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/data/apis.py",
       "source_location": "L17",
       "id": "data_apis_removesheetapi_init",
-      "community": 3,
+      "community": 2,
       "norm_label": ".__init__()"
     },
     {
@@ -3600,7 +3600,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/data/repository.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_sheets_data_repository_py",
-      "community": 3,
+      "community": 2,
       "norm_label": "repository.py"
     },
     {
@@ -3609,7 +3609,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/data/repository.py",
       "source_location": "L17",
       "id": "data_repository_extract_sheet_id",
-      "community": 3,
+      "community": 2,
       "norm_label": "_extract_sheet_id()"
     },
     {
@@ -3618,7 +3618,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/data/repository.py",
       "source_location": "L24",
       "id": "data_repository_sheetsrepository",
-      "community": 3,
+      "community": 2,
       "norm_label": "sheetsrepository"
     },
     {
@@ -3627,7 +3627,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/data/repository.py",
       "source_location": "L25",
       "id": "data_repository_sheetsrepository_connect",
-      "community": 3,
+      "community": 2,
       "norm_label": ".connect()"
     },
     {
@@ -3636,7 +3636,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/data/repository.py",
       "source_location": "L41",
       "id": "data_repository_sheetsrepository_select",
-      "community": 3,
+      "community": 2,
       "norm_label": ".select()"
     },
     {
@@ -3645,7 +3645,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/data/repository.py",
       "source_location": "L47",
       "id": "data_repository_sheetsrepository_find_by_link",
-      "community": 3,
+      "community": 2,
       "norm_label": ".find_by_link()"
     },
     {
@@ -3654,7 +3654,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/data/repository.py",
       "source_location": "L55",
       "id": "data_repository_sheetsrepository_load_all",
-      "community": 3,
+      "community": 2,
       "norm_label": ".load_all()"
     },
     {
@@ -3663,7 +3663,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/data/repository.py",
       "source_location": "L58",
       "id": "data_repository_sheetsrepository_remove",
-      "community": 3,
+      "community": 2,
       "norm_label": ".remove()"
     },
     {
@@ -3672,7 +3672,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/data/repository.py",
       "source_location": "L68",
       "id": "data_repository_sheetsrepository_update_name",
-      "community": 3,
+      "community": 2,
       "norm_label": ".update_name()"
     },
     {
@@ -3681,7 +3681,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/data/repository.py",
       "source_location": "L77",
       "id": "data_repository_sheetsrepository_last_sheet_id_from_cache",
-      "community": 3,
+      "community": 2,
       "norm_label": ".last_sheet_id_from_cache()"
     },
     {
@@ -3690,7 +3690,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/data/repository.py",
       "source_location": "L82",
       "id": "data_repository_sheetsrepository_load_raw",
-      "community": 3,
+      "community": 2,
       "norm_label": "._load_raw()"
     },
     {
@@ -3698,9 +3698,9 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/data/repository.py",
       "source_location": "L78",
-      "id": "data_repository_rationale_78",
-      "community": 3,
-      "norm_label": "retorna o sheet_id da ultima planilha salva em cache, sem http."
+      "community": 2,
+      "norm_label": "retorna o sheet_id da ultima planilha salva em cache, sem http.",
+      "id": "data_repository_rationale_78"
     },
     {
       "label": "use_case.py",
@@ -3708,7 +3708,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/domain/use_case.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_sheets_domain_use_case_py",
-      "community": 6,
+      "community": 5,
       "norm_label": "use_case.py"
     },
     {
@@ -3717,7 +3717,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/domain/use_case.py",
       "source_location": "L7",
       "id": "domain_use_case_sheetsusecase",
-      "community": 6,
+      "community": 5,
       "norm_label": "sheetsusecase"
     },
     {
@@ -3726,7 +3726,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/domain/use_case.py",
       "source_location": "L8",
       "id": "domain_use_case_sheetsusecase_init",
-      "community": 6,
+      "community": 5,
       "norm_label": ".__init__()"
     },
     {
@@ -3735,7 +3735,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/domain/use_case.py",
       "source_location": "L11",
       "id": "domain_use_case_sheetsusecase_connect",
-      "community": 6,
+      "community": 5,
       "norm_label": ".connect()"
     },
     {
@@ -3744,7 +3744,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/domain/use_case.py",
       "source_location": "L17",
       "id": "domain_use_case_sheetsusecase_select",
-      "community": 6,
+      "community": 5,
       "norm_label": ".select()"
     },
     {
@@ -3753,7 +3753,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/domain/use_case.py",
       "source_location": "L22",
       "id": "domain_use_case_sheetsusecase_load_all",
-      "community": 6,
+      "community": 5,
       "norm_label": ".load_all()"
     },
     {
@@ -3762,7 +3762,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/domain/use_case.py",
       "source_location": "L25",
       "id": "domain_use_case_sheetsusecase_find_by_link",
-      "community": 6,
+      "community": 5,
       "norm_label": ".find_by_link()"
     },
     {
@@ -3771,7 +3771,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/domain/use_case.py",
       "source_location": "L28",
       "id": "domain_use_case_sheetsusecase_remove",
-      "community": 6,
+      "community": 5,
       "norm_label": ".remove()"
     },
     {
@@ -3780,25 +3780,25 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/domain/use_case.py",
       "source_location": "L35",
       "id": "domain_use_case_sheetsusecase_update_name",
-      "community": 6,
+      "community": 5,
       "norm_label": ".update_name()"
     },
     {
       "label": "signals.py",
       "file_type": "code",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/domain/signals.py",
+      "source_file": "features/sheets/domain/signals.py",
       "source_location": "L1",
-      "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_sheets_domain_signals_py",
-      "community": 2,
+      "id": "features_sheets_domain_signals_py",
+      "community": 1,
       "norm_label": "signals.py"
     },
     {
       "label": "SheetsSignals",
       "file_type": "code",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/domain/signals.py",
+      "source_file": "features/sheets/domain/signals.py",
       "source_location": "L6",
       "id": "domain_signals_sheetssignals",
-      "community": 2,
+      "community": 1,
       "norm_label": "sheetssignals"
     },
     {
@@ -3807,7 +3807,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/domain/models.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_sheets_domain_models_py",
-      "community": 6,
+      "community": 5,
       "norm_label": "models.py"
     },
     {
@@ -3816,7 +3816,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/domain/models.py",
       "source_location": "L5",
       "id": "domain_models_sheetmodel",
-      "community": 3,
+      "community": 2,
       "norm_label": "sheetmodel"
     },
     {
@@ -3825,7 +3825,7 @@
       "source_file": "features/sheets/domain/events.py",
       "source_location": "L1",
       "id": "features_sheets_domain_events_py",
-      "community": 8,
+      "community": 14,
       "norm_label": "events.py"
     },
     {
@@ -3834,7 +3834,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/domain/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_sheets_domain_init_py",
-      "community": 32,
+      "community": 36,
       "norm_label": "__init__.py"
     },
     {
@@ -3843,7 +3843,7 @@
       "source_file": "features/sheets/presentation/controller.py",
       "source_location": "L1",
       "id": "features_sheets_presentation_controller_py",
-      "community": 6,
+      "community": 1,
       "norm_label": "controller.py"
     },
     {
@@ -3852,7 +3852,7 @@
       "source_file": "features/sheets/presentation/controller.py",
       "source_location": "L17",
       "id": "presentation_controller_sheetscontroller",
-      "community": 6,
+      "community": 5,
       "norm_label": "sheetscontroller"
     },
     {
@@ -3861,7 +3861,7 @@
       "source_file": "features/sheets/presentation/controller.py",
       "source_location": "L18",
       "id": "presentation_controller_sheetscontroller_init",
-      "community": 6,
+      "community": 5,
       "norm_label": ".__init__()"
     },
     {
@@ -3870,7 +3870,7 @@
       "source_file": "features/sheets/presentation/controller.py",
       "source_location": "L25",
       "id": "presentation_controller_sheetscontroller_setup_actions",
-      "community": 6,
+      "community": 5,
       "norm_label": "._setup_actions()"
     },
     {
@@ -3879,7 +3879,7 @@
       "source_file": "features/sheets/presentation/controller.py",
       "source_location": "L36",
       "id": "presentation_controller_sheetscontroller_load_saved_sheets",
-      "community": 6,
+      "community": 5,
       "norm_label": "._load_saved_sheets()"
     },
     {
@@ -3888,7 +3888,7 @@
       "source_file": "features/sheets/presentation/controller.py",
       "source_location": "L40",
       "id": "presentation_controller_sheetscontroller_on_connect",
-      "community": 6,
+      "community": 5,
       "norm_label": "._on_connect()"
     },
     {
@@ -3897,7 +3897,7 @@
       "source_file": "features/sheets/presentation/controller.py",
       "source_location": "L54",
       "id": "presentation_controller_sheetscontroller_update_sheet_name_if_needed",
-      "community": 6,
+      "community": 5,
       "norm_label": "._update_sheet_name_if_needed()"
     },
     {
@@ -3906,7 +3906,7 @@
       "source_file": "features/sheets/presentation/controller.py",
       "source_location": "L60",
       "id": "presentation_controller_sheetscontroller_show_existing_dialog",
-      "community": 6,
+      "community": 5,
       "norm_label": "._show_existing_dialog()"
     },
     {
@@ -3915,7 +3915,7 @@
       "source_file": "features/sheets/presentation/controller.py",
       "source_location": "L81",
       "id": "presentation_controller_sheetscontroller_on_remove_requested",
-      "community": 11,
+      "community": 10,
       "norm_label": "._on_remove_requested()"
     },
     {
@@ -3924,7 +3924,7 @@
       "source_file": "features/sheets/presentation/controller.py",
       "source_location": "L92",
       "id": "presentation_controller_sheetscontroller_on_init_finished",
-      "community": 6,
+      "community": 5,
       "norm_label": "._on_init_finished()"
     },
     {
@@ -3933,7 +3933,7 @@
       "source_file": "features/sheets/presentation/controller.py",
       "source_location": "L96",
       "id": "presentation_controller_sheetscontroller_on_select",
-      "community": 11,
+      "community": 10,
       "norm_label": "._on_select()"
     },
     {
@@ -3942,7 +3942,7 @@
       "source_file": "features/sheets/presentation/controller.py",
       "source_location": "L99",
       "id": "presentation_controller_sheetscontroller_on_renamed",
-      "community": 6,
+      "community": 5,
       "norm_label": "._on_renamed()"
     },
     {
@@ -3951,7 +3951,7 @@
       "source_file": "features/sheets/presentation/controller.py",
       "source_location": "L103",
       "id": "presentation_controller_sheetscontroller_on_removed",
-      "community": 11,
+      "community": 10,
       "norm_label": "._on_removed()"
     },
     {
@@ -3960,7 +3960,7 @@
       "source_file": "features/sheets/presentation/controller.py",
       "source_location": "L107",
       "id": "presentation_controller_sheetscontroller_on_connected",
-      "community": 6,
+      "community": 5,
       "norm_label": "._on_connected()"
     },
     {
@@ -3969,7 +3969,7 @@
       "source_file": "features/sheets/presentation/controller.py",
       "source_location": "L112",
       "id": "presentation_controller_sheetscontroller_on_selected",
-      "community": 6,
+      "community": 5,
       "norm_label": "._on_selected()"
     },
     {
@@ -3987,7 +3987,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/presentation/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_sheets_presentation_init_py",
-      "community": 33,
+      "community": 37,
       "norm_label": "__init__.py"
     },
     {
@@ -3996,7 +3996,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/presentation/viewmodel.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_sheets_presentation_viewmodel_py",
-      "community": 6,
+      "community": 5,
       "norm_label": "viewmodel.py"
     },
     {
@@ -4005,7 +4005,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/presentation/viewmodel.py",
       "source_location": "L11",
       "id": "presentation_viewmodel_sheetsviewmodel",
-      "community": 6,
+      "community": 5,
       "norm_label": "sheetsviewmodel"
     },
     {
@@ -4014,7 +4014,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/presentation/viewmodel.py",
       "source_location": "L12",
       "id": "presentation_viewmodel_sheetsviewmodel_init",
-      "community": 6,
+      "community": 5,
       "norm_label": ".__init__()"
     },
     {
@@ -4023,7 +4023,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/presentation/viewmodel.py",
       "source_location": "L18",
       "id": "presentation_viewmodel_sheetsviewmodel_load_all",
-      "community": 6,
+      "community": 5,
       "norm_label": ".load_all()"
     },
     {
@@ -4032,7 +4032,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/presentation/viewmodel.py",
       "source_location": "L21",
       "id": "presentation_viewmodel_sheetsviewmodel_find_by_link",
-      "community": 6,
+      "community": 5,
       "norm_label": ".find_by_link()"
     },
     {
@@ -4041,7 +4041,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/presentation/viewmodel.py",
       "source_location": "L26",
       "id": "presentation_viewmodel_sheetsviewmodel_update_name",
-      "community": 6,
+      "community": 5,
       "norm_label": ".update_name()"
     },
     {
@@ -4050,7 +4050,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/presentation/viewmodel.py",
       "source_location": "L38",
       "id": "presentation_viewmodel_sheetsviewmodel_connect",
-      "community": 6,
+      "community": 5,
       "norm_label": ".connect()"
     },
     {
@@ -4059,7 +4059,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/presentation/viewmodel.py",
       "source_location": "L49",
       "id": "presentation_viewmodel_sheetsviewmodel_select",
-      "community": 6,
+      "community": 5,
       "norm_label": ".select()"
     },
     {
@@ -4068,7 +4068,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/presentation/viewmodel.py",
       "source_location": "L59",
       "id": "presentation_viewmodel_sheetsviewmodel_remove",
-      "community": 6,
+      "community": 5,
       "norm_label": ".remove()"
     },
     {
@@ -4077,7 +4077,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/presentation/view/sheet_create_view.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_sheets_presentation_view_sheet_create_view_py",
-      "community": 7,
+      "community": 8,
       "norm_label": "sheet_create_view.py"
     },
     {
@@ -4086,7 +4086,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/presentation/view/sheet_create_view.py",
       "source_location": "L8",
       "id": "view_sheet_create_view_sheetcreateview",
-      "community": 7,
+      "community": 8,
       "norm_label": "sheetcreateview"
     },
     {
@@ -4095,7 +4095,7 @@
       "source_file": "",
       "source_location": "",
       "id": "qdialog",
-      "community": 7,
+      "community": 8,
       "norm_label": "qdialog"
     },
     {
@@ -4104,7 +4104,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/presentation/view/sheet_create_view.py",
       "source_location": "L9",
       "id": "view_sheet_create_view_sheetcreateview_init",
-      "community": 7,
+      "community": 8,
       "norm_label": ".__init__()"
     },
     {
@@ -4113,7 +4113,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/presentation/view/sheet_create_view.py",
       "source_location": "L14",
       "id": "view_sheet_create_view_link",
-      "community": 7,
+      "community": 8,
       "norm_label": "link()"
     },
     {
@@ -4122,7 +4122,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/presentation/view/sheet_create_view.py",
       "source_location": "L18",
       "id": "view_sheet_create_view_name",
-      "community": 7,
+      "community": 8,
       "norm_label": "name()"
     },
     {
@@ -4131,7 +4131,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/presentation/view/sheet_create_view.py",
       "source_location": "L21",
       "id": "view_sheet_create_view_sheetcreateview_setup_ui",
-      "community": 7,
+      "community": 8,
       "norm_label": "._setup_ui()"
     },
     {
@@ -4140,7 +4140,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/presentation/view/sheet_create_view.py",
       "source_location": "L25",
       "id": "view_sheet_create_view_sheetcreateview_setup_components",
-      "community": 7,
+      "community": 8,
       "norm_label": "._setup_components()"
     },
     {
@@ -4149,7 +4149,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/presentation/view/sheet_create_view.py",
       "source_location": "L41",
       "id": "view_sheet_create_view_sheetcreateview_setup_layout",
-      "community": 7,
+      "community": 8,
       "norm_label": "._setup_layout()"
     },
     {
@@ -4158,7 +4158,7 @@
       "source_file": "features/sheets/presentation/view/sheets_menu_view.py",
       "source_location": "L1",
       "id": "features_sheets_presentation_view_sheets_menu_view_py",
-      "community": 6,
+      "community": 5,
       "norm_label": "sheets_menu_view.py"
     },
     {
@@ -4167,7 +4167,7 @@
       "source_file": "features/sheets/presentation/view/sheets_menu_view.py",
       "source_location": "L8",
       "id": "view_sheets_menu_view_sheetsmenuview",
-      "community": 6,
+      "community": 5,
       "norm_label": "sheetsmenuview"
     },
     {
@@ -4176,7 +4176,7 @@
       "source_file": "",
       "source_location": "",
       "id": "qmenu",
-      "community": 6,
+      "community": 5,
       "norm_label": "qmenu"
     },
     {
@@ -4185,7 +4185,7 @@
       "source_file": "features/sheets/presentation/view/sheets_menu_view.py",
       "source_location": "L14",
       "id": "view_sheets_menu_view_sheetsmenuview_init",
-      "community": 6,
+      "community": 5,
       "norm_label": ".__init__()"
     },
     {
@@ -4194,7 +4194,7 @@
       "source_file": "features/sheets/presentation/view/sheets_menu_view.py",
       "source_location": "L19",
       "id": "view_sheets_menu_view_view_title",
-      "community": 6,
+      "community": 5,
       "norm_label": "view_title()"
     },
     {
@@ -4203,7 +4203,7 @@
       "source_file": "features/sheets/presentation/view/sheets_menu_view.py",
       "source_location": "L22",
       "id": "view_sheets_menu_view_sheetsmenuview_setup_ui",
-      "community": 6,
+      "community": 5,
       "norm_label": "._setup_ui()"
     },
     {
@@ -4212,7 +4212,7 @@
       "source_file": "features/sheets/presentation/view/sheets_menu_view.py",
       "source_location": "L26",
       "id": "view_sheets_menu_view_sheetsmenuview_setup_components",
-      "community": 6,
+      "community": 5,
       "norm_label": "._setup_components()"
     },
     {
@@ -4221,7 +4221,7 @@
       "source_file": "features/sheets/presentation/view/sheets_menu_view.py",
       "source_location": "L37",
       "id": "view_sheets_menu_view_sheetsmenuview_setup_layout",
-      "community": 6,
+      "community": 5,
       "norm_label": "._setup_layout()"
     },
     {
@@ -4230,7 +4230,7 @@
       "source_file": "features/sheets/presentation/view/sheets_menu_view.py",
       "source_location": "L41",
       "id": "view_sheets_menu_view_sheetsmenuview_add_or_update_sheet",
-      "community": 6,
+      "community": 5,
       "norm_label": ".add_or_update_sheet()"
     },
     {
@@ -4239,7 +4239,7 @@
       "source_file": "features/sheets/presentation/view/sheets_menu_view.py",
       "source_location": "L69",
       "id": "view_sheets_menu_view_sheetsmenuview_set_active",
-      "community": 6,
+      "community": 5,
       "norm_label": ".set_active()"
     },
     {
@@ -4248,7 +4248,7 @@
       "source_file": "features/sheets/presentation/view/sheets_menu_view.py",
       "source_location": "L76",
       "id": "view_sheets_menu_view_sheetsmenuview_remove_sheet",
-      "community": 6,
+      "community": 5,
       "norm_label": ".remove_sheet()"
     },
     {
@@ -4257,7 +4257,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/presentation/view/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_sheets_presentation_view_init_py",
-      "community": 7,
+      "community": 8,
       "norm_label": "__init__.py"
     },
     {
@@ -4266,7 +4266,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_auth_init_py",
-      "community": 34,
+      "community": 38,
       "norm_label": "__init__.py"
     },
     {
@@ -4275,7 +4275,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/data/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_auth_data_init_py",
-      "community": 3,
+      "community": 2,
       "norm_label": "__init__.py"
     },
     {
@@ -4284,7 +4284,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/data/apis.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_auth_data_apis_py",
-      "community": 3,
+      "community": 2,
       "norm_label": "apis.py"
     },
     {
@@ -4293,7 +4293,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/data/apis.py",
       "source_location": "L7",
       "id": "data_apis_connectauthapi",
-      "community": 3,
+      "community": 2,
       "norm_label": "connectauthapi"
     },
     {
@@ -4302,7 +4302,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/data/apis.py",
       "source_location": "L8",
       "id": "data_apis_connectauthapi_init",
-      "community": 3,
+      "community": 2,
       "norm_label": ".__init__()"
     },
     {
@@ -4311,7 +4311,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/data/apis.py",
       "source_location": "L16",
       "id": "data_apis_connectauthapi_with_credentials",
-      "community": 3,
+      "community": 2,
       "norm_label": ".with_credentials()"
     },
     {
@@ -4320,7 +4320,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/data/apis.py",
       "source_location": "L21",
       "id": "data_apis_disconnectauthapi",
-      "community": 3,
+      "community": 2,
       "norm_label": "disconnectauthapi"
     },
     {
@@ -4329,7 +4329,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/data/apis.py",
       "source_location": "L22",
       "id": "data_apis_disconnectauthapi_init",
-      "community": 3,
+      "community": 2,
       "norm_label": ".__init__()"
     },
     {
@@ -4338,7 +4338,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/data/repository.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_auth_data_repository_py",
-      "community": 3,
+      "community": 2,
       "norm_label": "repository.py"
     },
     {
@@ -4347,7 +4347,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/data/repository.py",
       "source_location": "L14",
       "id": "data_repository_authrepository",
-      "community": 3,
+      "community": 2,
       "norm_label": "authrepository"
     },
     {
@@ -4356,7 +4356,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/data/repository.py",
       "source_location": "L15",
       "id": "data_repository_authrepository_configure",
-      "community": 3,
+      "community": 2,
       "norm_label": ".configure()"
     },
     {
@@ -4365,7 +4365,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/data/repository.py",
       "source_location": "L22",
       "id": "data_repository_authrepository_pre_login",
-      "community": 3,
+      "community": 2,
       "norm_label": ".pre_login()"
     },
     {
@@ -4374,7 +4374,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/data/repository.py",
       "source_location": "L29",
       "id": "data_repository_authrepository_read_credentials",
-      "community": 3,
+      "community": 2,
       "norm_label": ".read_credentials()"
     },
     {
@@ -4383,7 +4383,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/data/repository.py",
       "source_location": "L34",
       "id": "data_repository_authrepository_clear",
-      "community": 3,
+      "community": 2,
       "norm_label": ".clear()"
     },
     {
@@ -4391,36 +4391,36 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/data/repository.py",
       "source_location": "L16",
-      "id": "data_repository_rationale_16",
-      "community": 3,
-      "norm_label": "le o json do caminho, envia ao backend e persiste apenas se der sucesso."
+      "community": 2,
+      "norm_label": "le o json do caminho, envia ao backend e persiste apenas se der sucesso.",
+      "id": "data_repository_rationale_16"
     },
     {
       "label": "Reenvia credenciais ao backend com o sheet_id atual.",
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/data/repository.py",
       "source_location": "L23",
-      "id": "data_repository_rationale_23",
-      "community": 3,
-      "norm_label": "reenvia credenciais ao backend com o sheet_id atual."
+      "community": 2,
+      "norm_label": "reenvia credenciais ao backend com o sheet_id atual.",
+      "id": "data_repository_rationale_23"
     },
     {
       "label": "L\u00ea credenciais do storage sem fazer chamada HTTP.",
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/data/repository.py",
       "source_location": "L30",
-      "id": "data_repository_rationale_30",
-      "community": 3,
-      "norm_label": "le credenciais do storage sem fazer chamada http."
+      "community": 2,
+      "norm_label": "le credenciais do storage sem fazer chamada http.",
+      "id": "data_repository_rationale_30"
     },
     {
       "label": "Remove credenciais do storage e desautentica o backend.",
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/data/repository.py",
       "source_location": "L35",
-      "id": "data_repository_rationale_35",
-      "community": 3,
-      "norm_label": "remove credenciais do storage e desautentica o backend."
+      "community": 2,
+      "norm_label": "remove credenciais do storage e desautentica o backend.",
+      "id": "data_repository_rationale_35"
     },
     {
       "label": "use_case.py",
@@ -4428,7 +4428,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/domain/use_case.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_auth_domain_use_case_py",
-      "community": 2,
+      "community": 15,
       "norm_label": "use_case.py"
     },
     {
@@ -4437,7 +4437,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/domain/use_case.py",
       "source_location": "L8",
       "id": "domain_use_case_authusecase",
-      "community": 2,
+      "community": 15,
       "norm_label": "authusecase"
     },
     {
@@ -4446,7 +4446,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/domain/use_case.py",
       "source_location": "L9",
       "id": "domain_use_case_authusecase_init",
-      "community": 2,
+      "community": 15,
       "norm_label": ".__init__()"
     },
     {
@@ -4455,7 +4455,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/domain/use_case.py",
       "source_location": "L12",
       "id": "domain_use_case_authusecase_configure",
-      "community": 2,
+      "community": 15,
       "norm_label": ".configure()"
     },
     {
@@ -4464,7 +4464,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/domain/use_case.py",
       "source_location": "L17",
       "id": "domain_use_case_authusecase_clear",
-      "community": 2,
+      "community": 15,
       "norm_label": ".clear()"
     },
     {
@@ -4472,35 +4472,35 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/domain/use_case.py",
       "source_location": "L13",
-      "id": "domain_use_case_rationale_13",
-      "community": 2,
-      "norm_label": "le o arquivo json, salva em storage seguro e autentica o backend."
+      "community": 15,
+      "norm_label": "le o arquivo json, salva em storage seguro e autentica o backend.",
+      "id": "domain_use_case_rationale_13"
     },
     {
       "label": "Remove credenciais do storage e desautentica o backend.",
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/domain/use_case.py",
       "source_location": "L18",
-      "id": "domain_use_case_rationale_18",
-      "community": 2,
-      "norm_label": "remove credenciais do storage e desautentica o backend."
+      "community": 15,
+      "norm_label": "remove credenciais do storage e desautentica o backend.",
+      "id": "domain_use_case_rationale_18"
     },
     {
       "label": "signals.py",
       "file_type": "code",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/domain/signals.py",
+      "source_file": "features/auth/domain/signals.py",
       "source_location": "L1",
-      "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_auth_domain_signals_py",
-      "community": 2,
+      "id": "features_auth_domain_signals_py",
+      "community": 1,
       "norm_label": "signals.py"
     },
     {
       "label": "AuthSignals",
       "file_type": "code",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/domain/signals.py",
+      "source_file": "features/auth/domain/signals.py",
       "source_location": "L8",
       "id": "domain_signals_authsignals",
-      "community": 2,
+      "community": 1,
       "norm_label": "authsignals"
     },
     {
@@ -4509,7 +4509,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/domain/events.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_auth_domain_events_py",
-      "community": 8,
+      "community": 14,
       "norm_label": "events.py"
     },
     {
@@ -4518,7 +4518,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/domain/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_auth_domain_init_py",
-      "community": 35,
+      "community": 39,
       "norm_label": "__init__.py"
     },
     {
@@ -4527,7 +4527,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/domain/errors.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_auth_domain_errors_py",
-      "community": 3,
+      "community": 2,
       "norm_label": "errors.py"
     },
     {
@@ -4536,7 +4536,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/domain/errors.py",
       "source_location": "L4",
       "id": "domain_errors_nocachedcredentialserror",
-      "community": 3,
+      "community": 2,
       "norm_label": "nocachedcredentialserror"
     },
     {
@@ -4545,7 +4545,7 @@
       "source_file": "",
       "source_location": "",
       "id": "errormodel",
-      "community": 2,
+      "community": 1,
       "norm_label": "errormodel"
     },
     {
@@ -4554,7 +4554,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/domain/errors.py",
       "source_location": "L5",
       "id": "domain_errors_nocachedcredentialserror_init",
-      "community": 3,
+      "community": 2,
       "norm_label": ".__init__()"
     },
     {
@@ -4563,7 +4563,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/domain/init_use_case.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_auth_domain_init_use_case_py",
-      "community": 3,
+      "community": 2,
       "norm_label": "init_use_case.py"
     },
     {
@@ -4572,7 +4572,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/domain/init_use_case.py",
       "source_location": "L7",
       "id": "domain_init_use_case_appinitusecase",
-      "community": 3,
+      "community": 2,
       "norm_label": "appinitusecase"
     },
     {
@@ -4581,7 +4581,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/domain/init_use_case.py",
       "source_location": "L8",
       "id": "domain_init_use_case_appinitusecase_init",
-      "community": 3,
+      "community": 2,
       "norm_label": ".__init__()"
     },
     {
@@ -4590,7 +4590,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/domain/init_use_case.py",
       "source_location": "L12",
       "id": "domain_init_use_case_appinitusecase_initialize",
-      "community": 3,
+      "community": 2,
       "norm_label": ".initialize()"
     },
     {
@@ -4599,7 +4599,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/presentation/controller.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_auth_presentation_controller_py",
-      "community": 2,
+      "community": 1,
       "norm_label": "controller.py"
     },
     {
@@ -4608,7 +4608,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/presentation/controller.py",
       "source_location": "L17",
       "id": "presentation_controller_authcontroller",
-      "community": 4,
+      "community": 15,
       "norm_label": "authcontroller"
     },
     {
@@ -4617,7 +4617,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/presentation/controller.py",
       "source_location": "L18",
       "id": "presentation_controller_authcontroller_init",
-      "community": 4,
+      "community": 15,
       "norm_label": ".__init__()"
     },
     {
@@ -4626,7 +4626,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/presentation/controller.py",
       "source_location": "L24",
       "id": "presentation_controller_authcontroller_setup_actions",
-      "community": 4,
+      "community": 15,
       "norm_label": "._setup_actions()"
     },
     {
@@ -4635,7 +4635,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/presentation/controller.py",
       "source_location": "L32",
       "id": "presentation_controller_authcontroller_on_configure",
-      "community": 4,
+      "community": 15,
       "norm_label": "._on_configure()"
     },
     {
@@ -4644,7 +4644,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/presentation/controller.py",
       "source_location": "L39",
       "id": "presentation_controller_authcontroller_on_clear",
-      "community": 4,
+      "community": 15,
       "norm_label": "._on_clear()"
     },
     {
@@ -4653,7 +4653,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/presentation/controller.py",
       "source_location": "L49",
       "id": "presentation_controller_authcontroller_on_configured",
-      "community": 4,
+      "community": 15,
       "norm_label": "._on_configured()"
     },
     {
@@ -4662,7 +4662,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/presentation/controller.py",
       "source_location": "L52",
       "id": "presentation_controller_authcontroller_on_cleared",
-      "community": 4,
+      "community": 15,
       "norm_label": "._on_cleared()"
     },
     {
@@ -4680,7 +4680,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/presentation/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_auth_presentation_init_py",
-      "community": 2,
+      "community": 1,
       "norm_label": "__init__.py"
     },
     {
@@ -4689,7 +4689,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/presentation/viewmodel.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_auth_presentation_viewmodel_py",
-      "community": 2,
+      "community": 15,
       "norm_label": "viewmodel.py"
     },
     {
@@ -4698,7 +4698,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/presentation/viewmodel.py",
       "source_location": "L12",
       "id": "presentation_viewmodel_authviewmodel",
-      "community": 4,
+      "community": 15,
       "norm_label": "authviewmodel"
     },
     {
@@ -4707,7 +4707,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/presentation/viewmodel.py",
       "source_location": "L13",
       "id": "presentation_viewmodel_authviewmodel_init",
-      "community": 4,
+      "community": 15,
       "norm_label": ".__init__()"
     },
     {
@@ -4716,7 +4716,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/presentation/viewmodel.py",
       "source_location": "L18",
       "id": "presentation_viewmodel_authviewmodel_configure",
-      "community": 4,
+      "community": 15,
       "norm_label": ".configure()"
     },
     {
@@ -4725,7 +4725,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/presentation/viewmodel.py",
       "source_location": "L29",
       "id": "presentation_viewmodel_authviewmodel_clear",
-      "community": 4,
+      "community": 15,
       "norm_label": ".clear()"
     },
     {
@@ -4734,7 +4734,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/presentation/view.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_auth_presentation_view_py",
-      "community": 2,
+      "community": 1,
       "norm_label": "view.py"
     },
     {
@@ -4743,7 +4743,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/presentation/view.py",
       "source_location": "L10",
       "id": "presentation_view_authview",
-      "community": 6,
+      "community": 5,
       "norm_label": "authview"
     },
     {
@@ -4752,7 +4752,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/presentation/view.py",
       "source_location": "L14",
       "id": "presentation_view_authview_init",
-      "community": 6,
+      "community": 5,
       "norm_label": ".__init__()"
     },
     {
@@ -4761,7 +4761,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/presentation/view.py",
       "source_location": "L22",
       "id": "presentation_view_authview_setup_actions",
-      "community": 6,
+      "community": 5,
       "norm_label": "._setup_actions()"
     },
     {
@@ -4770,7 +4770,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_cpf_validation_init_py",
-      "community": 36,
+      "community": 40,
       "norm_label": "__init__.py"
     },
     {
@@ -4779,7 +4779,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/domain/use_case.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_cpf_validation_domain_use_case_py",
-      "community": 7,
+      "community": 8,
       "norm_label": "use_case.py"
     },
     {
@@ -4788,7 +4788,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/domain/use_case.py",
       "source_location": "L6",
       "id": "domain_use_case_is_valid_cpf",
-      "community": 7,
+      "community": 8,
       "norm_label": "_is_valid_cpf()"
     },
     {
@@ -4797,7 +4797,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/domain/use_case.py",
       "source_location": "L29",
       "id": "domain_use_case_cpfvalidationusecase",
-      "community": 7,
+      "community": 8,
       "norm_label": "cpfvalidationusecase"
     },
     {
@@ -4806,7 +4806,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/domain/use_case.py",
       "source_location": "L30",
       "id": "domain_use_case_cpfvalidationusecase_validate",
-      "community": 7,
+      "community": 8,
       "norm_label": ".validate()"
     },
     {
@@ -4814,9 +4814,9 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/domain/use_case.py",
       "source_location": "L7",
-      "id": "domain_use_case_rationale_7",
-      "community": 7,
-      "norm_label": "valida um cpf pela regra dos dois digitos verificadores (algoritmo da receita fe"
+      "community": 8,
+      "norm_label": "valida um cpf pela regra dos dois digitos verificadores (algoritmo da receita fe",
+      "id": "domain_use_case_rationale_7"
     },
     {
       "label": "signals.py",
@@ -4824,7 +4824,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/domain/signals.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_cpf_validation_domain_signals_py",
-      "community": 7,
+      "community": 1,
       "norm_label": "signals.py"
     },
     {
@@ -4833,7 +4833,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/domain/signals.py",
       "source_location": "L8",
       "id": "domain_signals_cpfvalidationsignals",
-      "community": 2,
+      "community": 1,
       "norm_label": "cpfvalidationsignals"
     },
     {
@@ -4842,7 +4842,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/domain/models.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_cpf_validation_domain_models_py",
-      "community": 7,
+      "community": 8,
       "norm_label": "models.py"
     },
     {
@@ -4851,7 +4851,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/domain/models.py",
       "source_location": "L7",
       "id": "domain_models_cpfvalidationresult",
-      "community": 7,
+      "community": 8,
       "norm_label": "cpfvalidationresult"
     },
     {
@@ -4860,16 +4860,16 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/domain/events.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_cpf_validation_domain_events_py",
-      "community": 8,
+      "community": 14,
       "norm_label": "events.py"
     },
     {
       "label": "__init__.py",
       "file_type": "code",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/domain/__init__.py",
+      "source_file": "features/cpf_validation/domain/__init__.py",
       "source_location": "L1",
-      "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_cpf_validation_domain_init_py",
-      "community": 7,
+      "id": "features_cpf_validation_domain_init_py",
+      "community": 41,
       "norm_label": "__init__.py"
     },
     {
@@ -4878,7 +4878,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/presentation/controller.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_cpf_validation_presentation_controller_py",
-      "community": 7,
+      "community": 8,
       "norm_label": "controller.py"
     },
     {
@@ -4887,7 +4887,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/presentation/controller.py",
       "source_location": "L12",
       "id": "presentation_controller_cpfvalidationcontroller",
-      "community": 7,
+      "community": 8,
       "norm_label": "cpfvalidationcontroller"
     },
     {
@@ -4896,7 +4896,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/presentation/controller.py",
       "source_location": "L13",
       "id": "presentation_controller_cpfvalidationcontroller_init",
-      "community": 7,
+      "community": 8,
       "norm_label": ".__init__()"
     },
     {
@@ -4905,7 +4905,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/presentation/controller.py",
       "source_location": "L18",
       "id": "presentation_controller_cpfvalidationcontroller_setup_actions",
-      "community": 7,
+      "community": 8,
       "norm_label": "._setup_actions()"
     },
     {
@@ -4914,7 +4914,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/presentation/controller.py",
       "source_location": "L22",
       "id": "presentation_controller_cpfvalidationcontroller_on_validate",
-      "community": 7,
+      "community": 8,
       "norm_label": ".on_validate()"
     },
     {
@@ -4923,7 +4923,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/presentation/controller.py",
       "source_location": "L29",
       "id": "presentation_controller_cpfvalidationcontroller_handle_result",
-      "community": 7,
+      "community": 8,
       "norm_label": ".handle_result()"
     },
     {
@@ -4932,7 +4932,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/presentation/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_cpf_validation_presentation_init_py",
-      "community": 7,
+      "community": 8,
       "norm_label": "__init__.py"
     },
     {
@@ -4941,7 +4941,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/presentation/viewmodel.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_cpf_validation_presentation_viewmodel_py",
-      "community": 7,
+      "community": 8,
       "norm_label": "viewmodel.py"
     },
     {
@@ -4950,7 +4950,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/presentation/viewmodel.py",
       "source_location": "L7",
       "id": "presentation_viewmodel_cpfvalidationviewmodel",
-      "community": 7,
+      "community": 8,
       "norm_label": "cpfvalidationviewmodel"
     },
     {
@@ -4959,7 +4959,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/presentation/viewmodel.py",
       "source_location": "L8",
       "id": "presentation_viewmodel_cpfvalidationviewmodel_init",
-      "community": 7,
+      "community": 8,
       "norm_label": ".__init__()"
     },
     {
@@ -4968,7 +4968,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/presentation/viewmodel.py",
       "source_location": "L11",
       "id": "presentation_viewmodel_cpfvalidationviewmodel_on_validate",
-      "community": 7,
+      "community": 8,
       "norm_label": ".on_validate()"
     },
     {
@@ -4977,7 +4977,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/presentation/view.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_cpf_validation_presentation_view_py",
-      "community": 7,
+      "community": 8,
       "norm_label": "view.py"
     },
     {
@@ -4986,7 +4986,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/presentation/view.py",
       "source_location": "L14",
       "id": "presentation_view_cpfvalidationview",
-      "community": 7,
+      "community": 8,
       "norm_label": "cpfvalidationview"
     },
     {
@@ -4995,7 +4995,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/presentation/view.py",
       "source_location": "L20",
       "id": "presentation_view_cpfvalidationview_init",
-      "community": 7,
+      "community": 8,
       "norm_label": ".__init__()"
     },
     {
@@ -5004,7 +5004,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/presentation/view.py",
       "source_location": "L25",
       "id": "presentation_view_menu_title",
-      "community": 7,
+      "community": 8,
       "norm_label": "menu_title()"
     },
     {
@@ -5013,7 +5013,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/presentation/view.py",
       "source_location": "L28",
       "id": "presentation_view_cpfvalidationview_setup_ui",
-      "community": 7,
+      "community": 8,
       "norm_label": "._setup_ui()"
     },
     {
@@ -5022,7 +5022,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/presentation/view.py",
       "source_location": "L32",
       "id": "presentation_view_cpfvalidationview_setup_components",
-      "community": 7,
+      "community": 8,
       "norm_label": "._setup_components()"
     },
     {
@@ -5031,7 +5031,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/presentation/view.py",
       "source_location": "L46",
       "id": "presentation_view_cpfvalidationview_setup_layout",
-      "community": 7,
+      "community": 8,
       "norm_label": "._setup_layout()"
     },
     {
@@ -5040,7 +5040,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/presentation/view.py",
       "source_location": "L63",
       "id": "presentation_view_cpfvalidationview_get_cpf",
-      "community": 7,
+      "community": 8,
       "norm_label": ".get_cpf()"
     },
     {
@@ -5049,7 +5049,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/presentation/view.py",
       "source_location": "L66",
       "id": "presentation_view_cpfvalidationview_update_result",
-      "community": 7,
+      "community": 8,
       "norm_label": ".update_result()"
     },
     {
@@ -5058,7 +5058,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/status_bar/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_status_bar_init_py",
-      "community": 37,
+      "community": 42,
       "norm_label": "__init__.py"
     },
     {
@@ -5292,7 +5292,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_init_py",
-      "community": 38,
+      "community": 43,
       "norm_label": "__init__.py"
     },
     {
@@ -5301,7 +5301,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/_server.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_server_py",
-      "community": 14,
+      "community": 17,
       "norm_label": "_server.py"
     },
     {
@@ -5310,7 +5310,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/_server.py",
       "source_location": "L15",
       "id": "backend_server_handle_data_source_error",
-      "community": 14,
+      "community": 17,
       "norm_label": "handle_data_source_error()"
     },
     {
@@ -5319,7 +5319,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/_server.py",
       "source_location": "L21",
       "id": "backend_server_handle_backend_error",
-      "community": 14,
+      "community": 17,
       "norm_label": "handle_backend_error()"
     },
     {
@@ -5328,7 +5328,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/_server.py",
       "source_location": "L26",
       "id": "backend_server_handle_unexpected_error",
-      "community": 14,
+      "community": 17,
       "norm_label": "handle_unexpected_error()"
     },
     {
@@ -5337,7 +5337,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/_server.py",
       "source_location": "L34",
       "id": "backend_server_backendserver",
-      "community": 14,
+      "community": 17,
       "norm_label": "backendserver"
     },
     {
@@ -5346,7 +5346,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/_server.py",
       "source_location": "L35",
       "id": "backend_server_backendserver_execute",
-      "community": 14,
+      "community": 17,
       "norm_label": ".execute()"
     },
     {
@@ -5453,9 +5453,9 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_google_sheets.py",
       "source_location": "L16",
-      "id": "data_source_google_sheets_rationale_16",
       "community": 0,
-      "norm_label": "implementacao de datasourceprotocol para google sheets via gspread."
+      "norm_label": "implementacao de datasourceprotocol para google sheets via gspread.",
+      "id": "data_source_google_sheets_rationale_16"
     },
     {
       "label": "__init__.py",
@@ -5472,7 +5472,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_protocol.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_data_source_protocol_py",
-      "community": 11,
+      "community": 10,
       "norm_label": "_protocol.py"
     },
     {
@@ -5481,7 +5481,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_protocol.py",
       "source_location": "L5",
       "id": "data_source_protocol_datasourceprotocol",
-      "community": 11,
+      "community": 10,
       "norm_label": "datasourceprotocol"
     },
     {
@@ -5490,7 +5490,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_protocol.py",
       "source_location": "L8",
       "id": "data_source_protocol_datasourceprotocol_is_ready",
-      "community": 0,
+      "community": 10,
       "norm_label": ".is_ready()"
     },
     {
@@ -5499,7 +5499,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_protocol.py",
       "source_location": "L12",
       "id": "data_source_protocol_datasourceprotocol_set_credentials",
-      "community": 11,
+      "community": 10,
       "norm_label": ".set_credentials()"
     },
     {
@@ -5508,7 +5508,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_protocol.py",
       "source_location": "L16",
       "id": "data_source_protocol_datasourceprotocol_clear_credentials",
-      "community": 11,
+      "community": 10,
       "norm_label": ".clear_credentials()"
     },
     {
@@ -5517,7 +5517,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_protocol.py",
       "source_location": "L20",
       "id": "data_source_protocol_datasourceprotocol_clear_sheet",
-      "community": 11,
+      "community": 10,
       "norm_label": ".clear_sheet()"
     },
     {
@@ -5526,7 +5526,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_protocol.py",
       "source_location": "L24",
       "id": "data_source_protocol_datasourceprotocol_set_sheet",
-      "community": 11,
+      "community": 10,
       "norm_label": ".set_sheet()"
     },
     {
@@ -5535,7 +5535,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_protocol.py",
       "source_location": "L28",
       "id": "data_source_protocol_datasourceprotocol_fetch_orders_by_date",
-      "community": 1,
+      "community": 11,
       "norm_label": ".fetch_orders_by_date()"
     },
     {
@@ -5544,7 +5544,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_protocol.py",
       "source_location": "L32",
       "id": "data_source_protocol_datasourceprotocol_fetch_orders_by_period",
-      "community": 1,
+      "community": 7,
       "norm_label": ".fetch_orders_by_period()"
     },
     {
@@ -5552,72 +5552,72 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_protocol.py",
       "source_location": "L6",
-      "id": "data_source_protocol_rationale_6",
-      "community": 11,
-      "norm_label": "contrato agnostico de fonte de dados para pedidos."
+      "community": 10,
+      "norm_label": "contrato agnostico de fonte de dados para pedidos.",
+      "id": "data_source_protocol_rationale_6"
     },
     {
       "label": "Retorna True se credentials e sheet est\u00e3o configurados em mem\u00f3ria.",
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_protocol.py",
       "source_location": "L9",
-      "id": "data_source_protocol_rationale_9",
-      "community": 0,
-      "norm_label": "retorna true se credentials e sheet estao configurados em memoria."
+      "community": 10,
+      "norm_label": "retorna true se credentials e sheet estao configurados em memoria.",
+      "id": "data_source_protocol_rationale_9"
     },
     {
       "label": "Autentica com o dict da service account e guarda o client em mem\u00f3ria.",
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_protocol.py",
       "source_location": "L13",
-      "id": "data_source_protocol_rationale_13",
-      "community": 11,
-      "norm_label": "autentica com o dict da service account e guarda o client em memoria."
+      "community": 10,
+      "norm_label": "autentica com o dict da service account e guarda o client em memoria.",
+      "id": "data_source_protocol_rationale_13"
     },
     {
       "label": "Remove o client autenticado da mem\u00f3ria. Mant\u00e9m o sheet_id.",
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_protocol.py",
       "source_location": "L17",
-      "id": "data_source_protocol_rationale_17",
-      "community": 11,
-      "norm_label": "remove o client autenticado da memoria. mantem o sheet_id."
+      "community": 10,
+      "norm_label": "remove o client autenticado da memoria. mantem o sheet_id.",
+      "id": "data_source_protocol_rationale_17"
     },
     {
       "label": "Remove a planilha ativa da mem\u00f3ria. Mant\u00e9m as credenciais.",
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_protocol.py",
       "source_location": "L21",
-      "id": "data_source_protocol_rationale_21",
-      "community": 11,
-      "norm_label": "remove a planilha ativa da memoria. mantem as credenciais."
+      "community": 10,
+      "norm_label": "remove a planilha ativa da memoria. mantem as credenciais.",
+      "id": "data_source_protocol_rationale_21"
     },
     {
       "label": "Define a planilha ativa e dispara prewarm em background.",
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_protocol.py",
       "source_location": "L25",
-      "id": "data_source_protocol_rationale_25",
-      "community": 11,
-      "norm_label": "define a planilha ativa e dispara prewarm em background."
+      "community": 10,
+      "norm_label": "define a planilha ativa e dispara prewarm em background.",
+      "id": "data_source_protocol_rationale_25"
     },
     {
       "label": "Retorna pedidos da data informada (DD/MM/YYYY).",
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_protocol.py",
       "source_location": "L29",
-      "id": "data_source_protocol_rationale_29",
-      "community": 1,
-      "norm_label": "retorna pedidos da data informada (dd/mm/yyyy)."
+      "community": 11,
+      "norm_label": "retorna pedidos da data informada (dd/mm/yyyy).",
+      "id": "data_source_protocol_rationale_29"
     },
     {
       "label": "Retorna pedidos no intervalo de datas informado (DD/MM/YYYY).",
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_protocol.py",
       "source_location": "L33",
-      "id": "data_source_protocol_rationale_33",
-      "community": 1,
-      "norm_label": "retorna pedidos no intervalo de datas informado (dd/mm/yyyy)."
+      "community": 7,
+      "norm_label": "retorna pedidos no intervalo de datas informado (dd/mm/yyyy).",
+      "id": "data_source_protocol_rationale_33"
     },
     {
       "label": "sheet_mapper.py",
@@ -5679,7 +5679,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/sheet_mapper.py",
       "source_location": "L82",
       "id": "data_source_sheet_mapper_paymentcols_slot",
-      "community": 1,
+      "community": 7,
       "norm_label": ".slot()"
     },
     {
@@ -5687,36 +5687,36 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/sheet_mapper.py",
       "source_location": "L1",
-      "id": "data_source_sheet_mapper_rationale_1",
       "community": 0,
-      "norm_label": "mapeamento de colunas e tabs da planilha."
+      "norm_label": "mapeamento de colunas e tabs da planilha.",
+      "id": "data_source_sheet_mapper_rationale_1"
     },
     {
       "label": "Colunas fixas da aba Cadastro, agrupadas por dom\u00ednio.",
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/sheet_mapper.py",
       "source_location": "L15",
-      "id": "data_source_sheet_mapper_rationale_15",
       "community": 0,
-      "norm_label": "colunas fixas da aba cadastro, agrupadas por dominio."
+      "norm_label": "colunas fixas da aba cadastro, agrupadas por dominio.",
+      "id": "data_source_sheet_mapper_rationale_15"
     },
     {
       "label": "Colunas dos slots de produto (1\u20137). Usar com .slot(n).",
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/sheet_mapper.py",
       "source_location": "L63",
-      "id": "data_source_sheet_mapper_rationale_63",
       "community": 0,
-      "norm_label": "colunas dos slots de produto (1\u20137). usar com .slot(n)."
+      "norm_label": "colunas dos slots de produto (1\u20137). usar com .slot(n).",
+      "id": "data_source_sheet_mapper_rationale_63"
     },
     {
       "label": "Colunas das parcelas de pagamento (1\u20136). Usar com .slot(n).",
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/sheet_mapper.py",
       "source_location": "L75",
-      "id": "data_source_sheet_mapper_rationale_75",
       "community": 0,
-      "norm_label": "colunas das parcelas de pagamento (1\u20136). usar com .slot(n)."
+      "norm_label": "colunas das parcelas de pagamento (1\u20136). usar com .slot(n).",
+      "id": "data_source_sheet_mapper_rationale_75"
     },
     {
       "label": "_normalizer.py",
@@ -5777,27 +5777,27 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_normalizer.py",
       "source_location": "L1",
-      "id": "data_source_normalizer_rationale_1",
       "community": 0,
-      "norm_label": "normaliza headers inconsistentes da planilha para os valores canonicos dos enums"
+      "norm_label": "normaliza headers inconsistentes da planilha para os valores canonicos dos enums",
+      "id": "data_source_normalizer_rationale_1"
     },
     {
       "label": "Traduz headers reais da planilha para os nomes can\u00f4nicos definidos nos enums.",
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_normalizer.py",
       "source_location": "L7",
-      "id": "data_source_normalizer_rationale_7",
       "community": 0,
-      "norm_label": "traduz headers reais da planilha para os nomes canonicos definidos nos enums."
+      "norm_label": "traduz headers reais da planilha para os nomes canonicos definidos nos enums.",
+      "id": "data_source_normalizer_rationale_7"
     },
     {
       "label": "Renomeia a coluna que segue prod3 para prod4, independente do header atual.",
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_normalizer.py",
       "source_location": "L33",
-      "id": "data_source_normalizer_rationale_33",
-      "community": 39,
-      "norm_label": "renomeia a coluna que segue prod3 para prod4, independente do header atual."
+      "community": 44,
+      "norm_label": "renomeia a coluna que segue prod3 para prod4, independente do header atual.",
+      "id": "data_source_normalizer_rationale_33"
     },
     {
       "label": "_viewmodel.py",
@@ -5867,27 +5867,27 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_viewmodel.py",
       "source_location": "L10",
-      "id": "data_source_viewmodel_rationale_10",
       "community": 0,
-      "norm_label": "encapsula o acesso a planilha: schema cacheado, prewarm e fetch."
+      "norm_label": "encapsula o acesso a planilha: schema cacheado, prewarm e fetch.",
+      "id": "data_source_viewmodel_rationale_10"
     },
     {
       "label": "Carrega cabe\u00e7alho e \u00edndice da coluna DATA na primeira chamada; no-op nas seguint",
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_viewmodel.py",
       "source_location": "L29",
-      "id": "data_source_viewmodel_rationale_29",
       "community": 0,
-      "norm_label": "carrega cabecalho e indice da coluna data na primeira chamada; no-op nas seguint"
+      "norm_label": "carrega cabecalho e indice da coluna data na primeira chamada; no-op nas seguint",
+      "id": "data_source_viewmodel_rationale_29"
     },
     {
       "label": "Busca pedidos por datas usando dois passes para minimizar chamadas \u00e0 API.",
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_viewmodel.py",
       "source_location": "L43",
-      "id": "data_source_viewmodel_rationale_43",
-      "community": 40,
-      "norm_label": "busca pedidos por datas usando dois passes para minimizar chamadas a api."
+      "community": 45,
+      "norm_label": "busca pedidos por datas usando dois passes para minimizar chamadas a api.",
+      "id": "data_source_viewmodel_rationale_43"
     },
     {
       "label": "_utils.py",
@@ -5939,36 +5939,36 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_utils.py",
       "source_location": "L6",
-      "id": "data_source_utils_rationale_6",
       "community": 0,
-      "norm_label": "normaliza uma data para dd/mm/yyyy aceitando os formatos dd/mm/yy e dd/mm/yyyy."
+      "norm_label": "normaliza uma data para dd/mm/yyyy aceitando os formatos dd/mm/yy e dd/mm/yyyy.",
+      "id": "data_source_utils_rationale_6"
     },
     {
       "label": "Converte linhas da planilha em lista de dicts usando o cabe\u00e7alho como chaves (lo",
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_utils.py",
       "source_location": "L16",
-      "id": "data_source_utils_rationale_16",
       "community": 0,
-      "norm_label": "converte linhas da planilha em lista de dicts usando o cabecalho como chaves (lo"
+      "norm_label": "converte linhas da planilha em lista de dicts usando o cabecalho como chaves (lo",
+      "id": "data_source_utils_rationale_16"
     },
     {
       "label": "Agrupa n\u00fameros de linha consecutivos em ranges A1 notation e divide em batches d",
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_utils.py",
       "source_location": "L22",
-      "id": "data_source_utils_rationale_22",
       "community": 0,
-      "norm_label": "agrupa numeros de linha consecutivos em ranges a1 notation e divide em batches d"
+      "norm_label": "agrupa numeros de linha consecutivos em ranges a1 notation e divide em batches d",
+      "id": "data_source_utils_rationale_22"
     },
     {
       "label": "Retorna o conjunto de todas as datas (DD/MM/YYYY) entre start e end, inclusive.",
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_utils.py",
       "source_location": "L35",
-      "id": "data_source_utils_rationale_35",
       "community": 0,
-      "norm_label": "retorna o conjunto de todas as datas (dd/mm/yyyy) entre start e end, inclusive."
+      "norm_label": "retorna o conjunto de todas as datas (dd/mm/yyyy) entre start e end, inclusive.",
+      "id": "data_source_utils_rationale_35"
     },
     {
       "label": "_handler.py",
@@ -6435,7 +6435,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_features_init_py",
-      "community": 41,
+      "community": 46,
       "norm_label": "__init__.py"
     },
     {
@@ -6444,7 +6444,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/auth/service.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_features_auth_service_py",
-      "community": 11,
+      "community": 10,
       "norm_label": "service.py"
     },
     {
@@ -6453,7 +6453,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/auth/service.py",
       "source_location": "L6",
       "id": "auth_service_authservice",
-      "community": 11,
+      "community": 10,
       "norm_label": "authservice"
     },
     {
@@ -6462,7 +6462,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/auth/service.py",
       "source_location": "L7",
       "id": "auth_service_authservice_connect",
-      "community": 11,
+      "community": 10,
       "norm_label": ".connect()"
     },
     {
@@ -6471,7 +6471,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/auth/service.py",
       "source_location": "L12",
       "id": "auth_service_authservice_disconnect",
-      "community": 11,
+      "community": 10,
       "norm_label": ".disconnect()"
     },
     {
@@ -6479,9 +6479,9 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/auth/service.py",
       "source_location": "L1",
-      "id": "auth_service_rationale_1",
-      "community": 11,
-      "norm_label": "service de autenticacao \u2014 gerencia o estado de conexao do datasource."
+      "community": 10,
+      "norm_label": "service de autenticacao \u2014 gerencia o estado de conexao do datasource.",
+      "id": "auth_service_rationale_1"
     },
     {
       "label": "route.py",
@@ -6489,7 +6489,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/auth/route.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_features_auth_route_py",
-      "community": 11,
+      "community": 10,
       "norm_label": "route.py"
     },
     {
@@ -6498,7 +6498,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/auth/route.py",
       "source_location": "L12",
       "id": "auth_route_connect",
-      "community": 6,
+      "community": 5,
       "norm_label": "connect()"
     },
     {
@@ -6507,7 +6507,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/auth/route.py",
       "source_location": "L19",
       "id": "auth_route_disconnect",
-      "community": 11,
+      "community": 10,
       "norm_label": "disconnect()"
     },
     {
@@ -6515,9 +6515,9 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/auth/route.py",
       "source_location": "L1",
-      "id": "auth_route_rationale_1",
-      "community": 11,
-      "norm_label": "rotas de autenticacao"
+      "community": 10,
+      "norm_label": "rotas de autenticacao",
+      "id": "auth_route_rationale_1"
     },
     {
       "label": "__init__.py",
@@ -6525,7 +6525,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/auth/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_features_auth_init_py",
-      "community": 11,
+      "community": 10,
       "norm_label": "__init__.py"
     },
     {
@@ -6552,7 +6552,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/shared/models.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_features_orders_shared_models_py",
-      "community": 1,
+      "community": 7,
       "norm_label": "models.py"
     },
     {
@@ -6561,7 +6561,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/shared/models.py",
       "source_location": "L5",
       "id": "shared_models_address",
-      "community": 1,
+      "community": 7,
       "norm_label": "address"
     },
     {
@@ -6570,7 +6570,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/shared/models.py",
       "source_location": "L18",
       "id": "shared_models_event",
-      "community": 1,
+      "community": 7,
       "norm_label": "event"
     },
     {
@@ -6579,7 +6579,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/shared/models.py",
       "source_location": "L24",
       "id": "shared_models_customer",
-      "community": 1,
+      "community": 7,
       "norm_label": "customer"
     },
     {
@@ -6588,7 +6588,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/shared/models.py",
       "source_location": "L33",
       "id": "shared_models_receiver",
-      "community": 1,
+      "community": 7,
       "norm_label": "receiver"
     },
     {
@@ -6597,7 +6597,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/shared/models.py",
       "source_location": "L40",
       "id": "shared_models_customization",
-      "community": 1,
+      "community": 7,
       "norm_label": "customization"
     },
     {
@@ -6606,7 +6606,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/shared/models.py",
       "source_location": "L48",
       "id": "shared_models_productitem",
-      "community": 1,
+      "community": 7,
       "norm_label": "productitem"
     },
     {
@@ -6615,7 +6615,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/shared/models.py",
       "source_location": "L56",
       "id": "shared_models_paymentitem",
-      "community": 1,
+      "community": 7,
       "norm_label": "paymentitem"
     },
     {
@@ -6624,7 +6624,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/shared/models.py",
       "source_location": "L65",
       "id": "shared_models_financial",
-      "community": 1,
+      "community": 7,
       "norm_label": "financial"
     },
     {
@@ -6633,7 +6633,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/shared/models.py",
       "source_location": "L76",
       "id": "shared_models_delivery",
-      "community": 1,
+      "community": 7,
       "norm_label": "delivery"
     },
     {
@@ -6642,7 +6642,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/shared/models.py",
       "source_location": "L86",
       "id": "shared_models_order",
-      "community": 1,
+      "community": 7,
       "norm_label": "order"
     },
     {
@@ -6651,7 +6651,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/shared/mapper.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_features_orders_shared_mapper_py",
-      "community": 1,
+      "community": 7,
       "norm_label": "mapper.py"
     },
     {
@@ -6660,7 +6660,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/shared/mapper.py",
       "source_location": "L11",
       "id": "shared_mapper_ordermapper",
-      "community": 1,
+      "community": 7,
       "norm_label": "ordermapper"
     },
     {
@@ -6669,7 +6669,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/shared/mapper.py",
       "source_location": "L15",
       "id": "shared_mapper_to_model",
-      "community": 1,
+      "community": 7,
       "norm_label": "to_model()"
     },
     {
@@ -6678,7 +6678,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/shared/mapper.py",
       "source_location": "L32",
       "id": "shared_mapper_customer",
-      "community": 1,
+      "community": 7,
       "norm_label": "_customer()"
     },
     {
@@ -6687,7 +6687,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/shared/mapper.py",
       "source_location": "L42",
       "id": "shared_mapper_receiver",
-      "community": 1,
+      "community": 7,
       "norm_label": "_receiver()"
     },
     {
@@ -6696,7 +6696,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/shared/mapper.py",
       "source_location": "L53",
       "id": "shared_mapper_customization",
-      "community": 1,
+      "community": 7,
       "norm_label": "_customization()"
     },
     {
@@ -6705,7 +6705,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/shared/mapper.py",
       "source_location": "L62",
       "id": "shared_mapper_products",
-      "community": 1,
+      "community": 7,
       "norm_label": "_products()"
     },
     {
@@ -6714,7 +6714,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/shared/mapper.py",
       "source_location": "L77",
       "id": "shared_mapper_payments",
-      "community": 1,
+      "community": 7,
       "norm_label": "_payments()"
     },
     {
@@ -6723,7 +6723,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/shared/mapper.py",
       "source_location": "L94",
       "id": "shared_mapper_financial",
-      "community": 1,
+      "community": 7,
       "norm_label": "_financial()"
     },
     {
@@ -6732,7 +6732,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/shared/mapper.py",
       "source_location": "L106",
       "id": "shared_mapper_delivery",
-      "community": 1,
+      "community": 7,
       "norm_label": "_delivery()"
     },
     {
@@ -6740,27 +6740,27 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/shared/mapper.py",
       "source_location": "L1",
-      "id": "shared_mapper_rationale_1",
-      "community": 1,
-      "norm_label": "mapeamento de uma linha do dataframe para o model order."
+      "community": 7,
+      "norm_label": "mapeamento de uma linha do dataframe para o model order.",
+      "id": "shared_mapper_rationale_1"
     },
     {
       "label": "Converte uma linha do DataFrame (vinda do SheetsRepository) em um Order.",
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/shared/mapper.py",
       "source_location": "L12",
-      "id": "shared_mapper_rationale_12",
-      "community": 1,
-      "norm_label": "converte uma linha do dataframe (vinda do sheetsrepository) em um order."
+      "community": 7,
+      "norm_label": "converte uma linha do dataframe (vinda do sheetsrepository) em um order.",
+      "id": "shared_mapper_rationale_12"
     },
     {
       "label": "Monta um Order completo a partir de uma linha do DataFrame.",
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/shared/mapper.py",
       "source_location": "L16",
-      "id": "shared_mapper_rationale_16",
-      "community": 42,
-      "norm_label": "monta um order completo a partir de uma linha do dataframe."
+      "community": 47,
+      "norm_label": "monta um order completo a partir de uma linha do dataframe.",
+      "id": "shared_mapper_rationale_16"
     },
     {
       "label": "__init__.py",
@@ -6768,7 +6768,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/shared/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_features_orders_shared_init_py",
-      "community": 1,
+      "community": 7,
       "norm_label": "__init__.py"
     },
     {
@@ -6777,7 +6777,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_features_orders_subfeatures_init_py",
-      "community": 1,
+      "community": 11,
       "norm_label": "__init__.py"
     },
     {
@@ -6786,7 +6786,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/payments/service.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_features_orders_subfeatures_payments_service_py",
-      "community": 1,
+      "community": 11,
       "norm_label": "service.py"
     },
     {
@@ -6795,7 +6795,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/payments/service.py",
       "source_location": "L10",
       "id": "payments_service_paymentsmapper",
-      "community": 1,
+      "community": 11,
       "norm_label": "paymentsmapper"
     },
     {
@@ -6804,7 +6804,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/payments/service.py",
       "source_location": "L14",
       "id": "payments_service_to_response",
-      "community": 1,
+      "community": 11,
       "norm_label": "to_response()"
     },
     {
@@ -6813,7 +6813,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/payments/service.py",
       "source_location": "L21",
       "id": "payments_service_paymentsservice",
-      "community": 1,
+      "community": 11,
       "norm_label": "paymentsservice"
     },
     {
@@ -6822,7 +6822,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/payments/service.py",
       "source_location": "L24",
       "id": "payments_service_paymentsservice_init",
-      "community": 1,
+      "community": 11,
       "norm_label": ".__init__()"
     },
     {
@@ -6831,7 +6831,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/payments/service.py",
       "source_location": "L27",
       "id": "payments_service_paymentsservice_get_pendent",
-      "community": 1,
+      "community": 11,
       "norm_label": ".get_pendent()"
     },
     {
@@ -6839,36 +6839,36 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/payments/service.py",
       "source_location": "L1",
-      "id": "payments_service_rationale_1",
-      "community": 1,
-      "norm_label": "service e mapper de pagamentos pendentes."
+      "community": 11,
+      "norm_label": "service e mapper de pagamentos pendentes.",
+      "id": "payments_service_rationale_1"
     },
     {
       "label": "Serializa o resultado do PaymentsService para dict JSON-ready.",
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/payments/service.py",
       "source_location": "L11",
-      "id": "payments_service_rationale_11",
-      "community": 1,
-      "norm_label": "serializa o resultado do paymentsservice para dict json-ready."
+      "community": 11,
+      "norm_label": "serializa o resultado do paymentsservice para dict json-ready.",
+      "id": "payments_service_rationale_11"
     },
     {
       "label": "Filtra pedidos com pagamento pendente e monta os objetos de dom\u00ednio.",
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/payments/service.py",
       "source_location": "L22",
-      "id": "payments_service_rationale_22",
-      "community": 1,
-      "norm_label": "filtra pedidos com pagamento pendente e monta os objetos de dominio."
+      "community": 11,
+      "norm_label": "filtra pedidos com pagamento pendente e monta os objetos de dominio.",
+      "id": "payments_service_rationale_22"
     },
     {
       "label": "Retorna pedidos com amount_pendent > 0 para a data informada.",
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/payments/service.py",
       "source_location": "L28",
-      "id": "payments_service_rationale_28",
-      "community": 1,
-      "norm_label": "retorna pedidos com amount_pendent > 0 para a data informada."
+      "community": 11,
+      "norm_label": "retorna pedidos com amount_pendent > 0 para a data informada.",
+      "id": "payments_service_rationale_28"
     },
     {
       "label": "route.py",
@@ -6876,7 +6876,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/payments/route.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_features_orders_subfeatures_payments_route_py",
-      "community": 1,
+      "community": 11,
       "norm_label": "route.py"
     },
     {
@@ -6885,7 +6885,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/payments/route.py",
       "source_location": "L12",
       "id": "payments_route_get_payments_pendent",
-      "community": 1,
+      "community": 11,
       "norm_label": "get_payments_pendent()"
     },
     {
@@ -6893,9 +6893,9 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/payments/route.py",
       "source_location": "L1",
-      "id": "payments_route_rationale_1",
-      "community": 1,
-      "norm_label": "rota de pagamentos \u2014 get /orders/payments-pendent."
+      "community": 11,
+      "norm_label": "rota de pagamentos \u2014 get /orders/payments-pendent.",
+      "id": "payments_route_rationale_1"
     },
     {
       "label": "__init__.py",
@@ -6903,7 +6903,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/payments/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_features_orders_subfeatures_payments_init_py",
-      "community": 43,
+      "community": 48,
       "norm_label": "__init__.py"
     },
     {
@@ -6912,7 +6912,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/payments/repository.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_features_orders_subfeatures_payments_repository_py",
-      "community": 1,
+      "community": 11,
       "norm_label": "repository.py"
     },
     {
@@ -6921,7 +6921,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/payments/repository.py",
       "source_location": "L11",
       "id": "payments_repository_paymentsrepository",
-      "community": 1,
+      "community": 11,
       "norm_label": "paymentsrepository"
     },
     {
@@ -6930,7 +6930,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/payments/repository.py",
       "source_location": "L17",
       "id": "payments_repository_paymentsrepository_get_by_date",
-      "community": 1,
+      "community": 11,
       "norm_label": ".get_by_date()"
     },
     {
@@ -6939,7 +6939,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/payments/repository.py",
       "source_location": "L25",
       "id": "payments_repository_to_dataframe",
-      "community": 1,
+      "community": 11,
       "norm_label": "_to_dataframe()"
     },
     {
@@ -6948,7 +6948,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/payments/repository.py",
       "source_location": "L51",
       "id": "payments_repository_cast_numeric",
-      "community": 1,
+      "community": 11,
       "norm_label": "_cast_numeric()"
     },
     {
@@ -6956,45 +6956,45 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/payments/repository.py",
       "source_location": "L1",
-      "id": "payments_repository_rationale_1",
-      "community": 1,
-      "norm_label": "repositorio de pagamentos \u2014 busca e prepara dados da planilha para o paymentsser"
+      "community": 11,
+      "norm_label": "repositorio de pagamentos \u2014 busca e prepara dados da planilha para o paymentsser",
+      "id": "payments_repository_rationale_1"
     },
     {
       "label": "Acessa o data source e entrega um DataFrame tipado para o PaymentsService.",
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/payments/repository.py",
       "source_location": "L12",
-      "id": "payments_repository_rationale_12",
-      "community": 1,
-      "norm_label": "acessa o data source e entrega um dataframe tipado para o paymentsservice."
+      "community": 11,
+      "norm_label": "acessa o data source e entrega um dataframe tipado para o paymentsservice.",
+      "id": "payments_repository_rationale_12"
     },
     {
       "label": "Retorna todos os pedidos de uma data com colunas num\u00e9ricas convertidas para floa",
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/payments/repository.py",
       "source_location": "L18",
-      "id": "payments_repository_rationale_18",
-      "community": 1,
-      "norm_label": "retorna todos os pedidos de uma data com colunas numericas convertidas para floa"
+      "community": 11,
+      "norm_label": "retorna todos os pedidos de uma data com colunas numericas convertidas para floa",
+      "id": "payments_repository_rationale_18"
     },
     {
       "label": "Converte list[dict] em DataFrame com cast num\u00e9rico de todas as colunas de valor.",
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/payments/repository.py",
       "source_location": "L26",
-      "id": "payments_repository_rationale_26",
-      "community": 44,
-      "norm_label": "converte list[dict] em dataframe com cast numerico de todas as colunas de valor."
+      "community": 49,
+      "norm_label": "converte list[dict] em dataframe com cast numerico de todas as colunas de valor.",
+      "id": "payments_repository_rationale_26"
     },
     {
       "label": "Faz cast num\u00e9rico de uma coluna se ela existir no DataFrame.",
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/payments/repository.py",
       "source_location": "L52",
-      "id": "payments_repository_rationale_52",
-      "community": 45,
-      "norm_label": "faz cast numerico de uma coluna se ela existir no dataframe."
+      "community": 50,
+      "norm_label": "faz cast numerico de uma coluna se ela existir no dataframe.",
+      "id": "payments_repository_rationale_52"
     },
     {
       "label": "service.py",
@@ -7002,7 +7002,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/summary/service.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_features_orders_subfeatures_summary_service_py",
-      "community": 1,
+      "community": 7,
       "norm_label": "service.py"
     },
     {
@@ -7011,7 +7011,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/summary/service.py",
       "source_location": "L9",
       "id": "summary_service_ordersmapper",
-      "community": 1,
+      "community": 7,
       "norm_label": "ordersmapper"
     },
     {
@@ -7020,7 +7020,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/summary/service.py",
       "source_location": "L13",
       "id": "summary_service_to_response",
-      "community": 1,
+      "community": 7,
       "norm_label": "to_response()"
     },
     {
@@ -7029,7 +7029,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/summary/service.py",
       "source_location": "L20",
       "id": "summary_service_ordersservice",
-      "community": 1,
+      "community": 7,
       "norm_label": "ordersservice"
     },
     {
@@ -7038,7 +7038,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/summary/service.py",
       "source_location": "L23",
       "id": "summary_service_ordersservice_init",
-      "community": 1,
+      "community": 7,
       "norm_label": ".__init__()"
     },
     {
@@ -7047,7 +7047,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/summary/service.py",
       "source_location": "L26",
       "id": "summary_service_ordersservice_get_by_period",
-      "community": 1,
+      "community": 7,
       "norm_label": ".get_by_period()"
     },
     {
@@ -7055,36 +7055,36 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/summary/service.py",
       "source_location": "L1",
-      "id": "summary_service_rationale_1",
-      "community": 1,
-      "norm_label": "service e mapper de resumo de pedidos por periodo."
+      "community": 7,
+      "norm_label": "service e mapper de resumo de pedidos por periodo.",
+      "id": "summary_service_rationale_1"
     },
     {
       "label": "Serializa o resultado do OrdersService para dict JSON-ready.",
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/summary/service.py",
       "source_location": "L10",
-      "id": "summary_service_rationale_10",
-      "community": 1,
-      "norm_label": "serializa o resultado do ordersservice para dict json-ready."
+      "community": 7,
+      "norm_label": "serializa o resultado do ordersservice para dict json-ready.",
+      "id": "summary_service_rationale_10"
     },
     {
       "label": "Busca e monta os pedidos de um per\u00edodo.",
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/summary/service.py",
       "source_location": "L21",
-      "id": "summary_service_rationale_21",
-      "community": 1,
-      "norm_label": "busca e monta os pedidos de um periodo."
+      "community": 7,
+      "norm_label": "busca e monta os pedidos de um periodo.",
+      "id": "summary_service_rationale_21"
     },
     {
       "label": "Retorna todos os pedidos do per\u00edodo informado.",
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/summary/service.py",
       "source_location": "L27",
-      "id": "summary_service_rationale_27",
-      "community": 1,
-      "norm_label": "retorna todos os pedidos do periodo informado."
+      "community": 7,
+      "norm_label": "retorna todos os pedidos do periodo informado.",
+      "id": "summary_service_rationale_27"
     },
     {
       "label": "route.py",
@@ -7092,7 +7092,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/summary/route.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_features_orders_subfeatures_summary_route_py",
-      "community": 1,
+      "community": 11,
       "norm_label": "route.py"
     },
     {
@@ -7101,7 +7101,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/summary/route.py",
       "source_location": "L12",
       "id": "summary_route_get_orders",
-      "community": 1,
+      "community": 11,
       "norm_label": "get_orders()"
     },
     {
@@ -7109,9 +7109,9 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/summary/route.py",
       "source_location": "L1",
-      "id": "summary_route_rationale_1",
-      "community": 1,
-      "norm_label": "rota de pedidos \u2014 get /orders."
+      "community": 11,
+      "norm_label": "rota de pedidos \u2014 get /orders.",
+      "id": "summary_route_rationale_1"
     },
     {
       "label": "__init__.py",
@@ -7119,7 +7119,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/summary/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_features_orders_subfeatures_summary_init_py",
-      "community": 46,
+      "community": 51,
       "norm_label": "__init__.py"
     },
     {
@@ -7128,7 +7128,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/summary/repository.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_features_orders_subfeatures_summary_repository_py",
-      "community": 1,
+      "community": 7,
       "norm_label": "repository.py"
     },
     {
@@ -7137,7 +7137,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/summary/repository.py",
       "source_location": "L11",
       "id": "summary_repository_orderssummaryrepository",
-      "community": 1,
+      "community": 7,
       "norm_label": "orderssummaryrepository"
     },
     {
@@ -7146,7 +7146,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/summary/repository.py",
       "source_location": "L17",
       "id": "summary_repository_orderssummaryrepository_get_by_period",
-      "community": 1,
+      "community": 7,
       "norm_label": ".get_by_period()"
     },
     {
@@ -7155,7 +7155,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/summary/repository.py",
       "source_location": "L25",
       "id": "summary_repository_to_dataframe",
-      "community": 1,
+      "community": 7,
       "norm_label": "_to_dataframe()"
     },
     {
@@ -7164,7 +7164,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/summary/repository.py",
       "source_location": "L50",
       "id": "summary_repository_cast_numeric",
-      "community": 1,
+      "community": 7,
       "norm_label": "_cast_numeric()"
     },
     {
@@ -7172,45 +7172,45 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/summary/repository.py",
       "source_location": "L1",
-      "id": "summary_repository_rationale_1",
-      "community": 1,
-      "norm_label": "repositorio de pedidos por periodo \u2014 busca e prepara dados da planilha para o or"
+      "community": 7,
+      "norm_label": "repositorio de pedidos por periodo \u2014 busca e prepara dados da planilha para o or",
+      "id": "summary_repository_rationale_1"
     },
     {
       "label": "Acessa o data source e entrega um DataFrame tipado para o OrdersService.      \u00dan",
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/summary/repository.py",
       "source_location": "L12",
-      "id": "summary_repository_rationale_12",
-      "community": 1,
-      "norm_label": "acessa o data source e entrega um dataframe tipado para o ordersservice.      un"
+      "community": 7,
+      "norm_label": "acessa o data source e entrega um dataframe tipado para o ordersservice.      un",
+      "id": "summary_repository_rationale_12"
     },
     {
       "label": "Retorna todos os pedidos de um per\u00edodo com colunas num\u00e9ricas convertidas para fl",
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/summary/repository.py",
       "source_location": "L18",
-      "id": "summary_repository_rationale_18",
-      "community": 1,
-      "norm_label": "retorna todos os pedidos de um periodo com colunas numericas convertidas para fl"
+      "community": 7,
+      "norm_label": "retorna todos os pedidos de um periodo com colunas numericas convertidas para fl",
+      "id": "summary_repository_rationale_18"
     },
     {
       "label": "Converte list[dict] em DataFrame com cast num\u00e9rico de todas as colunas de valor.",
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/summary/repository.py",
       "source_location": "L26",
-      "id": "summary_repository_rationale_26",
-      "community": 47,
-      "norm_label": "converte list[dict] em dataframe com cast numerico de todas as colunas de valor."
+      "community": 52,
+      "norm_label": "converte list[dict] em dataframe com cast numerico de todas as colunas de valor.",
+      "id": "summary_repository_rationale_26"
     },
     {
       "label": "Faz cast num\u00e9rico de uma coluna se ela existir no DataFrame.",
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/summary/repository.py",
       "source_location": "L51",
-      "id": "summary_repository_rationale_51",
-      "community": 48,
-      "norm_label": "faz cast numerico de uma coluna se ela existir no dataframe."
+      "community": 53,
+      "norm_label": "faz cast numerico de uma coluna se ela existir no dataframe.",
+      "id": "summary_repository_rationale_51"
     },
     {
       "label": "service.py",
@@ -7218,7 +7218,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/deliveries/service.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_features_orders_subfeatures_deliveries_service_py",
-      "community": 10,
+      "community": 9,
       "norm_label": "service.py"
     },
     {
@@ -7227,7 +7227,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/deliveries/service.py",
       "source_location": "L10",
       "id": "deliveries_service_deliveriesmapper",
-      "community": 10,
+      "community": 9,
       "norm_label": "deliveriesmapper"
     },
     {
@@ -7236,7 +7236,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/deliveries/service.py",
       "source_location": "L14",
       "id": "deliveries_service_to_response",
-      "community": 1,
+      "community": 11,
       "norm_label": "to_response()"
     },
     {
@@ -7245,7 +7245,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/deliveries/service.py",
       "source_location": "L18",
       "id": "deliveries_service_deliveriesservice",
-      "community": 10,
+      "community": 9,
       "norm_label": "deliveriesservice"
     },
     {
@@ -7254,7 +7254,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/deliveries/service.py",
       "source_location": "L21",
       "id": "deliveries_service_deliveriesservice_init",
-      "community": 10,
+      "community": 9,
       "norm_label": ".__init__()"
     },
     {
@@ -7263,7 +7263,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/deliveries/service.py",
       "source_location": "L24",
       "id": "deliveries_service_deliveriesservice_get_by_date",
-      "community": 10,
+      "community": 9,
       "norm_label": ".get_by_date()"
     },
     {
@@ -7271,36 +7271,36 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/deliveries/service.py",
       "source_location": "L1",
-      "id": "deliveries_service_rationale_1",
-      "community": 10,
-      "norm_label": "service e mapper de entregas \u2014 agrupa pedidos do dia por tipo de entrega."
+      "community": 9,
+      "norm_label": "service e mapper de entregas \u2014 agrupa pedidos do dia por tipo de entrega.",
+      "id": "deliveries_service_rationale_1"
     },
     {
       "label": "Serializa DeliveriesSummary para dict JSON-ready.",
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/deliveries/service.py",
       "source_location": "L11",
-      "id": "deliveries_service_rationale_11",
-      "community": 10,
-      "norm_label": "serializa deliveriessummary para dict json-ready."
+      "community": 9,
+      "norm_label": "serializa deliveriessummary para dict json-ready.",
+      "id": "deliveries_service_rationale_11"
     },
     {
       "label": "Aplica regra de neg\u00f3cio sobre os pedidos do dia e retorna o resumo de entregas.",
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/deliveries/service.py",
       "source_location": "L19",
-      "id": "deliveries_service_rationale_19",
-      "community": 10,
-      "norm_label": "aplica regra de negocio sobre os pedidos do dia e retorna o resumo de entregas."
+      "community": 9,
+      "norm_label": "aplica regra de negocio sobre os pedidos do dia e retorna o resumo de entregas.",
+      "id": "deliveries_service_rationale_19"
     },
     {
       "label": "Retorna contagem de pedidos agrupada por tipo de entrega para a data informada.",
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/deliveries/service.py",
       "source_location": "L25",
-      "id": "deliveries_service_rationale_25",
-      "community": 10,
-      "norm_label": "retorna contagem de pedidos agrupada por tipo de entrega para a data informada."
+      "community": 9,
+      "norm_label": "retorna contagem de pedidos agrupada por tipo de entrega para a data informada.",
+      "id": "deliveries_service_rationale_25"
     },
     {
       "label": "models.py",
@@ -7308,7 +7308,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/deliveries/models.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_features_orders_subfeatures_deliveries_models_py",
-      "community": 10,
+      "community": 9,
       "norm_label": "models.py"
     },
     {
@@ -7317,7 +7317,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/deliveries/models.py",
       "source_location": "L7",
       "id": "deliveries_models_deliverytypecount",
-      "community": 10,
+      "community": 9,
       "norm_label": "deliverytypecount"
     },
     {
@@ -7326,7 +7326,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/deliveries/models.py",
       "source_location": "L13",
       "id": "deliveries_models_deliveriessummary",
-      "community": 10,
+      "community": 9,
       "norm_label": "deliveriessummary"
     },
     {
@@ -7334,9 +7334,9 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/deliveries/models.py",
       "source_location": "L1",
-      "id": "deliveries_models_rationale_1",
-      "community": 10,
-      "norm_label": "models de dominio da feature de entregas."
+      "community": 9,
+      "norm_label": "models de dominio da feature de entregas.",
+      "id": "deliveries_models_rationale_1"
     },
     {
       "label": "route.py",
@@ -7344,7 +7344,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/deliveries/route.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_features_orders_subfeatures_deliveries_route_py",
-      "community": 1,
+      "community": 11,
       "norm_label": "route.py"
     },
     {
@@ -7353,7 +7353,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/deliveries/route.py",
       "source_location": "L12",
       "id": "deliveries_route_get_deliveries",
-      "community": 1,
+      "community": 11,
       "norm_label": "get_deliveries()"
     },
     {
@@ -7361,9 +7361,9 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/deliveries/route.py",
       "source_location": "L1",
-      "id": "deliveries_route_rationale_1",
-      "community": 1,
-      "norm_label": "rota de entregas \u2014 get /orders/deliveries."
+      "community": 11,
+      "norm_label": "rota de entregas \u2014 get /orders/deliveries.",
+      "id": "deliveries_route_rationale_1"
     },
     {
       "label": "__init__.py",
@@ -7371,7 +7371,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/deliveries/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_features_orders_subfeatures_deliveries_init_py",
-      "community": 49,
+      "community": 54,
       "norm_label": "__init__.py"
     },
     {
@@ -7380,7 +7380,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/deliveries/repository.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_features_orders_subfeatures_deliveries_repository_py",
-      "community": 10,
+      "community": 9,
       "norm_label": "repository.py"
     },
     {
@@ -7389,7 +7389,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/deliveries/repository.py",
       "source_location": "L8",
       "id": "deliveries_repository_deliveriesrepository",
-      "community": 10,
+      "community": 9,
       "norm_label": "deliveriesrepository"
     },
     {
@@ -7398,7 +7398,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/deliveries/repository.py",
       "source_location": "L14",
       "id": "deliveries_repository_deliveriesrepository_get_by_date",
-      "community": 1,
+      "community": 11,
       "norm_label": ".get_by_date()"
     },
     {
@@ -7406,27 +7406,27 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/deliveries/repository.py",
       "source_location": "L1",
-      "id": "deliveries_repository_rationale_1",
-      "community": 10,
-      "norm_label": "repositorio de entregas \u2014 busca e prepara dados da planilha para o deliveriesser"
+      "community": 9,
+      "norm_label": "repositorio de entregas \u2014 busca e prepara dados da planilha para o deliveriesser",
+      "id": "deliveries_repository_rationale_1"
     },
     {
       "label": "Acessa o data source e entrega um DataFrame para o DeliveriesService.      N\u00e3o f",
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/deliveries/repository.py",
       "source_location": "L9",
-      "id": "deliveries_repository_rationale_9",
-      "community": 10,
-      "norm_label": "acessa o data source e entrega um dataframe para o deliveriesservice.      nao f"
+      "community": 9,
+      "norm_label": "acessa o data source e entrega um dataframe para o deliveriesservice.      nao f",
+      "id": "deliveries_repository_rationale_9"
     },
     {
       "label": "Retorna todos os pedidos de uma data como DataFrame bruto.",
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/deliveries/repository.py",
       "source_location": "L15",
-      "id": "deliveries_repository_rationale_15",
-      "community": 1,
-      "norm_label": "retorna todos os pedidos de uma data como dataframe bruto."
+      "community": 11,
+      "norm_label": "retorna todos os pedidos de uma data como dataframe bruto.",
+      "id": "deliveries_repository_rationale_15"
     },
     {
       "label": "service.py",
@@ -7434,7 +7434,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/sheet/service.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_features_sheet_service_py",
-      "community": 11,
+      "community": 10,
       "norm_label": "service.py"
     },
     {
@@ -7443,7 +7443,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/sheet/service.py",
       "source_location": "L6",
       "id": "sheet_service_sheetservice",
-      "community": 11,
+      "community": 10,
       "norm_label": "sheetservice"
     },
     {
@@ -7452,7 +7452,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/sheet/service.py",
       "source_location": "L7",
       "id": "sheet_service_sheetservice_select",
-      "community": 11,
+      "community": 10,
       "norm_label": ".select()"
     },
     {
@@ -7461,7 +7461,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/sheet/service.py",
       "source_location": "L10",
       "id": "sheet_service_sheetservice_remove",
-      "community": 11,
+      "community": 10,
       "norm_label": ".remove()"
     },
     {
@@ -7469,9 +7469,9 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/sheet/service.py",
       "source_location": "L1",
-      "id": "sheet_service_rationale_1",
-      "community": 11,
-      "norm_label": "service de planilha \u2014 gerencia a planilha ativa no datasource."
+      "community": 10,
+      "norm_label": "service de planilha \u2014 gerencia a planilha ativa no datasource.",
+      "id": "sheet_service_rationale_1"
     },
     {
       "label": "route.py",
@@ -7479,7 +7479,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/sheet/route.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_features_sheet_route_py",
-      "community": 11,
+      "community": 10,
       "norm_label": "route.py"
     },
     {
@@ -7488,7 +7488,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/sheet/route.py",
       "source_location": "L12",
       "id": "sheet_route_select_sheet",
-      "community": 11,
+      "community": 10,
       "norm_label": "select_sheet()"
     },
     {
@@ -7497,7 +7497,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/sheet/route.py",
       "source_location": "L18",
       "id": "sheet_route_remove_sheet",
-      "community": 11,
+      "community": 10,
       "norm_label": "remove_sheet()"
     },
     {
@@ -7506,7 +7506,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/sheet/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_features_sheet_init_py",
-      "community": 11,
+      "community": 10,
       "norm_label": "__init__.py"
     },
     {
@@ -7515,7 +7515,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/utils/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_utils_init_py",
-      "community": 16,
+      "community": 19,
       "norm_label": "__init__.py"
     },
     {
@@ -7524,7 +7524,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/utils/numbers.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_utils_numbers_py",
-      "community": 16,
+      "community": 19,
       "norm_label": "numbers.py"
     },
     {
@@ -7533,7 +7533,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/utils/numbers.py",
       "source_location": "L4",
       "id": "utils_numbers_normalize_decimal",
-      "community": 16,
+      "community": 19,
       "norm_label": "normalize_decimal()"
     },
     {
@@ -7541,18 +7541,18 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/utils/numbers.py",
       "source_location": "L1",
-      "id": "utils_numbers_rationale_1",
-      "community": 16,
-      "norm_label": "utilitarios de formatacao numerica."
+      "community": 19,
+      "norm_label": "utilitarios de formatacao numerica.",
+      "id": "utils_numbers_rationale_1"
     },
     {
       "label": "Converte n\u00famero no formato brasileiro para o formato ingl\u00eas.      Remove o separ",
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/utils/numbers.py",
       "source_location": "L5",
-      "id": "utils_numbers_rationale_5",
-      "community": 16,
-      "norm_label": "converte numero no formato brasileiro para o formato ingles.      remove o separ"
+      "community": 19,
+      "norm_label": "converte numero no formato brasileiro para o formato ingles.      remove o separ",
+      "id": "utils_numbers_rationale_5"
     },
     {
       "label": "_errors.py",
@@ -7560,7 +7560,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/errors/_errors.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_errors_errors_py",
-      "community": 14,
+      "community": 17,
       "norm_label": "_errors.py"
     },
     {
@@ -7569,7 +7569,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/errors/_errors.py",
       "source_location": "L1",
       "id": "errors_errors_backenderror",
-      "community": 14,
+      "community": 17,
       "norm_label": "backenderror"
     },
     {
@@ -7578,7 +7578,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/errors/_errors.py",
       "source_location": "L7",
       "id": "errors_errors_backenderror_to_dict",
-      "community": 14,
+      "community": 17,
       "norm_label": ".to_dict()"
     },
     {
@@ -7587,7 +7587,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/errors/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_errors_init_py",
-      "community": 14,
+      "community": 17,
       "norm_label": "__init__.py"
     },
     {
@@ -7596,7 +7596,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/errors/_mapper.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_errors_mapper_py",
-      "community": 14,
+      "community": 17,
       "norm_label": "_mapper.py"
     },
     {
@@ -7605,7 +7605,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/errors/_mapper.py",
       "source_location": "L26",
       "id": "errors_mapper_translate",
-      "community": 14,
+      "community": 17,
       "norm_label": "translate()"
     },
     {
@@ -7614,7 +7614,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/errors/_mapper.py",
       "source_location": "L35",
       "id": "errors_mapper_generic_mapper",
-      "community": 14,
+      "community": 17,
       "norm_label": "generic_mapper()"
     },
     {
@@ -7623,7 +7623,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/assets/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_assets_init_py",
-      "community": 50,
+      "community": 55,
       "norm_label": "__init__.py"
     },
     {
@@ -7632,7 +7632,7 @@
       "source_file": "assets/strings.py",
       "source_location": "L1",
       "id": "assets_strings_py",
-      "community": 51,
+      "community": 56,
       "norm_label": "strings.py"
     }
   ],
@@ -7680,8 +7680,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/alerts/dialog.py",
       "source_location": "L32",
       "weight": 1.0,
-      "_src": "alerts_dialog_dsdialog_setup_ui",
-      "_tgt": "maria_cacau_init_asset",
+      "_src": "maria_cacau_init_asset",
+      "_tgt": "alerts_dialog_dsdialog_setup_ui",
       "source": "maria_cacau_init_asset",
       "target": "alerts_dialog_dsdialog_setup_ui"
     },
@@ -8136,8 +8136,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/_observability.py",
       "source_location": "L25",
       "weight": 1.0,
-      "_src": "network_observability_track",
-      "_tgt": "core_observability_observability_log",
+      "_src": "core_observability_observability_log",
+      "_tgt": "network_observability_track",
       "source": "core_observability_observability_log",
       "target": "network_observability_track"
     },
@@ -8148,8 +8148,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/app/coordinator.py",
       "source_location": "L39",
       "weight": 1.0,
-      "_src": "app_coordinator_appcoordinator_initialize",
-      "_tgt": "core_observability_observability_log",
+      "_src": "core_observability_observability_log",
+      "_tgt": "app_coordinator_appcoordinator_initialize",
       "source": "core_observability_observability_log",
       "target": "app_coordinator_appcoordinator_initialize"
     },
@@ -8160,8 +8160,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/app/coordinator.py",
       "source_location": "L47",
       "weight": 1.0,
-      "_src": "app_coordinator_appcoordinator_on_quit",
-      "_tgt": "core_observability_observability_log",
+      "_src": "core_observability_observability_log",
+      "_tgt": "app_coordinator_appcoordinator_on_quit",
       "source": "core_observability_observability_log",
       "target": "app_coordinator_appcoordinator_on_quit"
     },
@@ -8172,8 +8172,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/presentation/controller.py",
       "source_location": "L40",
       "weight": 1.0,
-      "_src": "presentation_controller_deliverycontroller_on_generate_report",
-      "_tgt": "core_observability_observability_log",
+      "_src": "core_observability_observability_log",
+      "_tgt": "presentation_controller_deliverycontroller_on_generate_report",
       "source": "core_observability_observability_log",
       "target": "presentation_controller_deliverycontroller_on_generate_report"
     },
@@ -8184,8 +8184,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/presentation/controller.py",
       "source_location": "L43",
       "weight": 1.0,
-      "_src": "presentation_controller_deliverycontroller_on_copy_report",
-      "_tgt": "core_observability_observability_log",
+      "_src": "core_observability_observability_log",
+      "_tgt": "presentation_controller_deliverycontroller_on_copy_report",
       "source": "core_observability_observability_log",
       "target": "presentation_controller_deliverycontroller_on_copy_report"
     },
@@ -8196,8 +8196,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/presentation/controller.py",
       "source_location": "L46",
       "weight": 1.0,
-      "_src": "presentation_controller_deliverycontroller_on_copy_graph",
-      "_tgt": "core_observability_observability_log",
+      "_src": "core_observability_observability_log",
+      "_tgt": "presentation_controller_deliverycontroller_on_copy_graph",
       "source": "core_observability_observability_log",
       "target": "presentation_controller_deliverycontroller_on_copy_graph"
     },
@@ -8208,8 +8208,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/presentation/controller.py",
       "source_location": "L49",
       "weight": 1.0,
-      "_src": "presentation_controller_deliverycontroller_on_download_graph",
-      "_tgt": "core_observability_observability_log",
+      "_src": "core_observability_observability_log",
+      "_tgt": "presentation_controller_deliverycontroller_on_download_graph",
       "source": "core_observability_observability_log",
       "target": "presentation_controller_deliverycontroller_on_download_graph"
     },
@@ -8220,8 +8220,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/presentation/controller.py",
       "source_location": "L62",
       "weight": 1.0,
-      "_src": "presentation_controller_deliverycontroller_handle_report_generated",
-      "_tgt": "core_observability_observability_log",
+      "_src": "core_observability_observability_log",
+      "_tgt": "presentation_controller_deliverycontroller_handle_report_generated",
       "source": "core_observability_observability_log",
       "target": "presentation_controller_deliverycontroller_handle_report_generated"
     },
@@ -8232,8 +8232,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/presentation/controller.py",
       "source_location": "L38",
       "weight": 1.0,
-      "_src": "presentation_controller_summarycontroller_on_generate_report",
-      "_tgt": "core_observability_observability_log",
+      "_src": "core_observability_observability_log",
+      "_tgt": "presentation_controller_summarycontroller_on_generate_report",
       "source": "core_observability_observability_log",
       "target": "presentation_controller_summarycontroller_on_generate_report"
     },
@@ -8244,8 +8244,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/presentation/controller.py",
       "source_location": "L41",
       "weight": 1.0,
-      "_src": "presentation_controller_summarycontroller_on_copy_report",
-      "_tgt": "core_observability_observability_log",
+      "_src": "core_observability_observability_log",
+      "_tgt": "presentation_controller_summarycontroller_on_copy_report",
       "source": "core_observability_observability_log",
       "target": "presentation_controller_summarycontroller_on_copy_report"
     },
@@ -8256,8 +8256,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/presentation/controller.py",
       "source_location": "L44",
       "weight": 1.0,
-      "_src": "presentation_controller_summarycontroller_on_copy_graph",
-      "_tgt": "core_observability_observability_log",
+      "_src": "core_observability_observability_log",
+      "_tgt": "presentation_controller_summarycontroller_on_copy_graph",
       "source": "core_observability_observability_log",
       "target": "presentation_controller_summarycontroller_on_copy_graph"
     },
@@ -8268,8 +8268,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/presentation/controller.py",
       "source_location": "L47",
       "weight": 1.0,
-      "_src": "presentation_controller_summarycontroller_on_download_graph",
-      "_tgt": "core_observability_observability_log",
+      "_src": "core_observability_observability_log",
+      "_tgt": "presentation_controller_summarycontroller_on_download_graph",
       "source": "core_observability_observability_log",
       "target": "presentation_controller_summarycontroller_on_download_graph"
     },
@@ -8280,8 +8280,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/presentation/controller.py",
       "source_location": "L50",
       "weight": 1.0,
-      "_src": "presentation_controller_summarycontroller_on_change_chart_type",
-      "_tgt": "core_observability_observability_log",
+      "_src": "core_observability_observability_log",
+      "_tgt": "presentation_controller_summarycontroller_on_change_chart_type",
       "source": "core_observability_observability_log",
       "target": "presentation_controller_summarycontroller_on_change_chart_type"
     },
@@ -8292,8 +8292,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/presentation/controller.py",
       "source_location": "L61",
       "weight": 1.0,
-      "_src": "presentation_controller_summarycontroller_handle_report_generated",
-      "_tgt": "core_observability_observability_log",
+      "_src": "core_observability_observability_log",
+      "_tgt": "presentation_controller_summarycontroller_handle_report_generated",
       "source": "core_observability_observability_log",
       "target": "presentation_controller_summarycontroller_handle_report_generated"
     },
@@ -8304,8 +8304,8 @@
       "source_file": "features/sheets/presentation/controller.py",
       "source_location": "L101",
       "weight": 1.0,
-      "_src": "presentation_controller_sheetscontroller_on_renamed",
-      "_tgt": "core_observability_observability_log",
+      "_src": "core_observability_observability_log",
+      "_tgt": "presentation_controller_sheetscontroller_on_renamed",
       "source": "core_observability_observability_log",
       "target": "presentation_controller_sheetscontroller_on_renamed"
     },
@@ -8316,8 +8316,8 @@
       "source_file": "features/sheets/presentation/controller.py",
       "source_location": "L105",
       "weight": 1.0,
-      "_src": "presentation_controller_sheetscontroller_on_removed",
-      "_tgt": "core_observability_observability_log",
+      "_src": "core_observability_observability_log",
+      "_tgt": "presentation_controller_sheetscontroller_on_removed",
       "source": "core_observability_observability_log",
       "target": "presentation_controller_sheetscontroller_on_removed"
     },
@@ -8328,8 +8328,8 @@
       "source_file": "features/sheets/presentation/controller.py",
       "source_location": "L110",
       "weight": 1.0,
-      "_src": "presentation_controller_sheetscontroller_on_connected",
-      "_tgt": "core_observability_observability_log",
+      "_src": "core_observability_observability_log",
+      "_tgt": "presentation_controller_sheetscontroller_on_connected",
       "source": "core_observability_observability_log",
       "target": "presentation_controller_sheetscontroller_on_connected"
     },
@@ -8340,8 +8340,8 @@
       "source_file": "features/sheets/presentation/controller.py",
       "source_location": "L114",
       "weight": 1.0,
-      "_src": "presentation_controller_sheetscontroller_on_selected",
-      "_tgt": "core_observability_observability_log",
+      "_src": "core_observability_observability_log",
+      "_tgt": "presentation_controller_sheetscontroller_on_selected",
       "source": "core_observability_observability_log",
       "target": "presentation_controller_sheetscontroller_on_selected"
     },
@@ -8352,8 +8352,8 @@
       "source_file": "features/sheets/presentation/controller.py",
       "source_location": "L118",
       "weight": 1.0,
-      "_src": "presentation_controller_sheetscontroller_on_error",
-      "_tgt": "core_observability_observability_log",
+      "_src": "core_observability_observability_log",
+      "_tgt": "presentation_controller_sheetscontroller_on_error",
       "source": "core_observability_observability_log",
       "target": "presentation_controller_sheetscontroller_on_error"
     },
@@ -8364,8 +8364,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/presentation/controller.py",
       "source_location": "L50",
       "weight": 1.0,
-      "_src": "presentation_controller_authcontroller_on_configured",
-      "_tgt": "core_observability_observability_log",
+      "_src": "core_observability_observability_log",
+      "_tgt": "presentation_controller_authcontroller_on_configured",
       "source": "core_observability_observability_log",
       "target": "presentation_controller_authcontroller_on_configured"
     },
@@ -8376,8 +8376,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/presentation/controller.py",
       "source_location": "L53",
       "weight": 1.0,
-      "_src": "presentation_controller_authcontroller_on_cleared",
-      "_tgt": "core_observability_observability_log",
+      "_src": "core_observability_observability_log",
+      "_tgt": "presentation_controller_authcontroller_on_cleared",
       "source": "core_observability_observability_log",
       "target": "presentation_controller_authcontroller_on_cleared"
     },
@@ -8388,8 +8388,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/presentation/controller.py",
       "source_location": "L57",
       "weight": 1.0,
-      "_src": "presentation_controller_authcontroller_on_error",
-      "_tgt": "core_observability_observability_log",
+      "_src": "core_observability_observability_log",
+      "_tgt": "presentation_controller_authcontroller_on_error",
       "source": "core_observability_observability_log",
       "target": "presentation_controller_authcontroller_on_error"
     },
@@ -8400,8 +8400,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/presentation/controller.py",
       "source_location": "L26",
       "weight": 1.0,
-      "_src": "presentation_controller_cpfvalidationcontroller_on_validate",
-      "_tgt": "core_observability_observability_log",
+      "_src": "core_observability_observability_log",
+      "_tgt": "presentation_controller_cpfvalidationcontroller_on_validate",
       "source": "core_observability_observability_log",
       "target": "presentation_controller_cpfvalidationcontroller_on_validate"
     },
@@ -8412,8 +8412,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/presentation/controller.py",
       "source_location": "L31",
       "weight": 1.0,
-      "_src": "presentation_controller_cpfvalidationcontroller_handle_result",
-      "_tgt": "core_observability_observability_log",
+      "_src": "core_observability_observability_log",
+      "_tgt": "presentation_controller_cpfvalidationcontroller_handle_result",
       "source": "core_observability_observability_log",
       "target": "presentation_controller_cpfvalidationcontroller_handle_result"
     },
@@ -8468,7 +8468,7 @@
     {
       "relation": "inherits",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/domain/signals.py",
+      "source_file": "features/sheets/domain/signals.py",
       "source_location": "L6",
       "weight": 1.0,
       "_src": "domain_signals_sheetssignals",
@@ -8480,7 +8480,7 @@
     {
       "relation": "inherits",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/domain/signals.py",
+      "source_file": "features/auth/domain/signals.py",
       "source_location": "L8",
       "weight": 1.0,
       "_src": "domain_signals_authsignals",
@@ -8748,8 +8748,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/_config.py",
       "source_location": "L34",
       "weight": 1.0,
-      "_src": "network_config_get_client",
-      "_tgt": "network_errors_networknotconfigurederror",
+      "_src": "network_errors_networknotconfigurederror",
+      "_tgt": "network_config_get_client",
       "source": "network_errors_networknotconfigurederror",
       "target": "network_config_get_client"
     },
@@ -8832,8 +8832,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/api.py",
       "source_location": "L29",
       "weight": 1.0,
-      "_src": "network_api_call",
-      "_tgt": "network_errors_httpresponseerror",
+      "_src": "network_errors_httpresponseerror",
+      "_tgt": "network_api_call",
       "source": "network_errors_httpresponseerror",
       "target": "network_api_call"
     },
@@ -9035,11 +9035,11 @@
       "source_file": "core/network/_client.py",
       "source_location": "L8",
       "weight": 0.8,
-      "_src": "network_client_httpclientcontract",
-      "_tgt": "network_response_httpresponse",
+      "_src": "network_response_httpresponse",
+      "_tgt": "network_client_httpclientcontract",
+      "confidence_score": 0.5,
       "source": "network_response_httpresponse",
-      "target": "network_client_httpclientcontract",
-      "confidence_score": 0.5
+      "target": "network_client_httpclientcontract"
     },
     {
       "relation": "uses",
@@ -9047,11 +9047,11 @@
       "source_file": "core/network/_client.py",
       "source_location": "L8",
       "weight": 0.8,
-      "_src": "network_client_localclient",
-      "_tgt": "network_response_httpresponse",
+      "_src": "network_response_httpresponse",
+      "_tgt": "network_client_localclient",
+      "confidence_score": 0.5,
       "source": "network_response_httpresponse",
-      "target": "network_client_localclient",
-      "confidence_score": 0.5
+      "target": "network_client_localclient"
     },
     {
       "relation": "uses",
@@ -9059,11 +9059,11 @@
       "source_file": "core/network/_client.py",
       "source_location": "L8",
       "weight": 0.8,
-      "_src": "network_client_rationale_1",
-      "_tgt": "network_response_httpresponse",
+      "_src": "network_response_httpresponse",
+      "_tgt": "network_client_rationale_1",
+      "confidence_score": 0.5,
       "source": "network_response_httpresponse",
-      "target": "network_client_rationale_1",
-      "confidence_score": 0.5
+      "target": "network_client_rationale_1"
     },
     {
       "relation": "uses",
@@ -9071,11 +9071,11 @@
       "source_file": "core/network/_client.py",
       "source_location": "L8",
       "weight": 0.8,
-      "_src": "network_client_rationale_14",
-      "_tgt": "network_response_httpresponse",
+      "_src": "network_response_httpresponse",
+      "_tgt": "network_client_rationale_14",
+      "confidence_score": 0.5,
       "source": "network_response_httpresponse",
-      "target": "network_client_rationale_14",
-      "confidence_score": 0.5
+      "target": "network_client_rationale_14"
     },
     {
       "relation": "uses",
@@ -9083,11 +9083,11 @@
       "source_file": "core/network/_client.py",
       "source_location": "L8",
       "weight": 0.8,
-      "_src": "network_client_rationale_21",
-      "_tgt": "network_response_httpresponse",
+      "_src": "network_response_httpresponse",
+      "_tgt": "network_client_rationale_21",
+      "confidence_score": 0.5,
       "source": "network_response_httpresponse",
-      "target": "network_client_rationale_21",
-      "confidence_score": 0.5
+      "target": "network_client_rationale_21"
     },
     {
       "relation": "calls",
@@ -9096,8 +9096,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/_server.py",
       "source_location": "L42",
       "weight": 1.0,
-      "_src": "backend_server_backendserver_execute",
-      "_tgt": "network_response_httpresponse",
+      "_src": "network_response_httpresponse",
+      "_tgt": "backend_server_backendserver_execute",
       "source": "network_response_httpresponse",
       "target": "backend_server_backendserver_execute"
     },
@@ -9120,8 +9120,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/api.py",
       "source_location": "L35",
       "weight": 1.0,
-      "_src": "network_api_entity",
-      "_tgt": "network_response_httpresponse_json",
+      "_src": "network_response_httpresponse_json",
+      "_tgt": "network_api_entity",
       "source": "network_response_httpresponse_json",
       "target": "network_api_entity"
     },
@@ -9132,8 +9132,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/data/mapper.py",
       "source_location": "L14",
       "weight": 1.0,
-      "_src": "data_mapper_from_response",
-      "_tgt": "network_response_httpresponse_json",
+      "_src": "network_response_httpresponse_json",
+      "_tgt": "data_mapper_from_response",
       "source": "network_response_httpresponse_json",
       "target": "data_mapper_from_response"
     },
@@ -9227,11 +9227,11 @@
       "source_file": "core/network/_client.py",
       "source_location": "L7",
       "weight": 0.8,
-      "_src": "network_client_httpclientcontract",
-      "_tgt": "network_request_httprequest",
+      "_src": "network_request_httprequest",
+      "_tgt": "network_client_httpclientcontract",
+      "confidence_score": 0.5,
       "source": "network_request_httprequest",
-      "target": "network_client_httpclientcontract",
-      "confidence_score": 0.5
+      "target": "network_client_httpclientcontract"
     },
     {
       "relation": "uses",
@@ -9239,11 +9239,11 @@
       "source_file": "core/network/_client.py",
       "source_location": "L7",
       "weight": 0.8,
-      "_src": "network_client_localclient",
-      "_tgt": "network_request_httprequest",
+      "_src": "network_request_httprequest",
+      "_tgt": "network_client_localclient",
+      "confidence_score": 0.5,
       "source": "network_request_httprequest",
-      "target": "network_client_localclient",
-      "confidence_score": 0.5
+      "target": "network_client_localclient"
     },
     {
       "relation": "uses",
@@ -9251,11 +9251,11 @@
       "source_file": "core/network/_client.py",
       "source_location": "L7",
       "weight": 0.8,
-      "_src": "network_client_rationale_1",
-      "_tgt": "network_request_httprequest",
+      "_src": "network_request_httprequest",
+      "_tgt": "network_client_rationale_1",
+      "confidence_score": 0.5,
       "source": "network_request_httprequest",
-      "target": "network_client_rationale_1",
-      "confidence_score": 0.5
+      "target": "network_client_rationale_1"
     },
     {
       "relation": "uses",
@@ -9263,11 +9263,11 @@
       "source_file": "core/network/_client.py",
       "source_location": "L7",
       "weight": 0.8,
-      "_src": "network_client_rationale_14",
-      "_tgt": "network_request_httprequest",
+      "_src": "network_request_httprequest",
+      "_tgt": "network_client_rationale_14",
+      "confidence_score": 0.5,
       "source": "network_request_httprequest",
-      "target": "network_client_rationale_14",
-      "confidence_score": 0.5
+      "target": "network_client_rationale_14"
     },
     {
       "relation": "uses",
@@ -9275,11 +9275,11 @@
       "source_file": "core/network/_client.py",
       "source_location": "L7",
       "weight": 0.8,
-      "_src": "network_client_rationale_21",
-      "_tgt": "network_request_httprequest",
+      "_src": "network_request_httprequest",
+      "_tgt": "network_client_rationale_21",
+      "confidence_score": 0.5,
       "source": "network_request_httprequest",
-      "target": "network_client_rationale_21",
-      "confidence_score": 0.5
+      "target": "network_client_rationale_21"
     },
     {
       "relation": "calls",
@@ -9288,8 +9288,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/api.py",
       "source_location": "L17",
       "weight": 1.0,
-      "_src": "network_api_api_init",
-      "_tgt": "network_request_httprequest",
+      "_src": "network_request_httprequest",
+      "_tgt": "network_api_api_init",
       "source": "network_request_httprequest",
       "target": "network_api_api_init"
     },
@@ -9468,8 +9468,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/data/repository.py",
       "source_location": "L16",
       "weight": 1.0,
-      "_src": "data_repository_ordersrepository_get_deliveries",
-      "_tgt": "network_api_call",
+      "_src": "network_api_call",
+      "_tgt": "data_repository_ordersrepository_get_deliveries",
       "source": "network_api_call",
       "target": "data_repository_ordersrepository_get_deliveries"
     },
@@ -9480,8 +9480,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/data/repository.py",
       "source_location": "L26",
       "weight": 1.0,
-      "_src": "data_repository_ordersrepository_get_pendent_payments",
-      "_tgt": "network_api_call",
+      "_src": "network_api_call",
+      "_tgt": "data_repository_ordersrepository_get_pendent_payments",
       "source": "network_api_call",
       "target": "data_repository_ordersrepository_get_pendent_payments"
     },
@@ -9492,8 +9492,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/data/repository.py",
       "source_location": "L16",
       "weight": 1.0,
-      "_src": "data_repository_summaryrepository_get_by_period",
-      "_tgt": "network_api_call",
+      "_src": "network_api_call",
+      "_tgt": "data_repository_summaryrepository_get_by_period",
       "source": "network_api_call",
       "target": "data_repository_summaryrepository_get_by_period"
     },
@@ -9504,8 +9504,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/data/repository.py",
       "source_location": "L37",
       "weight": 1.0,
-      "_src": "data_repository_sheetsrepository_connect",
-      "_tgt": "network_api_call",
+      "_src": "network_api_call",
+      "_tgt": "data_repository_sheetsrepository_connect",
       "source": "network_api_call",
       "target": "data_repository_sheetsrepository_connect"
     },
@@ -9516,8 +9516,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/data/repository.py",
       "source_location": "L42",
       "weight": 1.0,
-      "_src": "data_repository_sheetsrepository_select",
-      "_tgt": "network_api_call",
+      "_src": "network_api_call",
+      "_tgt": "data_repository_sheetsrepository_select",
       "source": "network_api_call",
       "target": "data_repository_sheetsrepository_select"
     },
@@ -9528,8 +9528,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/data/repository.py",
       "source_location": "L64",
       "weight": 1.0,
-      "_src": "data_repository_sheetsrepository_remove",
-      "_tgt": "network_api_call",
+      "_src": "network_api_call",
+      "_tgt": "data_repository_sheetsrepository_remove",
       "source": "network_api_call",
       "target": "data_repository_sheetsrepository_remove"
     },
@@ -9540,8 +9540,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/data/repository.py",
       "source_location": "L19",
       "weight": 1.0,
-      "_src": "data_repository_authrepository_configure",
-      "_tgt": "network_api_call",
+      "_src": "network_api_call",
+      "_tgt": "data_repository_authrepository_configure",
       "source": "network_api_call",
       "target": "data_repository_authrepository_configure"
     },
@@ -9552,8 +9552,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/data/repository.py",
       "source_location": "L27",
       "weight": 1.0,
-      "_src": "data_repository_authrepository_pre_login",
-      "_tgt": "network_api_call",
+      "_src": "network_api_call",
+      "_tgt": "data_repository_authrepository_pre_login",
       "source": "network_api_call",
       "target": "data_repository_authrepository_pre_login"
     },
@@ -9564,8 +9564,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/data/repository.py",
       "source_location": "L38",
       "weight": 1.0,
-      "_src": "data_repository_authrepository_clear",
-      "_tgt": "network_api_call",
+      "_src": "network_api_call",
+      "_tgt": "data_repository_authrepository_clear",
       "source": "network_api_call",
       "target": "data_repository_authrepository_clear"
     },
@@ -9696,8 +9696,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/app/coordinator.py",
       "source_location": "L25",
       "weight": 1.0,
-      "_src": "app_coordinator_appcoordinator_launch",
-      "_tgt": "network_client_localclient",
+      "_src": "network_client_localclient",
+      "_tgt": "app_coordinator_appcoordinator_launch",
       "source": "network_client_localclient",
       "target": "app_coordinator_appcoordinator_launch"
     },
@@ -10176,8 +10176,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/data/repository.py",
       "source_location": "L34",
       "weight": 1.0,
-      "_src": "data_repository_sheetsrepository_connect",
-      "_tgt": "storage_cache_cachestorage_save",
+      "_src": "storage_cache_cachestorage_save",
+      "_tgt": "data_repository_sheetsrepository_connect",
       "source": "storage_cache_cachestorage_save",
       "target": "data_repository_sheetsrepository_connect"
     },
@@ -10188,8 +10188,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/data/repository.py",
       "source_location": "L61",
       "weight": 1.0,
-      "_src": "data_repository_sheetsrepository_remove",
-      "_tgt": "storage_cache_cachestorage_save",
+      "_src": "storage_cache_cachestorage_save",
+      "_tgt": "data_repository_sheetsrepository_remove",
       "source": "storage_cache_cachestorage_save",
       "target": "data_repository_sheetsrepository_remove"
     },
@@ -10200,8 +10200,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/data/repository.py",
       "source_location": "L74",
       "weight": 1.0,
-      "_src": "data_repository_sheetsrepository_update_name",
-      "_tgt": "storage_cache_cachestorage_save",
+      "_src": "storage_cache_cachestorage_save",
+      "_tgt": "data_repository_sheetsrepository_update_name",
       "source": "storage_cache_cachestorage_save",
       "target": "data_repository_sheetsrepository_update_name"
     },
@@ -10212,8 +10212,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/data/repository.py",
       "source_location": "L20",
       "weight": 1.0,
-      "_src": "data_repository_authrepository_configure",
-      "_tgt": "storage_cache_cachestorage_save",
+      "_src": "storage_cache_cachestorage_save",
+      "_tgt": "data_repository_authrepository_configure",
       "source": "storage_cache_cachestorage_save",
       "target": "data_repository_authrepository_configure"
     },
@@ -10236,8 +10236,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/data/repository.py",
       "source_location": "L83",
       "weight": 1.0,
-      "_src": "data_repository_sheetsrepository_load_raw",
-      "_tgt": "storage_cache_cachestorage_retrieve",
+      "_src": "storage_cache_cachestorage_retrieve",
+      "_tgt": "data_repository_sheetsrepository_load_raw",
       "source": "storage_cache_cachestorage_retrieve",
       "target": "data_repository_sheetsrepository_load_raw"
     },
@@ -10248,8 +10248,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/data/repository.py",
       "source_location": "L31",
       "weight": 1.0,
-      "_src": "data_repository_authrepository_read_credentials",
-      "_tgt": "storage_cache_cachestorage_retrieve",
+      "_src": "storage_cache_cachestorage_retrieve",
+      "_tgt": "data_repository_authrepository_read_credentials",
       "source": "storage_cache_cachestorage_retrieve",
       "target": "data_repository_authrepository_read_credentials"
     },
@@ -10272,8 +10272,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/data/repository.py",
       "source_location": "L36",
       "weight": 1.0,
-      "_src": "data_repository_authrepository_clear",
-      "_tgt": "storage_cache_cachestorage_delete",
+      "_src": "storage_cache_cachestorage_delete",
+      "_tgt": "data_repository_authrepository_clear",
       "source": "storage_cache_cachestorage_delete",
       "target": "data_repository_authrepository_clear"
     },
@@ -10380,8 +10380,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/presentation/controller.py",
       "source_location": "L54",
       "weight": 1.0,
-      "_src": "presentation_controller_deliverycontroller_handle_error",
-      "_tgt": "error_models_errormodel_to_popup",
+      "_src": "error_models_errormodel_to_popup",
+      "_tgt": "presentation_controller_deliverycontroller_handle_error",
       "source": "error_models_errormodel_to_popup",
       "target": "presentation_controller_deliverycontroller_handle_error"
     },
@@ -10392,8 +10392,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/presentation/controller.py",
       "source_location": "L55",
       "weight": 1.0,
-      "_src": "presentation_controller_summarycontroller_handle_error",
-      "_tgt": "error_models_errormodel_to_popup",
+      "_src": "error_models_errormodel_to_popup",
+      "_tgt": "presentation_controller_summarycontroller_handle_error",
       "source": "error_models_errormodel_to_popup",
       "target": "presentation_controller_summarycontroller_handle_error"
     },
@@ -10404,8 +10404,8 @@
       "source_file": "features/sheets/presentation/controller.py",
       "source_location": "L117",
       "weight": 1.0,
-      "_src": "presentation_controller_sheetscontroller_on_error",
-      "_tgt": "error_models_errormodel_to_popup",
+      "_src": "error_models_errormodel_to_popup",
+      "_tgt": "presentation_controller_sheetscontroller_on_error",
       "source": "error_models_errormodel_to_popup",
       "target": "presentation_controller_sheetscontroller_on_error"
     },
@@ -10416,8 +10416,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/presentation/controller.py",
       "source_location": "L56",
       "weight": 1.0,
-      "_src": "presentation_controller_authcontroller_on_error",
-      "_tgt": "error_models_errormodel_to_popup",
+      "_src": "error_models_errormodel_to_popup",
+      "_tgt": "presentation_controller_authcontroller_on_error",
       "source": "error_models_errormodel_to_popup",
       "target": "presentation_controller_authcontroller_on_error"
     },
@@ -10668,8 +10668,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/presentation/viewmodel.py",
       "source_location": "L29",
       "weight": 1.0,
-      "_src": "presentation_viewmodel_deliveryviewmodel_fetch",
-      "_tgt": "error_errors_unexpected_error",
+      "_src": "error_errors_unexpected_error",
+      "_tgt": "presentation_viewmodel_deliveryviewmodel_fetch",
       "source": "error_errors_unexpected_error",
       "target": "presentation_viewmodel_deliveryviewmodel_fetch"
     },
@@ -10680,8 +10680,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/presentation/viewmodel.py",
       "source_location": "L30",
       "weight": 1.0,
-      "_src": "presentation_viewmodel_summaryviewmodel_fetch",
-      "_tgt": "error_errors_unexpected_error",
+      "_src": "error_errors_unexpected_error",
+      "_tgt": "presentation_viewmodel_summaryviewmodel_fetch",
       "source": "error_errors_unexpected_error",
       "target": "presentation_viewmodel_summaryviewmodel_fetch"
     },
@@ -10692,8 +10692,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/presentation/viewmodel.py",
       "source_location": "L34",
       "weight": 1.0,
-      "_src": "presentation_viewmodel_sheetsviewmodel_update_name",
-      "_tgt": "error_errors_unexpected_error",
+      "_src": "error_errors_unexpected_error",
+      "_tgt": "presentation_viewmodel_sheetsviewmodel_update_name",
       "source": "error_errors_unexpected_error",
       "target": "presentation_viewmodel_sheetsviewmodel_update_name"
     },
@@ -10704,8 +10704,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/presentation/viewmodel.py",
       "source_location": "L46",
       "weight": 1.0,
-      "_src": "presentation_viewmodel_sheetsviewmodel_connect",
-      "_tgt": "error_errors_unexpected_error",
+      "_src": "error_errors_unexpected_error",
+      "_tgt": "presentation_viewmodel_sheetsviewmodel_connect",
       "source": "error_errors_unexpected_error",
       "target": "presentation_viewmodel_sheetsviewmodel_connect"
     },
@@ -10716,8 +10716,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/presentation/viewmodel.py",
       "source_location": "L57",
       "weight": 1.0,
-      "_src": "presentation_viewmodel_sheetsviewmodel_select",
-      "_tgt": "error_errors_unexpected_error",
+      "_src": "error_errors_unexpected_error",
+      "_tgt": "presentation_viewmodel_sheetsviewmodel_select",
       "source": "error_errors_unexpected_error",
       "target": "presentation_viewmodel_sheetsviewmodel_select"
     },
@@ -10728,8 +10728,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/presentation/viewmodel.py",
       "source_location": "L67",
       "weight": 1.0,
-      "_src": "presentation_viewmodel_sheetsviewmodel_remove",
-      "_tgt": "error_errors_unexpected_error",
+      "_src": "error_errors_unexpected_error",
+      "_tgt": "presentation_viewmodel_sheetsviewmodel_remove",
       "source": "error_errors_unexpected_error",
       "target": "presentation_viewmodel_sheetsviewmodel_remove"
     },
@@ -10740,8 +10740,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/presentation/viewmodel.py",
       "source_location": "L26",
       "weight": 1.0,
-      "_src": "presentation_viewmodel_authviewmodel_configure",
-      "_tgt": "error_errors_unexpected_error",
+      "_src": "error_errors_unexpected_error",
+      "_tgt": "presentation_viewmodel_authviewmodel_configure",
       "source": "error_errors_unexpected_error",
       "target": "presentation_viewmodel_authviewmodel_configure"
     },
@@ -10752,8 +10752,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/presentation/viewmodel.py",
       "source_location": "L37",
       "weight": 1.0,
-      "_src": "presentation_viewmodel_authviewmodel_clear",
-      "_tgt": "error_errors_unexpected_error",
+      "_src": "error_errors_unexpected_error",
+      "_tgt": "presentation_viewmodel_authviewmodel_clear",
       "source": "error_errors_unexpected_error",
       "target": "presentation_viewmodel_authviewmodel_clear"
     },
@@ -10788,8 +10788,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/data/mapper.py",
       "source_location": "L16",
       "weight": 1.0,
-      "_src": "data_mapper_from_response",
-      "_tgt": "error_errors_http_error",
+      "_src": "error_errors_http_error",
+      "_tgt": "data_mapper_from_response",
       "source": "error_errors_http_error",
       "target": "data_mapper_from_response"
     },
@@ -11076,8 +11076,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/app/window.py",
       "source_location": "L14",
       "weight": 1.0,
-      "_src": "app_window_mainwindow_init",
-      "_tgt": "app_handler_menuhandler",
+      "_src": "app_handler_menuhandler",
+      "_tgt": "app_window_mainwindow_init",
       "source": "app_handler_menuhandler",
       "target": "app_window_mainwindow_init"
     },
@@ -11148,8 +11148,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/app/window.py",
       "source_location": "L34",
       "weight": 1.0,
-      "_src": "app_window_mainwindow_setup_menus",
-      "_tgt": "app_handler_menuhandler_setup_menus",
+      "_src": "app_handler_menuhandler_setup_menus",
+      "_tgt": "app_window_mainwindow_setup_menus",
       "source": "app_handler_menuhandler_setup_menus",
       "target": "app_window_mainwindow_setup_menus"
     },
@@ -11436,8 +11436,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/presentation/view.py",
       "source_location": "L43",
       "weight": 1.0,
-      "_src": "presentation_view_deliveryview_setup_components",
-      "_tgt": "buttons_button_dsbutton",
+      "_src": "buttons_button_dsbutton",
+      "_tgt": "presentation_view_deliveryview_setup_components",
       "source": "buttons_button_dsbutton",
       "target": "presentation_view_deliveryview_setup_components"
     },
@@ -11448,8 +11448,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/presentation/view.py",
       "source_location": "L52",
       "weight": 1.0,
-      "_src": "presentation_view_summaryview_setup_components",
-      "_tgt": "buttons_button_dsbutton",
+      "_src": "buttons_button_dsbutton",
+      "_tgt": "presentation_view_summaryview_setup_components",
       "source": "buttons_button_dsbutton",
       "target": "presentation_view_summaryview_setup_components"
     },
@@ -11460,8 +11460,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/presentation/view.py",
       "source_location": "L43",
       "weight": 1.0,
-      "_src": "presentation_view_cpfvalidationview_setup_components",
-      "_tgt": "buttons_button_dsbutton",
+      "_src": "buttons_button_dsbutton",
+      "_tgt": "presentation_view_cpfvalidationview_setup_components",
       "source": "buttons_button_dsbutton",
       "target": "presentation_view_cpfvalidationview_setup_components"
     },
@@ -11508,8 +11508,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/presentation/view.py",
       "source_location": "L101",
       "weight": 1.0,
-      "_src": "presentation_view_deliveryview_activate_button_state",
-      "_tgt": "buttons_button_dsbutton_update_state",
+      "_src": "buttons_button_dsbutton_update_state",
+      "_tgt": "presentation_view_deliveryview_activate_button_state",
       "source": "buttons_button_dsbutton_update_state",
       "target": "presentation_view_deliveryview_activate_button_state"
     },
@@ -11520,8 +11520,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/presentation/view.py",
       "source_location": "L110",
       "weight": 1.0,
-      "_src": "presentation_view_deliveryview_prepare_to_fetch",
-      "_tgt": "buttons_button_dsbutton_update_state",
+      "_src": "buttons_button_dsbutton_update_state",
+      "_tgt": "presentation_view_deliveryview_prepare_to_fetch",
       "source": "buttons_button_dsbutton_update_state",
       "target": "presentation_view_deliveryview_prepare_to_fetch"
     },
@@ -11532,8 +11532,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/presentation/view.py",
       "source_location": "L130",
       "weight": 1.0,
-      "_src": "presentation_view_summaryview_activate_button_state",
-      "_tgt": "buttons_button_dsbutton_update_state",
+      "_src": "buttons_button_dsbutton_update_state",
+      "_tgt": "presentation_view_summaryview_activate_button_state",
       "source": "buttons_button_dsbutton_update_state",
       "target": "presentation_view_summaryview_activate_button_state"
     },
@@ -11544,8 +11544,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/presentation/view.py",
       "source_location": "L139",
       "weight": 1.0,
-      "_src": "presentation_view_summaryview_prepare_to_fetch",
-      "_tgt": "buttons_button_dsbutton_update_state",
+      "_src": "buttons_button_dsbutton_update_state",
+      "_tgt": "presentation_view_summaryview_prepare_to_fetch",
       "source": "buttons_button_dsbutton_update_state",
       "target": "presentation_view_summaryview_prepare_to_fetch"
     },
@@ -11820,8 +11820,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/presentation/view.py",
       "source_location": "L41",
       "weight": 1.0,
-      "_src": "presentation_view_deliveryview_setup_components",
-      "_tgt": "chart_chart_widget_dschart",
+      "_src": "chart_chart_widget_dschart",
+      "_tgt": "presentation_view_deliveryview_setup_components",
       "source": "chart_chart_widget_dschart",
       "target": "presentation_view_deliveryview_setup_components"
     },
@@ -11832,8 +11832,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/presentation/view.py",
       "source_location": "L43",
       "weight": 1.0,
-      "_src": "presentation_view_summaryview_setup_components",
-      "_tgt": "chart_chart_widget_dschart",
+      "_src": "chart_chart_widget_dschart",
+      "_tgt": "presentation_view_summaryview_setup_components",
       "source": "chart_chart_widget_dschart",
       "target": "presentation_view_summaryview_setup_components"
     },
@@ -11940,8 +11940,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/presentation/view.py",
       "source_location": "L106",
       "weight": 1.0,
-      "_src": "presentation_view_summaryview_on_chart_type_changed",
-      "_tgt": "chart_chart_widget_dschart_set_type",
+      "_src": "chart_chart_widget_dschart_set_type",
+      "_tgt": "presentation_view_summaryview_on_chart_type_changed",
       "source": "chart_chart_widget_dschart_set_type",
       "target": "presentation_view_summaryview_on_chart_type_changed"
     },
@@ -12084,8 +12084,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/presentation/view.py",
       "source_location": "L84",
       "weight": 1.0,
-      "_src": "presentation_view_summaryview_setup_layout",
-      "_tgt": "label_label_dslabel",
+      "_src": "label_label_dslabel",
+      "_tgt": "presentation_view_summaryview_setup_layout",
       "source": "label_label_dslabel",
       "target": "presentation_view_summaryview_setup_layout"
     },
@@ -12096,8 +12096,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/presentation/view.py",
       "source_location": "L40",
       "weight": 1.0,
-      "_src": "presentation_view_cpfvalidationview_setup_components",
-      "_tgt": "qlabel",
+      "_src": "qlabel",
+      "_tgt": "presentation_view_cpfvalidationview_setup_components",
       "source": "qlabel",
       "target": "presentation_view_cpfvalidationview_setup_components"
     },
@@ -12108,8 +12108,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/status_bar/presentation/view.py",
       "source_location": "L15",
       "weight": 1.0,
-      "_src": "presentation_view_statusbarview_init",
-      "_tgt": "qlabel",
+      "_src": "qlabel",
+      "_tgt": "presentation_view_statusbarview_init",
       "source": "qlabel",
       "target": "presentation_view_statusbarview_init"
     },
@@ -12228,8 +12228,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/presentation/view.py",
       "source_location": "L37",
       "weight": 1.0,
-      "_src": "presentation_view_deliveryview_setup_components",
-      "_tgt": "alerts_dialog_dsdialog",
+      "_src": "alerts_dialog_dsdialog",
+      "_tgt": "presentation_view_deliveryview_setup_components",
       "source": "alerts_dialog_dsdialog",
       "target": "presentation_view_deliveryview_setup_components"
     },
@@ -12240,8 +12240,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/presentation/view.py",
       "source_location": "L39",
       "weight": 1.0,
-      "_src": "presentation_view_summaryview_setup_components",
-      "_tgt": "alerts_dialog_dsdialog",
+      "_src": "alerts_dialog_dsdialog",
+      "_tgt": "presentation_view_summaryview_setup_components",
       "source": "alerts_dialog_dsdialog",
       "target": "presentation_view_summaryview_setup_components"
     },
@@ -12252,8 +12252,8 @@
       "source_file": "features/sheets/presentation/controller.py",
       "source_location": "L21",
       "weight": 1.0,
-      "_src": "presentation_controller_sheetscontroller_init",
-      "_tgt": "alerts_dialog_dsdialog",
+      "_src": "alerts_dialog_dsdialog",
+      "_tgt": "presentation_controller_sheetscontroller_init",
       "source": "alerts_dialog_dsdialog",
       "target": "presentation_controller_sheetscontroller_init"
     },
@@ -12264,8 +12264,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/presentation/controller.py",
       "source_location": "L21",
       "weight": 1.0,
-      "_src": "presentation_controller_authcontroller_init",
-      "_tgt": "alerts_dialog_dsdialog",
+      "_src": "alerts_dialog_dsdialog",
+      "_tgt": "presentation_controller_authcontroller_init",
       "source": "alerts_dialog_dsdialog",
       "target": "presentation_controller_authcontroller_init"
     },
@@ -12300,8 +12300,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/presentation/controller.py",
       "source_location": "L54",
       "weight": 1.0,
-      "_src": "presentation_controller_deliverycontroller_handle_error",
-      "_tgt": "alerts_dialog_dsdialog_show",
+      "_src": "alerts_dialog_dsdialog_show",
+      "_tgt": "presentation_controller_deliverycontroller_handle_error",
       "source": "alerts_dialog_dsdialog_show",
       "target": "presentation_controller_deliverycontroller_handle_error"
     },
@@ -12312,8 +12312,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/presentation/controller.py",
       "source_location": "L55",
       "weight": 1.0,
-      "_src": "presentation_controller_summarycontroller_handle_error",
-      "_tgt": "alerts_dialog_dsdialog_show",
+      "_src": "alerts_dialog_dsdialog_show",
+      "_tgt": "presentation_controller_summarycontroller_handle_error",
       "source": "alerts_dialog_dsdialog_show",
       "target": "presentation_controller_summarycontroller_handle_error"
     },
@@ -12324,8 +12324,8 @@
       "source_file": "features/sheets/presentation/controller.py",
       "source_location": "L117",
       "weight": 1.0,
-      "_src": "presentation_controller_sheetscontroller_on_error",
-      "_tgt": "alerts_dialog_dsdialog_show",
+      "_src": "alerts_dialog_dsdialog_show",
+      "_tgt": "presentation_controller_sheetscontroller_on_error",
       "source": "alerts_dialog_dsdialog_show",
       "target": "presentation_controller_sheetscontroller_on_error"
     },
@@ -12336,8 +12336,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/presentation/controller.py",
       "source_location": "L56",
       "weight": 1.0,
-      "_src": "presentation_controller_authcontroller_on_error",
-      "_tgt": "alerts_dialog_dsdialog_show",
+      "_src": "alerts_dialog_dsdialog_show",
+      "_tgt": "presentation_controller_authcontroller_on_error",
       "source": "alerts_dialog_dsdialog_show",
       "target": "presentation_controller_authcontroller_on_error"
     },
@@ -12396,8 +12396,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/presentation/view.py",
       "source_location": "L62",
       "weight": 1.0,
-      "_src": "presentation_view_summaryview_setup_components",
-      "_tgt": "combo_box_combo_box_dscombobox",
+      "_src": "combo_box_combo_box_dscombobox",
+      "_tgt": "presentation_view_summaryview_setup_components",
       "source": "combo_box_combo_box_dscombobox",
       "target": "presentation_view_summaryview_setup_components"
     },
@@ -12468,8 +12468,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/presentation/view.py",
       "source_location": "L38",
       "weight": 1.0,
-      "_src": "presentation_view_deliveryview_setup_components",
-      "_tgt": "text_view_text_view_dstextview",
+      "_src": "text_view_text_view_dstextview",
+      "_tgt": "presentation_view_deliveryview_setup_components",
       "source": "text_view_text_view_dstextview",
       "target": "presentation_view_deliveryview_setup_components"
     },
@@ -12480,8 +12480,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/presentation/view.py",
       "source_location": "L40",
       "weight": 1.0,
-      "_src": "presentation_view_summaryview_setup_components",
-      "_tgt": "text_view_text_view_dstextview",
+      "_src": "text_view_text_view_dstextview",
+      "_tgt": "presentation_view_summaryview_setup_components",
       "source": "text_view_text_view_dstextview",
       "target": "presentation_view_summaryview_setup_components"
     },
@@ -12540,8 +12540,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/presentation/view.py",
       "source_location": "L62",
       "weight": 1.0,
-      "_src": "presentation_view_deliveryview_setup_layout",
-      "_tgt": "containers_group_box_dsgroupbox",
+      "_src": "containers_group_box_dsgroupbox",
+      "_tgt": "presentation_view_deliveryview_setup_layout",
       "source": "containers_group_box_dsgroupbox",
       "target": "presentation_view_deliveryview_setup_layout"
     },
@@ -12552,8 +12552,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/presentation/view.py",
       "source_location": "L75",
       "weight": 1.0,
-      "_src": "presentation_view_summaryview_setup_layout",
-      "_tgt": "containers_group_box_dsgroupbox",
+      "_src": "containers_group_box_dsgroupbox",
+      "_tgt": "presentation_view_summaryview_setup_layout",
       "source": "containers_group_box_dsgroupbox",
       "target": "presentation_view_summaryview_setup_layout"
     },
@@ -12612,8 +12612,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/presentation/view.py",
       "source_location": "L36",
       "weight": 1.0,
-      "_src": "presentation_view_cpfvalidationview_setup_components",
-      "_tgt": "inputs_text_input_dstextinput",
+      "_src": "inputs_text_input_dstextinput",
+      "_tgt": "presentation_view_cpfvalidationview_setup_components",
       "source": "inputs_text_input_dstextinput",
       "target": "presentation_view_cpfvalidationview_setup_components"
     },
@@ -12624,8 +12624,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/presentation/view/sheet_create_view.py",
       "source_location": "L29",
       "weight": 1.0,
-      "_src": "view_sheet_create_view_sheetcreateview_setup_components",
-      "_tgt": "qlineedit",
+      "_src": "qlineedit",
+      "_tgt": "view_sheet_create_view_sheetcreateview_setup_components",
       "source": "qlineedit",
       "target": "view_sheet_create_view_sheetcreateview_setup_components"
     },
@@ -12684,8 +12684,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/presentation/view.py",
       "source_location": "L46",
       "weight": 1.0,
-      "_src": "presentation_view_deliveryview_setup_components",
-      "_tgt": "inputs_date_input_dsdateinput",
+      "_src": "inputs_date_input_dsdateinput",
+      "_tgt": "presentation_view_deliveryview_setup_components",
       "source": "inputs_date_input_dsdateinput",
       "target": "presentation_view_deliveryview_setup_components"
     },
@@ -12696,8 +12696,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/presentation/view.py",
       "source_location": "L49",
       "weight": 1.0,
-      "_src": "presentation_view_summaryview_setup_components",
-      "_tgt": "inputs_date_input_dsdateinput",
+      "_src": "inputs_date_input_dsdateinput",
+      "_tgt": "presentation_view_summaryview_setup_components",
       "source": "inputs_date_input_dsdateinput",
       "target": "presentation_view_summaryview_setup_components"
     },
@@ -12913,9 +12913,9 @@
       "weight": 0.8,
       "_src": "source_controller_homecontroller",
       "_tgt": "source_models_homefeaturesmodel",
+      "confidence_score": 0.5,
       "source": "source_controller_homecontroller",
-      "target": "source_models_homefeaturesmodel",
-      "confidence_score": 0.5
+      "target": "source_models_homefeaturesmodel"
     },
     {
       "relation": "uses",
@@ -12925,9 +12925,9 @@
       "weight": 0.8,
       "_src": "source_controller_homecontroller",
       "_tgt": "source_view_homeview",
+      "confidence_score": 0.5,
       "source": "source_controller_homecontroller",
-      "target": "source_view_homeview",
-      "confidence_score": 0.5
+      "target": "source_view_homeview"
     },
     {
       "relation": "calls",
@@ -13019,11 +13019,11 @@
       "source_file": "features/home/source/view.py",
       "source_location": "L6",
       "weight": 0.8,
-      "_src": "source_view_homeview",
-      "_tgt": "source_models_homefeaturesmodel",
+      "_src": "source_models_homefeaturesmodel",
+      "_tgt": "source_view_homeview",
+      "confidence_score": 0.5,
       "source": "source_models_homefeaturesmodel",
-      "target": "source_view_homeview",
-      "confidence_score": 0.5
+      "target": "source_view_homeview"
     },
     {
       "relation": "contains",
@@ -13236,8 +13236,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/data/repository.py",
       "source_location": "L18",
       "weight": 1.0,
-      "_src": "data_repository_ordersrepository_get_deliveries",
-      "_tgt": "data_mapper_from_response",
+      "_src": "data_mapper_from_response",
+      "_tgt": "data_repository_ordersrepository_get_deliveries",
       "source": "data_mapper_from_response",
       "target": "data_repository_ordersrepository_get_deliveries"
     },
@@ -13248,8 +13248,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/data/repository.py",
       "source_location": "L28",
       "weight": 1.0,
-      "_src": "data_repository_ordersrepository_get_pendent_payments",
-      "_tgt": "data_mapper_from_response",
+      "_src": "data_mapper_from_response",
+      "_tgt": "data_repository_ordersrepository_get_pendent_payments",
       "source": "data_mapper_from_response",
       "target": "data_repository_ordersrepository_get_pendent_payments"
     },
@@ -13284,8 +13284,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/data/repository.py",
       "source_location": "L18",
       "weight": 1.0,
-      "_src": "data_repository_summaryrepository_get_by_period",
-      "_tgt": "data_mapper_from_response",
+      "_src": "data_mapper_from_response",
+      "_tgt": "data_repository_summaryrepository_get_by_period",
       "source": "data_mapper_from_response",
       "target": "data_repository_summaryrepository_get_by_period"
     },
@@ -13404,8 +13404,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/data/repository.py",
       "source_location": "L16",
       "weight": 1.0,
-      "_src": "data_repository_ordersrepository_get_deliveries",
-      "_tgt": "data_apis_deliveriesapi",
+      "_src": "data_apis_deliveriesapi",
+      "_tgt": "data_repository_ordersrepository_get_deliveries",
       "source": "data_apis_deliveriesapi",
       "target": "data_repository_ordersrepository_get_deliveries"
     },
@@ -13536,8 +13536,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/data/repository.py",
       "source_location": "L26",
       "weight": 1.0,
-      "_src": "data_repository_ordersrepository_get_pendent_payments",
-      "_tgt": "data_apis_paymentspendentapi",
+      "_src": "data_apis_paymentspendentapi",
+      "_tgt": "data_repository_ordersrepository_get_pendent_payments",
       "source": "data_apis_paymentspendentapi",
       "target": "data_repository_ordersrepository_get_pendent_payments"
     },
@@ -13548,8 +13548,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/data/repository.py",
       "source_location": "L16",
       "weight": 1.0,
-      "_src": "data_repository_ordersrepository_get_deliveries",
-      "_tgt": "data_apis_paymentspendentapi_for_date",
+      "_src": "data_apis_paymentspendentapi_for_date",
+      "_tgt": "data_repository_ordersrepository_get_deliveries",
       "source": "data_apis_paymentspendentapi_for_date",
       "target": "data_repository_ordersrepository_get_deliveries"
     },
@@ -13560,8 +13560,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/data/repository.py",
       "source_location": "L26",
       "weight": 1.0,
-      "_src": "data_repository_ordersrepository_get_pendent_payments",
-      "_tgt": "data_apis_paymentspendentapi_for_date",
+      "_src": "data_apis_paymentspendentapi_for_date",
+      "_tgt": "data_repository_ordersrepository_get_pendent_payments",
       "source": "data_apis_paymentspendentapi_for_date",
       "target": "data_repository_ordersrepository_get_pendent_payments"
     },
@@ -13656,8 +13656,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/domain/use_case.py",
       "source_location": "L11",
       "weight": 1.0,
-      "_src": "domain_use_case_deliveryusecase_init",
-      "_tgt": "data_repository_ordersrepository",
+      "_src": "data_repository_ordersrepository",
+      "_tgt": "domain_use_case_deliveryusecase_init",
       "source": "data_repository_ordersrepository",
       "target": "domain_use_case_deliveryusecase_init"
     },
@@ -13724,18 +13724,6 @@
     {
       "relation": "imports_from",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/domain/__init__.py",
-      "source_location": "L5",
-      "weight": 1.0,
-      "_src": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_sub_features_delivery_domain_init_py",
-      "_tgt": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_sub_features_delivery_domain_use_case_py",
-      "source": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_sub_features_delivery_domain_use_case_py",
-      "target": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_sub_features_delivery_domain_init_py",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "imports_from",
-      "confidence": "EXTRACTED",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/presentation/viewmodel.py",
       "source_location": "L9",
       "weight": 1.0,
@@ -13776,8 +13764,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/presentation/viewmodel.py",
       "source_location": "L14",
       "weight": 1.0,
-      "_src": "presentation_viewmodel_deliveryviewmodel_init",
-      "_tgt": "domain_use_case_deliveryusecase",
+      "_src": "domain_use_case_deliveryusecase",
+      "_tgt": "presentation_viewmodel_deliveryviewmodel_init",
       "source": "domain_use_case_deliveryusecase",
       "target": "presentation_viewmodel_deliveryviewmodel_init"
     },
@@ -13868,18 +13856,6 @@
     {
       "relation": "imports_from",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/domain/__init__.py",
-      "source_location": "L4",
-      "weight": 1.0,
-      "_src": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_sub_features_delivery_domain_init_py",
-      "_tgt": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_sub_features_delivery_domain_signals_py",
-      "source": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_sub_features_delivery_domain_signals_py",
-      "target": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_sub_features_delivery_domain_init_py",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "imports_from",
-      "confidence": "EXTRACTED",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/presentation/controller.py",
       "source_location": "L10",
       "weight": 1.0,
@@ -13916,13 +13892,13 @@
     {
       "relation": "rationale_for",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/domain/signals.py",
+      "source_file": "features/auth/domain/signals.py",
       "source_location": "L1",
       "weight": 1.0,
       "_src": "domain_signals_rationale_1",
-      "_tgt": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_auth_domain_signals_py",
+      "_tgt": "features_auth_domain_signals_py",
       "source": "domain_signals_rationale_1",
-      "target": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_auth_domain_signals_py",
+      "target": "features_auth_domain_signals_py",
       "confidence_score": 1.0
     },
     {
@@ -14012,18 +13988,6 @@
     {
       "relation": "imports_from",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/domain/__init__.py",
-      "source_location": "L2",
-      "weight": 1.0,
-      "_src": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_sub_features_delivery_domain_init_py",
-      "_tgt": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_sub_features_delivery_domain_models_py",
-      "source": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_sub_features_delivery_domain_models_py",
-      "target": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_sub_features_delivery_domain_init_py",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "imports_from",
-      "confidence": "EXTRACTED",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/presentation/controller.py",
       "source_location": "L9",
       "weight": 1.0,
@@ -14064,8 +14028,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/presentation/viewmodel.py",
       "source_location": "L32",
       "weight": 1.0,
-      "_src": "presentation_viewmodel_deliveryviewmodel_build_view_data",
-      "_tgt": "domain_models_deliveryviewdata",
+      "_src": "domain_models_deliveryviewdata",
+      "_tgt": "presentation_viewmodel_deliveryviewmodel_build_view_data",
       "source": "domain_models_deliveryviewdata",
       "target": "presentation_viewmodel_deliveryviewmodel_build_view_data"
     },
@@ -14115,18 +14079,6 @@
       "_tgt": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_sub_features_delivery_domain_events_py",
       "source": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_sub_features_delivery_domain_events_py",
       "target": "domain_events_rationale_1",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "imports_from",
-      "confidence": "EXTRACTED",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/domain/__init__.py",
-      "source_location": "L1",
-      "weight": 1.0,
-      "_src": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_sub_features_delivery_domain_init_py",
-      "_tgt": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_sub_features_delivery_domain_events_py",
-      "source": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_sub_features_delivery_domain_events_py",
-      "target": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_sub_features_delivery_domain_init_py",
       "confidence_score": 1.0
     },
     {
@@ -14195,11 +14147,11 @@
       "source_file": "features/sheets/presentation/controller.py",
       "source_location": "L10",
       "weight": 0.8,
-      "_src": "presentation_controller_sheetscontroller",
-      "_tgt": "domain_events_featureevents",
+      "_src": "domain_events_featureevents",
+      "_tgt": "presentation_controller_sheetscontroller",
+      "confidence_score": 0.5,
       "source": "domain_events_featureevents",
-      "target": "presentation_controller_sheetscontroller",
-      "confidence_score": 0.5
+      "target": "presentation_controller_sheetscontroller"
     },
     {
       "relation": "rationale_for",
@@ -15180,8 +15132,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/data/repository.py",
       "source_location": "L16",
       "weight": 1.0,
-      "_src": "data_repository_summaryrepository_get_by_period",
-      "_tgt": "data_apis_orderssummaryapi",
+      "_src": "data_apis_orderssummaryapi",
+      "_tgt": "data_repository_summaryrepository_get_by_period",
       "source": "data_apis_orderssummaryapi",
       "target": "data_repository_summaryrepository_get_by_period"
     },
@@ -15192,8 +15144,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/data/repository.py",
       "source_location": "L16",
       "weight": 1.0,
-      "_src": "data_repository_summaryrepository_get_by_period",
-      "_tgt": "data_apis_orderssummaryapi_for_period",
+      "_src": "data_apis_orderssummaryapi_for_period",
+      "_tgt": "data_repository_summaryrepository_get_by_period",
       "source": "data_apis_orderssummaryapi_for_period",
       "target": "data_repository_summaryrepository_get_by_period"
     },
@@ -15252,8 +15204,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/domain/use_case.py",
       "source_location": "L11",
       "weight": 1.0,
-      "_src": "domain_use_case_summaryusecase_init",
-      "_tgt": "data_repository_summaryrepository",
+      "_src": "data_repository_summaryrepository",
+      "_tgt": "domain_use_case_summaryusecase_init",
       "source": "data_repository_summaryrepository",
       "target": "domain_use_case_summaryusecase_init"
     },
@@ -15348,8 +15300,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/presentation/viewmodel.py",
       "source_location": "L16",
       "weight": 1.0,
-      "_src": "presentation_viewmodel_summaryviewmodel_init",
-      "_tgt": "domain_use_case_summaryusecase",
+      "_src": "domain_use_case_summaryusecase",
+      "_tgt": "presentation_viewmodel_summaryviewmodel_init",
       "source": "domain_use_case_summaryusecase",
       "target": "presentation_viewmodel_summaryviewmodel_init"
     },
@@ -15384,8 +15336,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/presentation/viewmodel.py",
       "source_location": "L24",
       "weight": 1.0,
-      "_src": "presentation_viewmodel_summaryviewmodel_fetch",
-      "_tgt": "domain_use_case_summaryusecase_get_summary",
+      "_src": "domain_use_case_summaryusecase_get_summary",
+      "_tgt": "presentation_viewmodel_summaryviewmodel_fetch",
       "source": "domain_use_case_summaryusecase_get_summary",
       "target": "presentation_viewmodel_summaryviewmodel_fetch"
     },
@@ -15576,8 +15528,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/presentation/viewmodel.py",
       "source_location": "L33",
       "weight": 1.0,
-      "_src": "presentation_viewmodel_summaryviewmodel_build_view_data",
-      "_tgt": "domain_models_productsviewdata",
+      "_src": "domain_models_productsviewdata",
+      "_tgt": "presentation_viewmodel_summaryviewmodel_build_view_data",
       "source": "domain_models_productsviewdata",
       "target": "presentation_viewmodel_summaryviewmodel_build_view_data"
     },
@@ -16308,8 +16260,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/data/repository.py",
       "source_location": "L37",
       "weight": 1.0,
-      "_src": "data_repository_sheetsrepository_connect",
-      "_tgt": "data_apis_selectsheetapi",
+      "_src": "data_apis_selectsheetapi",
+      "_tgt": "data_repository_sheetsrepository_connect",
       "source": "data_apis_selectsheetapi",
       "target": "data_repository_sheetsrepository_connect"
     },
@@ -16320,8 +16272,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/data/repository.py",
       "source_location": "L42",
       "weight": 1.0,
-      "_src": "data_repository_sheetsrepository_select",
-      "_tgt": "data_apis_selectsheetapi",
+      "_src": "data_apis_selectsheetapi",
+      "_tgt": "data_repository_sheetsrepository_select",
       "source": "data_apis_selectsheetapi",
       "target": "data_repository_sheetsrepository_select"
     },
@@ -16356,8 +16308,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/data/repository.py",
       "source_location": "L64",
       "weight": 1.0,
-      "_src": "data_repository_sheetsrepository_remove",
-      "_tgt": "data_apis_removesheetapi",
+      "_src": "data_apis_removesheetapi",
+      "_tgt": "data_repository_sheetsrepository_remove",
       "source": "data_apis_removesheetapi",
       "target": "data_repository_sheetsrepository_remove"
     },
@@ -16524,8 +16476,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/domain/use_case.py",
       "source_location": "L9",
       "weight": 1.0,
-      "_src": "domain_use_case_sheetsusecase_init",
-      "_tgt": "data_repository_sheetsrepository",
+      "_src": "data_repository_sheetsrepository",
+      "_tgt": "domain_use_case_sheetsusecase_init",
       "source": "data_repository_sheetsrepository",
       "target": "domain_use_case_sheetsusecase_init"
     },
@@ -16536,8 +16488,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/domain/init_use_case.py",
       "source_location": "L10",
       "weight": 1.0,
-      "_src": "domain_init_use_case_appinitusecase_init",
-      "_tgt": "data_repository_sheetsrepository",
+      "_src": "data_repository_sheetsrepository",
+      "_tgt": "domain_init_use_case_appinitusecase_init",
       "source": "data_repository_sheetsrepository",
       "target": "domain_init_use_case_appinitusecase_init"
     },
@@ -16716,8 +16668,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/domain/init_use_case.py",
       "source_location": "L18",
       "weight": 1.0,
-      "_src": "domain_init_use_case_appinitusecase_initialize",
-      "_tgt": "data_repository_sheetsrepository_last_sheet_id_from_cache",
+      "_src": "data_repository_sheetsrepository_last_sheet_id_from_cache",
+      "_tgt": "domain_init_use_case_appinitusecase_initialize",
       "source": "data_repository_sheetsrepository_last_sheet_id_from_cache",
       "target": "domain_init_use_case_appinitusecase_initialize"
     },
@@ -16848,33 +16800,33 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/presentation/viewmodel.py",
       "source_location": "L13",
       "weight": 1.0,
-      "_src": "presentation_viewmodel_sheetsviewmodel_init",
-      "_tgt": "domain_use_case_sheetsusecase",
+      "_src": "domain_use_case_sheetsusecase",
+      "_tgt": "presentation_viewmodel_sheetsviewmodel_init",
       "source": "domain_use_case_sheetsusecase",
       "target": "presentation_viewmodel_sheetsviewmodel_init"
     },
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/domain/signals.py",
+      "source_file": "features/sheets/domain/signals.py",
       "source_location": "L6",
       "weight": 1.0,
-      "_src": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_sheets_domain_signals_py",
+      "_src": "features_sheets_domain_signals_py",
       "_tgt": "domain_signals_sheetssignals",
-      "source": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_sheets_domain_signals_py",
+      "source": "features_sheets_domain_signals_py",
       "target": "domain_signals_sheetssignals",
       "confidence_score": 1.0
     },
     {
       "relation": "imports_from",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/presentation/viewmodel.py",
-      "source_location": "L7",
+      "source_file": "features/sheets/presentation/controller.py",
+      "source_location": "L12",
       "weight": 1.0,
-      "_src": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_sheets_presentation_viewmodel_py",
-      "_tgt": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_sheets_domain_signals_py",
-      "source": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_sheets_domain_signals_py",
-      "target": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_sheets_presentation_viewmodel_py",
+      "_src": "features_sheets_presentation_controller_py",
+      "_tgt": "features_sheets_domain_signals_py",
+      "source": "features_sheets_domain_signals_py",
+      "target": "features_sheets_presentation_controller_py",
       "confidence_score": 1.0
     },
     {
@@ -16907,11 +16859,11 @@
       "source_file": "features/sheets/presentation/controller.py",
       "source_location": "L11",
       "weight": 0.8,
-      "_src": "presentation_controller_sheetscontroller",
-      "_tgt": "domain_models_sheetmodel",
+      "_src": "domain_models_sheetmodel",
+      "_tgt": "presentation_controller_sheetscontroller",
+      "confidence_score": 0.5,
       "source": "domain_models_sheetmodel",
-      "target": "presentation_controller_sheetscontroller",
-      "confidence_score": 0.5
+      "target": "presentation_controller_sheetscontroller"
     },
     {
       "relation": "imports_from",
@@ -17113,9 +17065,9 @@
       "weight": 0.8,
       "_src": "presentation_controller_sheetscontroller",
       "_tgt": "presentation_viewmodel_sheetsviewmodel",
+      "confidence_score": 0.5,
       "source": "presentation_controller_sheetscontroller",
-      "target": "presentation_viewmodel_sheetsviewmodel",
-      "confidence_score": 0.5
+      "target": "presentation_viewmodel_sheetsviewmodel"
     },
     {
       "relation": "calls",
@@ -17472,8 +17424,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/domain/init_use_case.py",
       "source_location": "L31",
       "weight": 1.0,
-      "_src": "domain_init_use_case_appinitusecase_initialize",
-      "_tgt": "presentation_viewmodel_sheetsviewmodel_load_all",
+      "_src": "presentation_viewmodel_sheetsviewmodel_load_all",
+      "_tgt": "domain_init_use_case_appinitusecase_initialize",
       "source": "presentation_viewmodel_sheetsviewmodel_load_all",
       "target": "domain_init_use_case_appinitusecase_initialize"
     },
@@ -17940,8 +17892,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/data/repository.py",
       "source_location": "L19",
       "weight": 1.0,
-      "_src": "data_repository_authrepository_configure",
-      "_tgt": "data_apis_connectauthapi",
+      "_src": "data_apis_connectauthapi",
+      "_tgt": "data_repository_authrepository_configure",
       "source": "data_apis_connectauthapi",
       "target": "data_repository_authrepository_configure"
     },
@@ -17952,8 +17904,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/data/repository.py",
       "source_location": "L27",
       "weight": 1.0,
-      "_src": "data_repository_authrepository_pre_login",
-      "_tgt": "data_apis_connectauthapi",
+      "_src": "data_apis_connectauthapi",
+      "_tgt": "data_repository_authrepository_pre_login",
       "source": "data_apis_connectauthapi",
       "target": "data_repository_authrepository_pre_login"
     },
@@ -17976,8 +17928,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/data/repository.py",
       "source_location": "L19",
       "weight": 1.0,
-      "_src": "data_repository_authrepository_configure",
-      "_tgt": "data_apis_connectauthapi_with_credentials",
+      "_src": "data_apis_connectauthapi_with_credentials",
+      "_tgt": "data_repository_authrepository_configure",
       "source": "data_apis_connectauthapi_with_credentials",
       "target": "data_repository_authrepository_configure"
     },
@@ -17988,8 +17940,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/data/repository.py",
       "source_location": "L27",
       "weight": 1.0,
-      "_src": "data_repository_authrepository_pre_login",
-      "_tgt": "data_apis_connectauthapi_with_credentials",
+      "_src": "data_apis_connectauthapi_with_credentials",
+      "_tgt": "data_repository_authrepository_pre_login",
       "source": "data_apis_connectauthapi_with_credentials",
       "target": "data_repository_authrepository_pre_login"
     },
@@ -18012,8 +17964,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/data/repository.py",
       "source_location": "L38",
       "weight": 1.0,
-      "_src": "data_repository_authrepository_clear",
-      "_tgt": "data_apis_disconnectauthapi",
+      "_src": "data_apis_disconnectauthapi",
+      "_tgt": "data_repository_authrepository_clear",
       "source": "data_apis_disconnectauthapi",
       "target": "data_repository_authrepository_clear"
     },
@@ -18096,8 +18048,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/domain/use_case.py",
       "source_location": "L10",
       "weight": 1.0,
-      "_src": "domain_use_case_authusecase_init",
-      "_tgt": "data_repository_authrepository",
+      "_src": "data_repository_authrepository",
+      "_tgt": "domain_use_case_authusecase_init",
       "source": "data_repository_authrepository",
       "target": "domain_use_case_authusecase_init"
     },
@@ -18108,8 +18060,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/domain/init_use_case.py",
       "source_location": "L9",
       "weight": 1.0,
-      "_src": "domain_init_use_case_appinitusecase_init",
-      "_tgt": "data_repository_authrepository",
+      "_src": "data_repository_authrepository",
+      "_tgt": "domain_init_use_case_appinitusecase_init",
       "source": "data_repository_authrepository",
       "target": "domain_init_use_case_appinitusecase_init"
     },
@@ -18168,8 +18120,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/domain/init_use_case.py",
       "source_location": "L22",
       "weight": 1.0,
-      "_src": "domain_init_use_case_appinitusecase_initialize",
-      "_tgt": "data_repository_authrepository_pre_login",
+      "_src": "data_repository_authrepository_pre_login",
+      "_tgt": "domain_init_use_case_appinitusecase_initialize",
       "source": "data_repository_authrepository_pre_login",
       "target": "domain_init_use_case_appinitusecase_initialize"
     },
@@ -18192,8 +18144,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/domain/init_use_case.py",
       "source_location": "L13",
       "weight": 1.0,
-      "_src": "domain_init_use_case_appinitusecase_initialize",
-      "_tgt": "data_repository_authrepository_read_credentials",
+      "_src": "data_repository_authrepository_read_credentials",
+      "_tgt": "domain_init_use_case_appinitusecase_initialize",
       "source": "data_repository_authrepository_read_credentials",
       "target": "domain_init_use_case_appinitusecase_initialize"
     },
@@ -18276,8 +18228,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/presentation/viewmodel.py",
       "source_location": "L14",
       "weight": 1.0,
-      "_src": "presentation_viewmodel_authviewmodel_init",
-      "_tgt": "domain_use_case_authusecase",
+      "_src": "domain_use_case_authusecase",
+      "_tgt": "presentation_viewmodel_authviewmodel_init",
       "source": "domain_use_case_authusecase",
       "target": "presentation_viewmodel_authviewmodel_init"
     },
@@ -18308,37 +18260,13 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/domain/signals.py",
+      "source_file": "features/auth/domain/signals.py",
       "source_location": "L8",
       "weight": 1.0,
-      "_src": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_auth_domain_signals_py",
+      "_src": "features_auth_domain_signals_py",
       "_tgt": "domain_signals_authsignals",
-      "source": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_auth_domain_signals_py",
+      "source": "features_auth_domain_signals_py",
       "target": "domain_signals_authsignals",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "imports_from",
-      "confidence": "EXTRACTED",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/presentation/controller.py",
-      "source_location": "L12",
-      "weight": 1.0,
-      "_src": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_auth_presentation_controller_py",
-      "_tgt": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_auth_domain_signals_py",
-      "source": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_auth_domain_signals_py",
-      "target": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_auth_presentation_controller_py",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "imports_from",
-      "confidence": "EXTRACTED",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/presentation/viewmodel.py",
-      "source_location": "L8",
-      "weight": 1.0,
-      "_src": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_auth_presentation_viewmodel_py",
-      "_tgt": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_auth_domain_signals_py",
-      "source": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_auth_domain_signals_py",
-      "target": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_auth_presentation_viewmodel_py",
       "confidence_score": 1.0
     },
     {
@@ -18776,18 +18704,6 @@
     {
       "relation": "imports_from",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/domain/__init__.py",
-      "source_location": "L4",
-      "weight": 1.0,
-      "_src": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_cpf_validation_domain_init_py",
-      "_tgt": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_cpf_validation_domain_use_case_py",
-      "source": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_cpf_validation_domain_use_case_py",
-      "target": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_cpf_validation_domain_init_py",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "imports_from",
-      "confidence": "EXTRACTED",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/presentation/viewmodel.py",
       "source_location": "L4",
       "weight": 1.0,
@@ -18840,8 +18756,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/presentation/viewmodel.py",
       "source_location": "L9",
       "weight": 1.0,
-      "_src": "presentation_viewmodel_cpfvalidationviewmodel_init",
-      "_tgt": "domain_use_case_cpfvalidationusecase",
+      "_src": "domain_use_case_cpfvalidationusecase",
+      "_tgt": "presentation_viewmodel_cpfvalidationviewmodel_init",
       "source": "domain_use_case_cpfvalidationusecase",
       "target": "presentation_viewmodel_cpfvalidationviewmodel_init"
     },
@@ -18864,8 +18780,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/presentation/viewmodel.py",
       "source_location": "L12",
       "weight": 1.0,
-      "_src": "presentation_viewmodel_cpfvalidationviewmodel_on_validate",
-      "_tgt": "domain_use_case_cpfvalidationusecase_validate",
+      "_src": "domain_use_case_cpfvalidationusecase_validate",
+      "_tgt": "presentation_viewmodel_cpfvalidationviewmodel_on_validate",
       "source": "domain_use_case_cpfvalidationusecase_validate",
       "target": "presentation_viewmodel_cpfvalidationviewmodel_on_validate"
     },
@@ -18879,18 +18795,6 @@
       "_tgt": "domain_signals_cpfvalidationsignals",
       "source": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_cpf_validation_domain_signals_py",
       "target": "domain_signals_cpfvalidationsignals",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "imports_from",
-      "confidence": "EXTRACTED",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/domain/__init__.py",
-      "source_location": "L3",
-      "weight": 1.0,
-      "_src": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_cpf_validation_domain_init_py",
-      "_tgt": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_cpf_validation_domain_signals_py",
-      "source": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_cpf_validation_domain_signals_py",
-      "target": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_cpf_validation_domain_init_py",
       "confidence_score": 1.0
     },
     {
@@ -18932,18 +18836,6 @@
     {
       "relation": "imports_from",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/domain/__init__.py",
-      "source_location": "L2",
-      "weight": 1.0,
-      "_src": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_cpf_validation_domain_init_py",
-      "_tgt": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_cpf_validation_domain_models_py",
-      "source": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_cpf_validation_domain_models_py",
-      "target": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_cpf_validation_domain_init_py",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "imports_from",
-      "confidence": "EXTRACTED",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/presentation/controller.py",
       "source_location": "L6",
       "weight": 1.0,
@@ -18963,18 +18855,6 @@
       "_tgt": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_cpf_validation_domain_models_py",
       "source": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_cpf_validation_domain_models_py",
       "target": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_cpf_validation_presentation_view_py",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "imports_from",
-      "confidence": "EXTRACTED",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/domain/__init__.py",
-      "source_location": "L1",
-      "weight": 1.0,
-      "_src": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_cpf_validation_domain_init_py",
-      "_tgt": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_cpf_validation_domain_events_py",
-      "source": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_cpf_validation_domain_events_py",
-      "target": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_cpf_validation_domain_init_py",
       "confidence_score": 1.0
     },
     {
@@ -20448,8 +20328,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/__init__.py",
       "source_location": "L15",
       "weight": 1.0,
-      "_src": "orders_init_check_connection",
-      "_tgt": "data_source_protocol_datasourceprotocol_is_ready",
+      "_src": "data_source_protocol_datasourceprotocol_is_ready",
+      "_tgt": "orders_init_check_connection",
       "source": "data_source_protocol_datasourceprotocol_is_ready",
       "target": "orders_init_check_connection"
     },
@@ -20472,8 +20352,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/auth/service.py",
       "source_location": "L8",
       "weight": 1.0,
-      "_src": "auth_service_authservice_connect",
-      "_tgt": "data_source_protocol_datasourceprotocol_set_credentials",
+      "_src": "data_source_protocol_datasourceprotocol_set_credentials",
+      "_tgt": "auth_service_authservice_connect",
       "source": "data_source_protocol_datasourceprotocol_set_credentials",
       "target": "auth_service_authservice_connect"
     },
@@ -20496,8 +20376,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/auth/service.py",
       "source_location": "L13",
       "weight": 1.0,
-      "_src": "auth_service_authservice_disconnect",
-      "_tgt": "data_source_protocol_datasourceprotocol_clear_credentials",
+      "_src": "data_source_protocol_datasourceprotocol_clear_credentials",
+      "_tgt": "auth_service_authservice_disconnect",
       "source": "data_source_protocol_datasourceprotocol_clear_credentials",
       "target": "auth_service_authservice_disconnect"
     },
@@ -20520,8 +20400,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/sheet/service.py",
       "source_location": "L11",
       "weight": 1.0,
-      "_src": "sheet_service_sheetservice_remove",
-      "_tgt": "data_source_protocol_datasourceprotocol_clear_sheet",
+      "_src": "data_source_protocol_datasourceprotocol_clear_sheet",
+      "_tgt": "sheet_service_sheetservice_remove",
       "source": "data_source_protocol_datasourceprotocol_clear_sheet",
       "target": "sheet_service_sheetservice_remove"
     },
@@ -20544,8 +20424,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/auth/service.py",
       "source_location": "L10",
       "weight": 1.0,
-      "_src": "auth_service_authservice_connect",
-      "_tgt": "data_source_protocol_datasourceprotocol_set_sheet",
+      "_src": "data_source_protocol_datasourceprotocol_set_sheet",
+      "_tgt": "auth_service_authservice_connect",
       "source": "data_source_protocol_datasourceprotocol_set_sheet",
       "target": "auth_service_authservice_connect"
     },
@@ -20556,8 +20436,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/sheet/service.py",
       "source_location": "L8",
       "weight": 1.0,
-      "_src": "sheet_service_sheetservice_select",
-      "_tgt": "data_source_protocol_datasourceprotocol_set_sheet",
+      "_src": "data_source_protocol_datasourceprotocol_set_sheet",
+      "_tgt": "sheet_service_sheetservice_select",
       "source": "data_source_protocol_datasourceprotocol_set_sheet",
       "target": "sheet_service_sheetservice_select"
     },
@@ -20580,8 +20460,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/payments/repository.py",
       "source_location": "L19",
       "weight": 1.0,
-      "_src": "payments_repository_paymentsrepository_get_by_date",
-      "_tgt": "data_source_protocol_datasourceprotocol_fetch_orders_by_date",
+      "_src": "data_source_protocol_datasourceprotocol_fetch_orders_by_date",
+      "_tgt": "payments_repository_paymentsrepository_get_by_date",
       "source": "data_source_protocol_datasourceprotocol_fetch_orders_by_date",
       "target": "payments_repository_paymentsrepository_get_by_date"
     },
@@ -20592,8 +20472,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/deliveries/repository.py",
       "source_location": "L16",
       "weight": 1.0,
-      "_src": "deliveries_repository_deliveriesrepository_get_by_date",
-      "_tgt": "data_source_protocol_datasourceprotocol_fetch_orders_by_date",
+      "_src": "data_source_protocol_datasourceprotocol_fetch_orders_by_date",
+      "_tgt": "deliveries_repository_deliveriesrepository_get_by_date",
       "source": "data_source_protocol_datasourceprotocol_fetch_orders_by_date",
       "target": "deliveries_repository_deliveriesrepository_get_by_date"
     },
@@ -20616,8 +20496,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/summary/repository.py",
       "source_location": "L19",
       "weight": 1.0,
-      "_src": "summary_repository_orderssummaryrepository_get_by_period",
-      "_tgt": "data_source_protocol_datasourceprotocol_fetch_orders_by_period",
+      "_src": "data_source_protocol_datasourceprotocol_fetch_orders_by_period",
+      "_tgt": "summary_repository_orderssummaryrepository_get_by_period",
       "source": "data_source_protocol_datasourceprotocol_fetch_orders_by_period",
       "target": "summary_repository_orderssummaryrepository_get_by_period"
     },
@@ -20772,8 +20652,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_normalizer.py",
       "source_location": "L41",
       "weight": 1.0,
-      "_src": "data_source_normalizer_fix_prod4",
-      "_tgt": "data_source_sheet_mapper_paymentcols_slot",
+      "_src": "data_source_sheet_mapper_paymentcols_slot",
+      "_tgt": "data_source_normalizer_fix_prod4",
       "source": "data_source_sheet_mapper_paymentcols_slot",
       "target": "data_source_normalizer_fix_prod4"
     },
@@ -20784,8 +20664,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/shared/mapper.py",
       "source_location": "L65",
       "weight": 1.0,
-      "_src": "shared_mapper_products",
-      "_tgt": "data_source_sheet_mapper_paymentcols_slot",
+      "_src": "data_source_sheet_mapper_paymentcols_slot",
+      "_tgt": "shared_mapper_products",
       "source": "data_source_sheet_mapper_paymentcols_slot",
       "target": "shared_mapper_products"
     },
@@ -20796,8 +20676,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/shared/mapper.py",
       "source_location": "L80",
       "weight": 1.0,
-      "_src": "shared_mapper_payments",
-      "_tgt": "data_source_sheet_mapper_paymentcols_slot",
+      "_src": "data_source_sheet_mapper_paymentcols_slot",
+      "_tgt": "shared_mapper_payments",
       "source": "data_source_sheet_mapper_paymentcols_slot",
       "target": "shared_mapper_payments"
     },
@@ -20808,8 +20688,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/payments/repository.py",
       "source_location": "L41",
       "weight": 1.0,
-      "_src": "payments_repository_to_dataframe",
-      "_tgt": "data_source_sheet_mapper_paymentcols_slot",
+      "_src": "data_source_sheet_mapper_paymentcols_slot",
+      "_tgt": "payments_repository_to_dataframe",
       "source": "data_source_sheet_mapper_paymentcols_slot",
       "target": "payments_repository_to_dataframe"
     },
@@ -20820,8 +20700,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/summary/repository.py",
       "source_location": "L40",
       "weight": 1.0,
-      "_src": "summary_repository_to_dataframe",
-      "_tgt": "data_source_sheet_mapper_paymentcols_slot",
+      "_src": "data_source_sheet_mapper_paymentcols_slot",
+      "_tgt": "summary_repository_to_dataframe",
       "source": "data_source_sheet_mapper_paymentcols_slot",
       "target": "summary_repository_to_dataframe"
     },
@@ -21216,8 +21096,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_handler.py",
       "source_location": "L15",
       "weight": 1.0,
-      "_src": "errors_handler_is_valid_date",
-      "_tgt": "data_source_utils_normalize_date",
+      "_src": "data_source_utils_normalize_date",
+      "_tgt": "errors_handler_is_valid_date",
       "source": "data_source_utils_normalize_date",
       "target": "errors_handler_is_valid_date"
     },
@@ -21228,8 +21108,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_handler.py",
       "source_location": "L19",
       "weight": 1.0,
-      "_src": "errors_handler_parse_date",
-      "_tgt": "data_source_utils_normalize_date",
+      "_src": "data_source_utils_normalize_date",
+      "_tgt": "errors_handler_parse_date",
       "source": "data_source_utils_normalize_date",
       "target": "errors_handler_parse_date"
     },
@@ -22464,8 +22344,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/__init__.py",
       "source_location": "L16",
       "weight": 1.0,
-      "_src": "orders_init_check_connection",
-      "_tgt": "errors_errors_datasourcenotreadyerror",
+      "_src": "errors_errors_datasourcenotreadyerror",
+      "_tgt": "orders_init_check_connection",
       "source": "errors_errors_datasourcenotreadyerror",
       "target": "orders_init_check_connection"
     },
@@ -22740,8 +22620,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/shared/mapper.py",
       "source_location": "L109",
       "weight": 1.0,
-      "_src": "shared_mapper_delivery",
-      "_tgt": "shared_models_address",
+      "_src": "shared_models_address",
+      "_tgt": "shared_mapper_delivery",
       "source": "shared_models_address",
       "target": "shared_mapper_delivery"
     },
@@ -22752,8 +22632,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/shared/mapper.py",
       "source_location": "L45",
       "weight": 1.0,
-      "_src": "shared_mapper_receiver",
-      "_tgt": "shared_models_event",
+      "_src": "shared_models_event",
+      "_tgt": "shared_mapper_receiver",
       "source": "shared_models_event",
       "target": "shared_mapper_receiver"
     },
@@ -22764,8 +22644,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/shared/mapper.py",
       "source_location": "L33",
       "weight": 1.0,
-      "_src": "shared_mapper_customer",
-      "_tgt": "shared_models_customer",
+      "_src": "shared_models_customer",
+      "_tgt": "shared_mapper_customer",
       "source": "shared_models_customer",
       "target": "shared_mapper_customer"
     },
@@ -22776,8 +22656,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/shared/mapper.py",
       "source_location": "L46",
       "weight": 1.0,
-      "_src": "shared_mapper_receiver",
-      "_tgt": "shared_models_receiver",
+      "_src": "shared_models_receiver",
+      "_tgt": "shared_mapper_receiver",
       "source": "shared_models_receiver",
       "target": "shared_mapper_receiver"
     },
@@ -22788,8 +22668,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/shared/mapper.py",
       "source_location": "L54",
       "weight": 1.0,
-      "_src": "shared_mapper_customization",
-      "_tgt": "shared_models_customization",
+      "_src": "shared_models_customization",
+      "_tgt": "shared_mapper_customization",
       "source": "shared_models_customization",
       "target": "shared_mapper_customization"
     },
@@ -22800,8 +22680,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/shared/mapper.py",
       "source_location": "L68",
       "weight": 1.0,
-      "_src": "shared_mapper_products",
-      "_tgt": "shared_models_productitem",
+      "_src": "shared_models_productitem",
+      "_tgt": "shared_mapper_products",
       "source": "shared_models_productitem",
       "target": "shared_mapper_products"
     },
@@ -22812,8 +22692,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/shared/mapper.py",
       "source_location": "L84",
       "weight": 1.0,
-      "_src": "shared_mapper_payments",
-      "_tgt": "shared_models_paymentitem",
+      "_src": "shared_models_paymentitem",
+      "_tgt": "shared_mapper_payments",
       "source": "shared_models_paymentitem",
       "target": "shared_mapper_payments"
     },
@@ -22824,8 +22704,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/shared/mapper.py",
       "source_location": "L95",
       "weight": 1.0,
-      "_src": "shared_mapper_financial",
-      "_tgt": "shared_models_financial",
+      "_src": "shared_models_financial",
+      "_tgt": "shared_mapper_financial",
       "source": "shared_models_financial",
       "target": "shared_mapper_financial"
     },
@@ -22836,8 +22716,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/shared/mapper.py",
       "source_location": "L117",
       "weight": 1.0,
-      "_src": "shared_mapper_delivery",
-      "_tgt": "shared_models_delivery",
+      "_src": "shared_models_delivery",
+      "_tgt": "shared_mapper_delivery",
       "source": "shared_models_delivery",
       "target": "shared_mapper_delivery"
     },
@@ -22848,8 +22728,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/shared/mapper.py",
       "source_location": "L18",
       "weight": 1.0,
-      "_src": "shared_mapper_to_model",
-      "_tgt": "shared_models_order",
+      "_src": "shared_models_order",
+      "_tgt": "shared_mapper_to_model",
       "source": "shared_models_order",
       "target": "shared_mapper_to_model"
     },
@@ -23076,8 +22956,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/payments/service.py",
       "source_location": "L33",
       "weight": 1.0,
-      "_src": "payments_service_paymentsservice_get_pendent",
-      "_tgt": "shared_mapper_to_model",
+      "_src": "shared_mapper_to_model",
+      "_tgt": "payments_service_paymentsservice_get_pendent",
       "source": "shared_mapper_to_model",
       "target": "payments_service_paymentsservice_get_pendent"
     },
@@ -23088,8 +22968,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/summary/service.py",
       "source_location": "L31",
       "weight": 1.0,
-      "_src": "summary_service_ordersservice_get_by_period",
-      "_tgt": "shared_mapper_to_model",
+      "_src": "shared_mapper_to_model",
+      "_tgt": "summary_service_ordersservice_get_by_period",
       "source": "shared_mapper_to_model",
       "target": "summary_service_ordersservice_get_by_period"
     },
@@ -23304,8 +23184,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/payments/route.py",
       "source_location": "L14",
       "weight": 1.0,
-      "_src": "payments_route_get_payments_pendent",
-      "_tgt": "payments_service_paymentsservice_get_pendent",
+      "_src": "payments_service_paymentsservice_get_pendent",
+      "_tgt": "payments_route_get_payments_pendent",
       "source": "payments_service_paymentsservice_get_pendent",
       "target": "payments_route_get_payments_pendent"
     },
@@ -23856,8 +23736,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/deliveries/route.py",
       "source_location": "L15",
       "weight": 1.0,
-      "_src": "deliveries_route_get_deliveries",
-      "_tgt": "deliveries_service_to_response",
+      "_src": "deliveries_service_to_response",
+      "_tgt": "deliveries_route_get_deliveries",
       "source": "deliveries_service_to_response",
       "target": "deliveries_route_get_deliveries"
     },
@@ -24144,8 +24024,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/sheet/route.py",
       "source_location": "L13",
       "weight": 1.0,
-      "_src": "sheet_route_select_sheet",
-      "_tgt": "sheet_service_sheetservice_select",
+      "_src": "sheet_service_sheetservice_select",
+      "_tgt": "sheet_route_select_sheet",
       "source": "sheet_service_sheetservice_select",
       "target": "sheet_route_select_sheet"
     },
@@ -24156,8 +24036,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/sheet/route.py",
       "source_location": "L19",
       "weight": 1.0,
-      "_src": "sheet_route_remove_sheet",
-      "_tgt": "sheet_service_sheetservice_remove",
+      "_src": "sheet_service_sheetservice_remove",
+      "_tgt": "sheet_route_remove_sheet",
       "source": "sheet_service_sheetservice_remove",
       "target": "sheet_route_remove_sheet"
     },
@@ -24300,8 +24180,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/errors/_mapper.py",
       "source_location": "L27",
       "weight": 1.0,
-      "_src": "errors_mapper_translate",
-      "_tgt": "errors_errors_backenderror",
+      "_src": "errors_errors_backenderror",
+      "_tgt": "errors_mapper_translate",
       "source": "errors_errors_backenderror",
       "target": "errors_mapper_translate"
     },
@@ -24312,8 +24192,8 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/errors/_mapper.py",
       "source_location": "L36",
       "weight": 1.0,
-      "_src": "errors_mapper_generic_mapper",
-      "_tgt": "errors_errors_backenderror",
+      "_src": "errors_errors_backenderror",
+      "_tgt": "errors_mapper_generic_mapper",
       "source": "errors_errors_backenderror",
       "target": "errors_mapper_generic_mapper"
     },

--- a/maria_cacau/features/auth/domain/signals.py
+++ b/maria_cacau/features/auth/domain/signals.py
@@ -6,9 +6,7 @@ from PyQt6.QtCore import QObject, pyqtSignal
 
 
 class AuthSignals(QObject):
-    credentials_configured = pyqtSignal()
-    credentials_cleared    = pyqtSignal()
-    error                  = pyqtSignal(object)
+    error = pyqtSignal(object)
 
 
 signals: Final = AuthSignals()

--- a/maria_cacau/features/cpf_validation/domain/__init__.py
+++ b/maria_cacau/features/cpf_validation/domain/__init__.py
@@ -1,4 +1,0 @@
-from .events import FeatureEvents
-from .models import CpfValidationResult
-from .signals import signals
-from .use_case import CpfValidationUseCase

--- a/maria_cacau/features/home/sub_features/delivery/domain/__init__.py
+++ b/maria_cacau/features/home/sub_features/delivery/domain/__init__.py
@@ -1,5 +1,0 @@
-from .events import FeatureEvents
-from .models import (DeliveriesSummary, DeliveryCount, DeliveryModel,
-                     PendentOrder)
-from .signals import signals
-from .use_case import DeliveryUseCase

--- a/maria_cacau/features/sheets/domain/signals.py
+++ b/maria_cacau/features/sheets/domain/signals.py
@@ -4,10 +4,7 @@ from PyQt6.QtCore import QObject, pyqtSignal
 
 
 class SheetsSignals(QObject):
-    sheet_connected = pyqtSignal(object)
-    sheet_selected  = pyqtSignal(object)
-    sheet_renamed   = pyqtSignal(object)
-    error           = pyqtSignal(object)
+    error = pyqtSignal(object)
 
 
 signals: Final = SheetsSignals()


### PR DESCRIPTION
## Overview

Limpeza de código morto no módulo `maria_cacau`, identificado via análise estática do grafo de dependências. A motivação principal é remover ruído que se acumulou após a migração dos sinais globais para o `EventBus` central (`core/bus.py`): sinais que foram movidos para o `bus` continuavam declarados nos arquivos locais de cada feature, criando uma falsa impressão de que o canal de comunicação ainda era local. Além disso, arquivos `__init__.py` de domínio estavam re-exportando símbolos que nenhum módulo consumia via esse caminho.

Nenhuma funcionalidade foi alterada — todas as remoções são de código inacessível confirmado por ausência de importação em todo o projeto.

## Ajustes feitos

- Removidos sinais migrados ao bus mas ainda declarados em `SheetsSignals`: `sheet_connected`, `sheet_selected` e `sheet_renamed`
- Removidos sinais migrados ao bus mas ainda declarados em `AuthSignals`: `credentials_configured` e `credentials_cleared`
- Esvaziados `delivery/domain/__init__.py` e `cpf_validation/domain/__init__.py`, cujos re-exports nunca eram consumidos via o caminho do pacote
