### PR TITLE
Feature: item de release

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,9 +16,9 @@ Ao adicionar qualquer string visível ao usuário (labels, botões, menus, diál
 ## Finalizar demanda
 
 Quando o usuário pedir "finalizar a demanda" (ou variações), executar sempre:
-1. Rodar `isort` no projeto todo (via `source .envrc && python3 -m isort`)
+1. Rodar `isort` no projeto todo (via `source .envrc && python3 -m isort`) -- SEMPRE
 2. Atualizar os arquivos em `.ai/` que forem afetados pelas mudanças da sessão
-3. Rodar `graphify update .` para manter o grafo atual
+3. Rodar `graphify update .` para manter o grafo atual -- SEMPRE
 4. Entregar a descrição do PR em bloco ```md para copy/paste``` — comparar com `develop` (`main` se for a develop)
    Estilo: `## Overview` com 1–2 parágrafos focados na motivação/impacto (não técnico), depois `## Ajustes feitos` com bullets contextuais. Sem checklist, sem referências a arquivos nos bullets.```
 5. Verificar se há perguntas pertinentes para atualizar no CBL.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,11 +16,12 @@ Ao adicionar qualquer string visível ao usuário (labels, botões, menus, diál
 ## Finalizar demanda
 
 Quando o usuário pedir "finalizar a demanda" (ou variações), executar sempre:
-1. Rodar `isort` nos arquivos Python alterados na sessão (via `source .envrc && python3 -m isort <arquivos>`)
+1. Rodar `isort` no projeto todo (via `source .envrc && python3 -m isort`)
 2. Atualizar os arquivos em `.ai/` que forem afetados pelas mudanças da sessão
 3. Rodar `graphify update .` para manter o grafo atual
-4. Entregar a descrição do PR em bloco ```md para copy/paste — comparar com `develop` (ou `main`)
+4. Entregar a descrição do PR em bloco ```md para copy/paste``` — comparar com `develop` (`main` se for a develop)
    Estilo: `## Overview` com 1–2 parágrafos focados na motivação/impacto (não técnico), depois `## Ajustes feitos` com bullets contextuais. Sem checklist, sem referências a arquivos nos bullets.```
+5. Verificar se há perguntas pertinentes para atualizar no CBL.
 
 Nunca trazer código de outras branches, nunca abrir PR automaticamente.
 

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,12 +1,12 @@
 # Graph Report - Maria-Cacau-App  (2026-05-21)
 
 ## Corpus Check
-- 174 files · ~18,918 words
+- 174 files · ~18,932 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 848 nodes · 1383 edges · 31 communities detected
-- Extraction: 76% EXTRACTED · 24% INFERRED · 0% AMBIGUOUS · INFERRED: 332 edges (avg confidence: 0.79)
+- 851 nodes · 1390 edges · 30 communities detected
+- Extraction: 76% EXTRACTED · 24% INFERRED · 0% AMBIGUOUS · INFERRED: 337 edges (avg confidence: 0.78)
 - Token cost: 0 input · 0 output
 
 ## Community Hubs (Navigation)
@@ -32,20 +32,19 @@
 - [[_COMMUNITY_Community 19|Community 19]]
 - [[_COMMUNITY_Community 20|Community 20]]
 - [[_COMMUNITY_Community 21|Community 21]]
-- [[_COMMUNITY_Community 22|Community 22]]
-- [[_COMMUNITY_Community 31|Community 31]]
+- [[_COMMUNITY_Community 30|Community 30]]
+- [[_COMMUNITY_Community 43|Community 43]]
 - [[_COMMUNITY_Community 44|Community 44]]
-- [[_COMMUNITY_Community 45|Community 45]]
-- [[_COMMUNITY_Community 47|Community 47]]
+- [[_COMMUNITY_Community 46|Community 46]]
+- [[_COMMUNITY_Community 48|Community 48]]
 - [[_COMMUNITY_Community 49|Community 49]]
-- [[_COMMUNITY_Community 50|Community 50]]
+- [[_COMMUNITY_Community 51|Community 51]]
 - [[_COMMUNITY_Community 52|Community 52]]
-- [[_COMMUNITY_Community 53|Community 53]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `DataSourceError` - 20 edges
-2. `SheetsController` - 19 edges
-3. `connect()` - 19 edges
+2. `connect()` - 20 edges
+3. `SheetsController` - 19 edges
 4. `DSChart` - 15 edges
 5. `call()` - 14 edges
 6. `SummaryView` - 14 edges
@@ -55,184 +54,180 @@
 10. `unexpected_error()` - 11 edges
 
 ## Surprising Connections (you probably didn't know these)
+- `HTTPResponse` --uses--> `Contrato que qualquer client precisa cumprir.`  [INFERRED]
+  /Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/_response.py → core/network/_client.py
+- `HTTPResponse` --uses--> `Roteia requests para o backend local (in-process).     Nenhuma rede envolvida —`  [INFERRED]
+  /Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/_response.py → core/network/_client.py
+- `HTTPRequest` --uses--> `Contrato que qualquer client precisa cumprir.`  [INFERRED]
+  /Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/_request.py → core/network/_client.py
+- `HTTPRequest` --uses--> `Roteia requests para o backend local (in-process).     Nenhuma rede envolvida —`  [INFERRED]
+  /Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/_request.py → core/network/_client.py
 - `FeatureEvents` --uses--> `SheetsController`  [INFERRED]
   /Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/domain/events.py → features/sheets/presentation/controller.py
-- `SheetModel` --uses--> `SheetsController`  [INFERRED]
-  /Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/domain/models.py → features/sheets/presentation/controller.py
-- `HTTPResponse` --uses--> `HTTPClientContract`  [INFERRED]
-  /Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/_response.py → core/network/_client.py
-- `HTTPResponse` --uses--> `LocalClient`  [INFERRED]
-  /Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/_response.py → core/network/_client.py
-- `HTTPResponse` --uses--> `Realiza as request de fato`  [INFERRED]
-  /Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/_response.py → core/network/_client.py
 
 ## Communities
 
 ### Community 0 - "Community 0"
 Cohesion: 0.03
-Nodes (57): GoogleSheetsDataSource, Implementação de DataSourceProtocol para Google Sheets via gspread., _fix_prod4(), normalize(), Normaliza headers inconsistentes da planilha para os valores canônicos dos enums, Traduz headers reais da planilha para os nomes canônicos definidos nos enums., _rename_at(), _rename_keys() (+49 more)
+Nodes (47): _EventBus, DeliveriesMapper, ErrorMapper, from_response(), OrdersSummaryMapper, PaymentsMapper, Mappers de HTTPResponse para domain models e de HTTPResponseError para ErrorMode, SummaryRepository (+39 more)
 
 ### Community 1 - "Community 1"
 Cohesion: 0.04
-Nodes (40): _EventBus, DeliveriesMapper, ErrorMapper, from_response(), OrdersSummaryMapper, PaymentsMapper, Mappers de HTTPResponse para domain models e de HTTPResponseError para ErrorMode, SummaryRepository (+32 more)
+Nodes (48): GoogleSheetsDataSource, Implementação de DataSourceProtocol para Google Sheets via gspread., _fix_prod4(), normalize(), Normaliza headers inconsistentes da planilha para os valores canônicos dos enums, Traduz headers reais da planilha para os nomes canônicos definidos nos enums., _rename_at(), _rename_keys() (+40 more)
 
 ### Community 2 - "Community 2"
 Cohesion: 0.05
 Nodes (26): API, ConnectAuthAPI, DeliveriesAPI, DisconnectAuthAPI, OrdersSummaryAPI, path(), PaymentsPendentAPI, Endpoints do backend consumidos pela feature Auth. (+18 more)
 
 ### Community 3 - "Community 3"
-Cohesion: 0.05
-Nodes (35): ABC, API, entity(), Comunicação alto nivel para chamadas de api, HTTPClientContract, LocalClient, Realiza as request de fato, Contrato que qualquer client precisa cumprir. (+27 more)
+Cohesion: 0.04
+Nodes (45): ABC, ProductCols, Colunas fixas da aba Cadastro, agrupadas por domínio., Colunas dos slots de produto (1–7). Usar com .slot(n)., SheetCols, SheetTabs, API, entity() (+37 more)
 
 ### Community 4 - "Community 4"
-Cohesion: 0.06
-Nodes (14): DSDialog, DSDialogIcon, DSDialogModel, DSComboBox, asset(), Metadados centralizados do pacote maria-cacau., Resolve um path relativo à pasta assets, funciona em dev e no .exe compilado., DeliveryController (+6 more)
+Cohesion: 0.05
+Nodes (16): DSDialog, DSDialogIcon, DSDialogModel, DSComboBox, asset(), Metadados centralizados do pacote maria-cacau., Resolve um path relativo à pasta assets, funciona em dev e no .exe compilado., AuthController (+8 more)
 
 ### Community 5 - "Community 5"
 Cohesion: 0.06
-Nodes (10): MenuHandler, connect(), SheetsUseCase, Erro genérico para exceções não tratadas., unexpected_error(), SheetsController, AuthView, SheetsViewModel (+2 more)
+Nodes (12): MenuHandler, connect(), DSTextInput, CpfValidationController, SheetsController, AuthView, CpfValidationView, QDialog (+4 more)
 
 ### Community 6 - "Community 6"
+Cohesion: 0.05
+Nodes (35): Retorna pedidos da data informada (DD/MM/YYYY)., DeliveriesSummary, DeliveryTypeCount, Models de domínio da feature de entregas., DeliveriesRepository, Repositório de entregas — busca e prepara dados da planilha para o DeliveriesSer, Retorna todos os pedidos de uma data como DataFrame bruto., Acessa o data source e entrega um DataFrame para o DeliveriesService.      Não f (+27 more)
+
+### Community 7 - "Community 7"
+Cohesion: 0.06
+Nodes (36): Retorna pedidos no intervalo de datas informado (DD/MM/YYYY)., PaymentCols, Colunas das parcelas de pagamento (1–6). Usar com .slot(n)., _customer(), _customization(), _delivery(), _financial(), OrderMapper (+28 more)
+
+### Community 8 - "Community 8"
 Cohesion: 0.06
 Nodes (14): DSButton, DSGroupBox, DSLoadingHandler, DSLoadingHandler, Deve ser chamado no __init__ do componente, após o super().__init__()., Implementar no componente: o que fazer com cada frame do spinner., Mixin que adiciona comportamento de loading animado a qualquer componente QObjec, DSDateInput (+6 more)
 
-### Community 7 - "Community 7"
-Cohesion: 0.07
-Nodes (34): Retorna pedidos no intervalo de datas informado (DD/MM/YYYY)., _customer(), _customization(), _delivery(), _financial(), OrderMapper, _payments(), _products() (+26 more)
-
-### Community 8 - "Community 8"
-Cohesion: 0.07
-Nodes (13): CpfValidationResult, Models utilizados no módulo, CpfValidationUseCase, _is_valid_cpf(), Valida um CPF pela regra dos dois dígitos verificadores (algoritmo da Receita Fe, DSTextInput, CpfValidationController, CpfValidationView (+5 more)
-
 ### Community 9 - "Community 9"
 Cohesion: 0.07
-Nodes (26): DeliveriesSummary, DeliveryTypeCount, Models de domínio da feature de entregas., DeliveriesRepository, Repositório de entregas — busca e prepara dados da planilha para o DeliveriesSer, Acessa o data source e entrega um DataFrame para o DeliveriesService.      Não f, DeliveriesMapper, DeliveriesService (+18 more)
+Nodes (16): SheetsUseCase, AppError, certificado_limpo(), certificado_ok(), planilha_conectada(), planilha_ok(), Códigos de erro da aplicação com estrutura AppError., Confirmação de certificado configurado com sucesso. (+8 more)
 
 ### Community 10 - "Community 10"
 Cohesion: 0.07
-Nodes (15): Rotas de autenticação, AuthService, Service de autenticação — gerencia o estado de conexão do DataSource., DataSourceProtocol, Autentica com o dict da service account e guarda o client em memória., Remove o client autenticado da memória. Mantém o sheet_id., Remove a planilha ativa da memória. Mantém as credenciais., Define a planilha ativa e dispara prewarm em background. (+7 more)
+Nodes (14): Rotas de autenticação, AuthService, Service de autenticação — gerencia o estado de conexão do DataSource., DataSourceProtocol, Autentica com o dict da service account e guarda o client em memória., Remove o client autenticado da memória. Mantém o sheet_id., Remove a planilha ativa da memória. Mantém as credenciais., Define a planilha ativa e dispara prewarm em background. (+6 more)
 
 ### Community 11 - "Community 11"
-Cohesion: 0.08
-Nodes (21): Retorna pedidos da data informada (DD/MM/YYYY)., Retorna todos os pedidos de uma data como DataFrame bruto., get_deliveries(), Rota de entregas — GET /orders/deliveries., to_response(), _cast_numeric(), PaymentsRepository, Repositório de pagamentos — busca e prepara dados da planilha para o PaymentsSer (+13 more)
-
-### Community 12 - "Community 12"
 Cohesion: 0.1
 Nodes (6): StatusBarState, DSLabel, StatusBarController, StatusBarView, QLabel, QStatusBar
 
-### Community 13 - "Community 13"
+### Community 12 - "Community 12"
 Cohesion: 0.1
 Nodes (9): AppCoordinator, MainWindow, main(), Entry point da aplicação. Execute com: python -m maria_cacau, QMainWindow, QWidget, HomeController, HomeFeaturesModel (+1 more)
 
-### Community 14 - "Community 14"
+### Community 13 - "Community 13"
 Cohesion: 0.13
 Nodes (11): DSButtonState, AppEvent, _Observability, Observabilidade centralizada do app., Services, FeatureEvents, Eventos de observabilidade da feature CPF Validation., Enum (+3 more)
 
-### Community 15 - "Community 15"
-Cohesion: 0.13
-Nodes (5): AuthUseCase, Lê o arquivo JSON, salva em storage seguro e autentica o backend., Remove credenciais do storage e desautentica o backend., AuthController, AuthViewModel
-
-### Community 16 - "Community 16"
+### Community 14 - "Community 14"
 Cohesion: 0.21
 Nodes (4): DSChartType, DSChart, Widget de gráfico reutilizável (barras ou pizza) usando seaborn + matplotlib., _short_label()
 
-### Community 17 - "Community 17"
+### Community 15 - "Community 15"
 Cohesion: 0.24
 Nodes (7): BackendServer, handle_backend_error(), handle_data_source_error(), handle_unexpected_error(), BackendError, generic_mapper(), translate()
 
-### Community 18 - "Community 18"
+### Community 16 - "Community 16"
 Cohesion: 0.31
 Nodes (2): Backend de armazenamento seguro via arquivo protegido no diretório do usuário., SecurityStorage
 
-### Community 19 - "Community 19"
+### Community 17 - "Community 17"
+Cohesion: 0.29
+Nodes (3): AuthUseCase, Lê o arquivo JSON, salva em storage seguro e autentica o backend., Remove credenciais do storage e desautentica o backend.
+
+### Community 18 - "Community 18"
 Cohesion: 0.4
 Nodes (3): normalize_decimal(), Utilitários de formatação numérica., Converte número no formato brasileiro para o formato inglês.      Remove o separ
 
-### Community 20 - "Community 20"
+### Community 19 - "Community 19"
 Cohesion: 0.5
 Nodes (1): AppSession
 
-### Community 21 - "Community 21"
+### Community 20 - "Community 20"
 Cohesion: 1.0
 Nodes (1): r"""Indica se a resposta foi bem sucedida (status code 2xx).
 
-### Community 22 - "Community 22"
+### Community 21 - "Community 21"
 Cohesion: 1.0
 Nodes (1): O tipo precisa aceitar **kwargs (dataclass ou similar).
 
-### Community 31 - "Community 31"
+### Community 30 - "Community 30"
 Cohesion: 1.0
 Nodes (1): Lê o JSON do backend; cai em http_error genérico se o corpo não for JSON válido.
 
-### Community 44 - "Community 44"
+### Community 43 - "Community 43"
 Cohesion: 1.0
 Nodes (1): Renomeia a coluna que segue prod3 para prod4, independente do header atual.
 
-### Community 45 - "Community 45"
+### Community 44 - "Community 44"
 Cohesion: 1.0
 Nodes (1): Busca pedidos por datas usando dois passes para minimizar chamadas à API.
 
-### Community 47 - "Community 47"
+### Community 46 - "Community 46"
 Cohesion: 1.0
 Nodes (1): Monta um Order completo a partir de uma linha do DataFrame.
 
-### Community 49 - "Community 49"
+### Community 48 - "Community 48"
 Cohesion: 1.0
 Nodes (1): Converte list[dict] em DataFrame com cast numérico de todas as colunas de valor.
 
-### Community 50 - "Community 50"
+### Community 49 - "Community 49"
 Cohesion: 1.0
 Nodes (1): Faz cast numérico de uma coluna se ela existir no DataFrame.
 
-### Community 52 - "Community 52"
+### Community 51 - "Community 51"
 Cohesion: 1.0
 Nodes (1): Converte list[dict] em DataFrame com cast numérico de todas as colunas de valor.
 
-### Community 53 - "Community 53"
+### Community 52 - "Community 52"
 Cohesion: 1.0
 Nodes (1): Faz cast numérico de uma coluna se ela existir no DataFrame.
 
 ## Knowledge Gaps
 - **113 isolated node(s):** `Metadados centralizados do pacote maria-cacau.`, `Resolve um path relativo à pasta assets, funciona em dev e no .exe compilado.`, `Entry point da aplicação. Execute com: python -m maria_cacau`, `Observabilidade centralizada do app.`, `Erros mapeados usados no módulo` (+108 more)
   These have ≤1 connection - possible missing edges or undocumented components.
-- **Thin community `Community 18`** (9 nodes): `Backend de armazenamento seguro via arquivo protegido no diretório do usuário.`, `SecurityStorage`, `.clean_all()`, `.delete()`, `.__init__()`, `._path()`, `.retrieve()`, `.save()`, `security.py`
+- **Thin community `Community 16`** (9 nodes): `Backend de armazenamento seguro via arquivo protegido no diretório do usuário.`, `SecurityStorage`, `.clean_all()`, `.delete()`, `.__init__()`, `._path()`, `.retrieve()`, `.save()`, `security.py`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 20`** (4 nodes): `AppSession`, `.__init__()`, `__init__.py`, `session.py`
+- **Thin community `Community 19`** (4 nodes): `AppSession`, `.__init__()`, `__init__.py`, `session.py`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 21`** (1 nodes): `r"""Indica se a resposta foi bem sucedida (status code 2xx).`
+- **Thin community `Community 20`** (1 nodes): `r"""Indica se a resposta foi bem sucedida (status code 2xx).`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 22`** (1 nodes): `O tipo precisa aceitar **kwargs (dataclass ou similar).`
+- **Thin community `Community 21`** (1 nodes): `O tipo precisa aceitar **kwargs (dataclass ou similar).`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 31`** (1 nodes): `Lê o JSON do backend; cai em http_error genérico se o corpo não for JSON válido.`
+- **Thin community `Community 30`** (1 nodes): `Lê o JSON do backend; cai em http_error genérico se o corpo não for JSON válido.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 44`** (1 nodes): `Renomeia a coluna que segue prod3 para prod4, independente do header atual.`
+- **Thin community `Community 43`** (1 nodes): `Renomeia a coluna que segue prod3 para prod4, independente do header atual.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 45`** (1 nodes): `Busca pedidos por datas usando dois passes para minimizar chamadas à API.`
+- **Thin community `Community 44`** (1 nodes): `Busca pedidos por datas usando dois passes para minimizar chamadas à API.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 47`** (1 nodes): `Monta um Order completo a partir de uma linha do DataFrame.`
+- **Thin community `Community 46`** (1 nodes): `Monta um Order completo a partir de uma linha do DataFrame.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 49`** (1 nodes): `Converte list[dict] em DataFrame com cast numérico de todas as colunas de valor.`
+- **Thin community `Community 48`** (1 nodes): `Converte list[dict] em DataFrame com cast numérico de todas as colunas de valor.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 50`** (1 nodes): `Faz cast numérico de uma coluna se ela existir no DataFrame.`
+- **Thin community `Community 49`** (1 nodes): `Faz cast numérico de uma coluna se ela existir no DataFrame.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 52`** (1 nodes): `Converte list[dict] em DataFrame com cast numérico de todas as colunas de valor.`
+- **Thin community `Community 51`** (1 nodes): `Converte list[dict] em DataFrame com cast numérico de todas as colunas de valor.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 53`** (1 nodes): `Faz cast numérico de uma coluna se ela existir no DataFrame.`
+- **Thin community `Community 52`** (1 nodes): `Faz cast numérico de uma coluna se ela existir no DataFrame.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions
 _Questions this graph is uniquely positioned to answer:_
 
-- **Why does `SheetsController` connect `Community 5` to `Community 1`, `Community 2`, `Community 4`, `Community 8`, `Community 10`, `Community 14`?**
-  _High betweenness centrality (0.108) - this node is a cross-community bridge._
-- **Why does `connect()` connect `Community 5` to `Community 4`, `Community 6`, `Community 8`, `Community 10`, `Community 12`, `Community 13`, `Community 15`?**
-  _High betweenness centrality (0.100) - this node is a cross-community bridge._
-- **Why does `call()` connect `Community 2` to `Community 17`, `Community 3`?**
+- **Why does `SheetsController` connect `Community 5` to `Community 0`, `Community 2`, `Community 4`, `Community 9`, `Community 10`, `Community 13`?**
+  _High betweenness centrality (0.107) - this node is a cross-community bridge._
+- **Why does `connect()` connect `Community 5` to `Community 4`, `Community 8`, `Community 10`, `Community 11`, `Community 12`?**
+  _High betweenness centrality (0.101) - this node is a cross-community bridge._
+- **Why does `call()` connect `Community 2` to `Community 3`, `Community 15`?**
   _High betweenness centrality (0.080) - this node is a cross-community bridge._
+- **Are the 19 inferred relationships involving `connect()` (e.g. with `.__init__()` and `._create_features_menu()`) actually correct?**
+  _`connect()` has 19 INFERRED edges - model-reasoned connections that need verification._
 - **Are the 4 inferred relationships involving `SheetsController` (e.g. with `FeatureEvents` and `SheetModel`) actually correct?**
   _`SheetsController` has 4 INFERRED edges - model-reasoned connections that need verification._
-- **Are the 18 inferred relationships involving `connect()` (e.g. with `.__init__()` and `._create_features_menu()`) actually correct?**
-  _`connect()` has 18 INFERRED edges - model-reasoned connections that need verification._
 - **Are the 2 inferred relationships involving `DSChart` (e.g. with `._setup_components()` and `._setup_components()`) actually correct?**
   _`DSChart` has 2 INFERRED edges - model-reasoned connections that need verification._
 - **What connects `Metadados centralizados do pacote maria-cacau.`, `Resolve um path relativo à pasta assets, funciona em dev e no .exe compilado.`, `Entry point da aplicação. Execute com: python -m maria_cacau` to the rest of the system?**

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -45,7 +45,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/__main__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_main_py",
-      "community": 13,
+      "community": 12,
       "norm_label": "__main__.py"
     },
     {
@@ -54,7 +54,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/__main__.py",
       "source_location": "L10",
       "id": "maria_cacau_main_main",
-      "community": 13,
+      "community": 12,
       "norm_label": "main()"
     },
     {
@@ -62,7 +62,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/__main__.py",
       "source_location": "L1",
-      "community": 13,
+      "community": 12,
       "norm_label": "entry point da aplicacao. execute com: python -m maria_cacau",
       "id": "maria_cacau_main_rationale_1"
     },
@@ -72,7 +72,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/services.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_core_services_py",
-      "community": 14,
+      "community": 13,
       "norm_label": "services.py"
     },
     {
@@ -81,7 +81,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/services.py",
       "source_location": "L4",
       "id": "core_services_services",
-      "community": 14,
+      "community": 13,
       "norm_label": "services"
     },
     {
@@ -90,7 +90,7 @@
       "source_file": "",
       "source_location": "",
       "id": "enum",
-      "community": 14,
+      "community": 13,
       "norm_label": "enum"
     },
     {
@@ -99,7 +99,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/session.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_core_session_py",
-      "community": 20,
+      "community": 19,
       "norm_label": "session.py"
     },
     {
@@ -108,7 +108,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/session.py",
       "source_location": "L1",
       "id": "core_session_appsession",
-      "community": 20,
+      "community": 19,
       "norm_label": "appsession"
     },
     {
@@ -117,7 +117,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/session.py",
       "source_location": "L2",
       "id": "core_session_appsession_init",
-      "community": 20,
+      "community": 19,
       "norm_label": ".__init__()"
     },
     {
@@ -126,7 +126,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_core_init_py",
-      "community": 20,
+      "community": 19,
       "norm_label": "__init__.py"
     },
     {
@@ -135,7 +135,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/observability.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_core_observability_py",
-      "community": 14,
+      "community": 13,
       "norm_label": "observability.py"
     },
     {
@@ -144,7 +144,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/observability.py",
       "source_location": "L13",
       "id": "core_observability_appevent",
-      "community": 14,
+      "community": 13,
       "norm_label": "appevent"
     },
     {
@@ -153,7 +153,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/observability.py",
       "source_location": "L18",
       "id": "core_observability_observability",
-      "community": 14,
+      "community": 13,
       "norm_label": "_observability"
     },
     {
@@ -162,7 +162,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/observability.py",
       "source_location": "L19",
       "id": "core_observability_observability_init",
-      "community": 14,
+      "community": 13,
       "norm_label": ".__init__()"
     },
     {
@@ -179,7 +179,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/observability.py",
       "source_location": "L1",
-      "community": 14,
+      "community": 13,
       "norm_label": "observabilidade centralizada do app.",
       "id": "core_observability_rationale_1"
     },
@@ -189,7 +189,7 @@
       "source_file": "core/bus.py",
       "source_location": "L1",
       "id": "core_bus_py",
-      "community": 1,
+      "community": 0,
       "norm_label": "bus.py"
     },
     {
@@ -198,7 +198,7 @@
       "source_file": "core/bus.py",
       "source_location": "L4",
       "id": "core_bus_eventbus",
-      "community": 1,
+      "community": 0,
       "norm_label": "_eventbus"
     },
     {
@@ -207,7 +207,7 @@
       "source_file": "",
       "source_location": "",
       "id": "qobject",
-      "community": 1,
+      "community": 0,
       "norm_label": "qobject"
     },
     {
@@ -234,7 +234,7 @@
       "source_file": "",
       "source_location": "",
       "id": "exception",
-      "community": 9,
+      "community": 6,
       "norm_label": "exception"
     },
     {
@@ -297,7 +297,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/_errors.py",
       "source_location": "L34",
       "id": "network_errors_errormessages",
-      "community": 0,
+      "community": 3,
       "norm_label": "errormessages"
     },
     {
@@ -306,7 +306,7 @@
       "source_file": "",
       "source_location": "",
       "id": "strenum",
-      "community": 0,
+      "community": 3,
       "norm_label": "strenum"
     },
     {
@@ -431,7 +431,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/_response.py",
       "source_location": "L17",
-      "community": 21,
+      "community": 20,
       "norm_label": "r\"\"\"indica se a resposta foi bem sucedida (status code 2xx).",
       "id": "network_response_rationale_17"
     },
@@ -548,7 +548,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/api.py",
       "source_location": "L34",
-      "community": 22,
+      "community": 21,
       "norm_label": "o tipo precisa aceitar **kwargs (dataclass ou similar).",
       "id": "network_api_rationale_34"
     },
@@ -565,7 +565,7 @@
       "label": "HTTPClientContract",
       "file_type": "code",
       "source_file": "core/network/_client.py",
-      "source_location": "L13",
+      "source_location": "L12",
       "id": "network_client_httpclientcontract",
       "community": 3,
       "norm_label": "httpclientcontract"
@@ -576,14 +576,14 @@
       "source_file": "",
       "source_location": "",
       "id": "protocol",
-      "community": 10,
+      "community": 3,
       "norm_label": "protocol"
     },
     {
       "label": ".execute()",
       "file_type": "code",
       "source_file": "core/network/_client.py",
-      "source_location": "L15",
+      "source_location": "L14",
       "id": "network_client_httpclientcontract_execute",
       "community": 3,
       "norm_label": ".execute()"
@@ -592,7 +592,7 @@
       "label": "LocalClient",
       "file_type": "code",
       "source_file": "core/network/_client.py",
-      "source_location": "L20",
+      "source_location": "L19",
       "id": "network_client_localclient",
       "community": 3,
       "norm_label": "localclient"
@@ -601,7 +601,7 @@
       "label": ".__init__()",
       "file_type": "code",
       "source_file": "core/network/_client.py",
-      "source_location": "L25",
+      "source_location": "L24",
       "id": "network_client_localclient_init",
       "community": 3,
       "norm_label": ".__init__()"
@@ -610,9 +610,9 @@
       "label": ".execute()",
       "file_type": "code",
       "source_file": "core/network/_client.py",
-      "source_location": "L28",
+      "source_location": "L27",
       "id": "network_client_localclient_execute",
-      "community": 14,
+      "community": 13,
       "norm_label": ".execute()"
     },
     {
@@ -628,19 +628,19 @@
       "label": "Contrato que qualquer client precisa cumprir.",
       "file_type": "rationale",
       "source_file": "core/network/_client.py",
-      "source_location": "L14",
+      "source_location": "L13",
+      "id": "network_client_rationale_13",
       "community": 3,
-      "norm_label": "contrato que qualquer client precisa cumprir.",
-      "id": "network_client_rationale_14"
+      "norm_label": "contrato que qualquer client precisa cumprir."
     },
     {
       "label": "Roteia requests para o backend local (in-process).     Nenhuma rede envolvida \u2014",
       "file_type": "rationale",
       "source_file": "core/network/_client.py",
-      "source_location": "L21",
+      "source_location": "L20",
+      "id": "network_client_rationale_20",
       "community": 3,
-      "norm_label": "roteia requests para o backend local (in-process).     nenhuma rede envolvida \u2014",
-      "id": "network_client_rationale_21"
+      "norm_label": "roteia requests para o backend local (in-process).     nenhuma rede envolvida \u2014"
     },
     {
       "label": "_observability.py",
@@ -648,7 +648,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/_observability.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_core_network_observability_py",
-      "community": 14,
+      "community": 13,
       "norm_label": "_observability.py"
     },
     {
@@ -657,7 +657,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/_observability.py",
       "source_location": "L12",
       "id": "network_observability_networkevent",
-      "community": 14,
+      "community": 13,
       "norm_label": "networkevent"
     },
     {
@@ -666,7 +666,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/_observability.py",
       "source_location": "L19",
       "id": "network_observability_track",
-      "community": 14,
+      "community": 13,
       "norm_label": "track()"
     },
     {
@@ -674,7 +674,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/_observability.py",
       "source_location": "L1",
-      "community": 14,
+      "community": 13,
       "norm_label": "observabilidade da camada de network.",
       "id": "network_observability_rationale_1"
     },
@@ -837,7 +837,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/storage/security.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_core_storage_security_py",
-      "community": 18,
+      "community": 16,
       "norm_label": "security.py"
     },
     {
@@ -846,7 +846,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/storage/security.py",
       "source_location": "L10",
       "id": "storage_security_securitystorage",
-      "community": 18,
+      "community": 16,
       "norm_label": "securitystorage"
     },
     {
@@ -855,7 +855,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/storage/security.py",
       "source_location": "L11",
       "id": "storage_security_securitystorage_init",
-      "community": 18,
+      "community": 16,
       "norm_label": ".__init__()"
     },
     {
@@ -864,7 +864,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/storage/security.py",
       "source_location": "L15",
       "id": "storage_security_securitystorage_save",
-      "community": 18,
+      "community": 16,
       "norm_label": ".save()"
     },
     {
@@ -873,7 +873,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/storage/security.py",
       "source_location": "L23",
       "id": "storage_security_securitystorage_retrieve",
-      "community": 18,
+      "community": 16,
       "norm_label": ".retrieve()"
     },
     {
@@ -882,7 +882,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/storage/security.py",
       "source_location": "L29",
       "id": "storage_security_securitystorage_delete",
-      "community": 18,
+      "community": 16,
       "norm_label": ".delete()"
     },
     {
@@ -891,7 +891,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/storage/security.py",
       "source_location": "L36",
       "id": "storage_security_securitystorage_clean_all",
-      "community": 18,
+      "community": 16,
       "norm_label": ".clean_all()"
     },
     {
@@ -900,7 +900,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/storage/security.py",
       "source_location": "L40",
       "id": "storage_security_securitystorage_path",
-      "community": 18,
+      "community": 16,
       "norm_label": "._path()"
     },
     {
@@ -908,7 +908,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/storage/security.py",
       "source_location": "L1",
-      "community": 18,
+      "community": 16,
       "norm_label": "backend de armazenamento seguro via arquivo protegido no diretorio do usuario.",
       "id": "storage_security_rationale_1"
     },
@@ -999,7 +999,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/storage/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_core_storage_init_py",
-      "community": 23,
+      "community": 22,
       "norm_label": "__init__.py"
     },
     {
@@ -1017,7 +1017,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/error/models.py",
       "source_location": "L7",
       "id": "error_models_errormodel",
-      "community": 9,
+      "community": 6,
       "norm_label": "errormodel"
     },
     {
@@ -1026,7 +1026,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/error/models.py",
       "source_location": "L12",
       "id": "error_models_errormodel_post_init",
-      "community": 9,
+      "community": 6,
       "norm_label": ".__post_init__()"
     },
     {
@@ -1116,7 +1116,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/error/errors.py",
       "source_location": "L131",
       "id": "error_errors_unexpected_error",
-      "community": 5,
+      "community": 9,
       "norm_label": "unexpected_error()"
     },
     {
@@ -1125,7 +1125,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/error/errors.py",
       "source_location": "L140",
       "id": "error_errors_http_error",
-      "community": 1,
+      "community": 0,
       "norm_label": "http_error()"
     },
     {
@@ -1187,7 +1187,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/error/errors.py",
       "source_location": "L132",
-      "community": 5,
+      "community": 9,
       "norm_label": "erro generico para excecoes nao tratadas.",
       "id": "error_errors_rationale_132"
     },
@@ -1196,7 +1196,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/error/errors.py",
       "source_location": "L141",
-      "community": 1,
+      "community": 0,
       "norm_label": "erro http sem body json \u2014 resposta de erro nao estruturada do servidor.",
       "id": "error_errors_rationale_141"
     },
@@ -1215,7 +1215,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/app/coordinator.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_app_coordinator_py",
-      "community": 13,
+      "community": 12,
       "norm_label": "coordinator.py"
     },
     {
@@ -1224,7 +1224,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/app/coordinator.py",
       "source_location": "L17",
       "id": "app_coordinator_appcoordinator",
-      "community": 13,
+      "community": 12,
       "norm_label": "appcoordinator"
     },
     {
@@ -1233,7 +1233,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/app/coordinator.py",
       "source_location": "L18",
       "id": "app_coordinator_appcoordinator_init",
-      "community": 13,
+      "community": 12,
       "norm_label": ".__init__()"
     },
     {
@@ -1242,7 +1242,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/app/coordinator.py",
       "source_location": "L24",
       "id": "app_coordinator_appcoordinator_launch",
-      "community": 13,
+      "community": 12,
       "norm_label": ".launch()"
     },
     {
@@ -1251,7 +1251,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/app/coordinator.py",
       "source_location": "L30",
       "id": "app_coordinator_appcoordinator_configure_app",
-      "community": 13,
+      "community": 12,
       "norm_label": "._configure_app()"
     },
     {
@@ -1260,7 +1260,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/app/coordinator.py",
       "source_location": "L35",
       "id": "app_coordinator_appcoordinator_on_launch",
-      "community": 13,
+      "community": 12,
       "norm_label": "._on_launch()"
     },
     {
@@ -1278,7 +1278,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/app/coordinator.py",
       "source_location": "L46",
       "id": "app_coordinator_appcoordinator_on_quit",
-      "community": 13,
+      "community": 12,
       "norm_label": "._on_quit()"
     },
     {
@@ -1305,7 +1305,7 @@
       "source_file": "app/handler.py",
       "source_location": "L11",
       "id": "app_handler_menuhandler_init",
-      "community": 8,
+      "community": 5,
       "norm_label": ".__init__()"
     },
     {
@@ -1336,12 +1336,21 @@
       "norm_label": "._create_help_menu()"
     },
     {
+      "label": "._create_url_action()",
+      "file_type": "code",
+      "source_file": "app/handler.py",
+      "source_location": "L39",
+      "id": "app_handler_menuhandler_create_url_action",
+      "community": 5,
+      "norm_label": "._create_url_action()"
+    },
+    {
       "label": "window.py",
       "file_type": "code",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/app/window.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_app_window_py",
-      "community": 13,
+      "community": 12,
       "norm_label": "window.py"
     },
     {
@@ -1350,7 +1359,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/app/window.py",
       "source_location": "L10",
       "id": "app_window_mainwindow",
-      "community": 13,
+      "community": 12,
       "norm_label": "mainwindow"
     },
     {
@@ -1359,7 +1368,7 @@
       "source_file": "",
       "source_location": "",
       "id": "qmainwindow",
-      "community": 13,
+      "community": 12,
       "norm_label": "qmainwindow"
     },
     {
@@ -1368,7 +1377,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/app/window.py",
       "source_location": "L11",
       "id": "app_window_mainwindow_init",
-      "community": 13,
+      "community": 12,
       "norm_label": ".__init__()"
     },
     {
@@ -1377,7 +1386,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/app/window.py",
       "source_location": "L20",
       "id": "app_window_mainwindow_setup_window",
-      "community": 13,
+      "community": 12,
       "norm_label": "._setup_window()"
     },
     {
@@ -1386,7 +1395,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/app/window.py",
       "source_location": "L30",
       "id": "app_window_mainwindow_setup_menus",
-      "community": 13,
+      "community": 12,
       "norm_label": "._setup_menus()"
     },
     {
@@ -1395,7 +1404,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/app/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_app_init_py",
-      "community": 13,
+      "community": 12,
       "norm_label": "__init__.py"
     },
     {
@@ -1404,7 +1413,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/constants.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_design_system_constants_py",
-      "community": 24,
+      "community": 23,
       "norm_label": "constants.py"
     },
     {
@@ -1413,7 +1422,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_design_system_init_py",
-      "community": 25,
+      "community": 24,
       "norm_label": "__init__.py"
     },
     {
@@ -1422,7 +1431,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_design_system_components_init_py",
-      "community": 26,
+      "community": 25,
       "norm_label": "__init__.py"
     },
     {
@@ -1431,7 +1440,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/buttons/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_design_system_components_buttons_init_py",
-      "community": 14,
+      "community": 13,
       "norm_label": "__init__.py"
     },
     {
@@ -1440,7 +1449,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/buttons/button.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_design_system_components_buttons_button_py",
-      "community": 14,
+      "community": 13,
       "norm_label": "button.py"
     },
     {
@@ -1449,7 +1458,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/buttons/button.py",
       "source_location": "L9",
       "id": "buttons_button_dsbutton",
-      "community": 6,
+      "community": 8,
       "norm_label": "dsbutton"
     },
     {
@@ -1458,7 +1467,7 @@
       "source_file": "",
       "source_location": "",
       "id": "qpushbutton",
-      "community": 6,
+      "community": 8,
       "norm_label": "qpushbutton"
     },
     {
@@ -1467,7 +1476,7 @@
       "source_file": "",
       "source_location": "",
       "id": "dsloadinghandler",
-      "community": 6,
+      "community": 8,
       "norm_label": "dsloadinghandler"
     },
     {
@@ -1476,7 +1485,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/buttons/button.py",
       "source_location": "L11",
       "id": "buttons_button_dsbutton_init",
-      "community": 6,
+      "community": 8,
       "norm_label": ".__init__()"
     },
     {
@@ -1485,7 +1494,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/buttons/button.py",
       "source_location": "L22",
       "id": "buttons_button_dsbutton_update_state",
-      "community": 6,
+      "community": 8,
       "norm_label": ".update_state()"
     },
     {
@@ -1494,7 +1503,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/buttons/button.py",
       "source_location": "L40",
       "id": "buttons_button_dsbutton_on_loading_tick",
-      "community": 6,
+      "community": 8,
       "norm_label": "._on_loading_tick()"
     },
     {
@@ -1503,7 +1512,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/buttons/button.py",
       "source_location": "L45",
       "id": "buttons_button_dsbutton_mousepressevent",
-      "community": 6,
+      "community": 8,
       "norm_label": ".mousepressevent()"
     },
     {
@@ -1512,7 +1521,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/buttons/states.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_design_system_components_buttons_states_py",
-      "community": 14,
+      "community": 13,
       "norm_label": "states.py"
     },
     {
@@ -1521,7 +1530,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/buttons/states.py",
       "source_location": "L4",
       "id": "buttons_states_dsbuttonstate",
-      "community": 14,
+      "community": 13,
       "norm_label": "dsbuttonstate"
     },
     {
@@ -1530,7 +1539,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/chart/chart_type.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_design_system_components_chart_chart_type_py",
-      "community": 16,
+      "community": 14,
       "norm_label": "chart_type.py"
     },
     {
@@ -1539,7 +1548,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/chart/chart_type.py",
       "source_location": "L4",
       "id": "chart_chart_type_dscharttype",
-      "community": 16,
+      "community": 14,
       "norm_label": "dscharttype"
     },
     {
@@ -1548,7 +1557,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/chart/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_design_system_components_chart_init_py",
-      "community": 16,
+      "community": 14,
       "norm_label": "__init__.py"
     },
     {
@@ -1557,7 +1566,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/chart/chart_widget.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_design_system_components_chart_chart_widget_py",
-      "community": 16,
+      "community": 14,
       "norm_label": "chart_widget.py"
     },
     {
@@ -1566,7 +1575,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/chart/chart_widget.py",
       "source_location": "L18",
       "id": "chart_chart_widget_short_label",
-      "community": 16,
+      "community": 14,
       "norm_label": "_short_label()"
     },
     {
@@ -1575,7 +1584,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/chart/chart_widget.py",
       "source_location": "L26",
       "id": "chart_chart_widget_dschart",
-      "community": 16,
+      "community": 14,
       "norm_label": "dschart"
     },
     {
@@ -1584,7 +1593,7 @@
       "source_file": "",
       "source_location": "",
       "id": "qwidget",
-      "community": 13,
+      "community": 12,
       "norm_label": "qwidget"
     },
     {
@@ -1593,7 +1602,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/chart/chart_widget.py",
       "source_location": "L27",
       "id": "chart_chart_widget_dschart_init",
-      "community": 16,
+      "community": 14,
       "norm_label": ".__init__()"
     },
     {
@@ -1602,7 +1611,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/chart/chart_widget.py",
       "source_location": "L64",
       "id": "chart_chart_widget_dschart_update_data",
-      "community": 16,
+      "community": 14,
       "norm_label": ".update_data()"
     },
     {
@@ -1611,7 +1620,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/chart/chart_widget.py",
       "source_location": "L69",
       "id": "chart_chart_widget_dschart_clear",
-      "community": 16,
+      "community": 14,
       "norm_label": ".clear()"
     },
     {
@@ -1620,7 +1629,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/chart/chart_widget.py",
       "source_location": "L76",
       "id": "chart_chart_widget_dschart_set_type",
-      "community": 16,
+      "community": 14,
       "norm_label": ".set_type()"
     },
     {
@@ -1629,7 +1638,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/chart/chart_widget.py",
       "source_location": "L81",
       "id": "chart_chart_widget_dschart_copy_to_clipboard",
-      "community": 16,
+      "community": 14,
       "norm_label": ".copy_to_clipboard()"
     },
     {
@@ -1638,7 +1647,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/chart/chart_widget.py",
       "source_location": "L91",
       "id": "chart_chart_widget_dschart_save_to_file",
-      "community": 16,
+      "community": 14,
       "norm_label": ".save_to_file()"
     },
     {
@@ -1647,7 +1656,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/chart/chart_widget.py",
       "source_location": "L101",
       "id": "chart_chart_widget_dschart_canvas_dims",
-      "community": 16,
+      "community": 14,
       "norm_label": "._canvas_dims()"
     },
     {
@@ -1656,7 +1665,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/chart/chart_widget.py",
       "source_location": "L109",
       "id": "chart_chart_widget_dschart_render",
-      "community": 16,
+      "community": 14,
       "norm_label": "._render()"
     },
     {
@@ -1665,7 +1674,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/chart/chart_widget.py",
       "source_location": "L115",
       "id": "chart_chart_widget_dschart_render_bar",
-      "community": 16,
+      "community": 14,
       "norm_label": "._render_bar()"
     },
     {
@@ -1674,7 +1683,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/chart/chart_widget.py",
       "source_location": "L153",
       "id": "chart_chart_widget_dschart_render_pie",
-      "community": 16,
+      "community": 14,
       "norm_label": "._render_pie()"
     },
     {
@@ -1683,7 +1692,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/chart/chart_widget.py",
       "source_location": "L196",
       "id": "chart_chart_widget_dschart_empty",
-      "community": 16,
+      "community": 14,
       "norm_label": "._empty()"
     },
     {
@@ -1691,7 +1700,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/chart/chart_widget.py",
       "source_location": "L1",
-      "community": 16,
+      "community": 14,
       "norm_label": "widget de grafico reutilizavel (barras ou pizza) usando seaborn + matplotlib.",
       "id": "chart_chart_widget_rationale_1"
     },
@@ -1701,7 +1710,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/label/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_design_system_components_label_init_py",
-      "community": 12,
+      "community": 11,
       "norm_label": "__init__.py"
     },
     {
@@ -1710,7 +1719,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/label/label.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_design_system_components_label_label_py",
-      "community": 12,
+      "community": 11,
       "norm_label": "label.py"
     },
     {
@@ -1719,7 +1728,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/label/label.py",
       "source_location": "L6",
       "id": "label_label_dslabel",
-      "community": 12,
+      "community": 11,
       "norm_label": "dslabel"
     },
     {
@@ -1728,7 +1737,7 @@
       "source_file": "",
       "source_location": "",
       "id": "qlabel",
-      "community": 12,
+      "community": 11,
       "norm_label": "qlabel"
     },
     {
@@ -1737,7 +1746,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/label/label.py",
       "source_location": "L8",
       "id": "label_label_dslabel_init",
-      "community": 12,
+      "community": 11,
       "norm_label": ".__init__()"
     },
     {
@@ -1881,7 +1890,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/text_view/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_design_system_components_text_view_init_py",
-      "community": 6,
+      "community": 8,
       "norm_label": "__init__.py"
     },
     {
@@ -1890,7 +1899,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/text_view/text_view.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_design_system_components_text_view_text_view_py",
-      "community": 6,
+      "community": 8,
       "norm_label": "text_view.py"
     },
     {
@@ -1899,7 +1908,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/text_view/text_view.py",
       "source_location": "L5",
       "id": "text_view_text_view_dstextview",
-      "community": 6,
+      "community": 8,
       "norm_label": "dstextview"
     },
     {
@@ -1908,7 +1917,7 @@
       "source_file": "",
       "source_location": "",
       "id": "qtextbrowser",
-      "community": 6,
+      "community": 8,
       "norm_label": "qtextbrowser"
     },
     {
@@ -1917,7 +1926,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/text_view/text_view.py",
       "source_location": "L7",
       "id": "text_view_text_view_dstextview_init",
-      "community": 6,
+      "community": 8,
       "norm_label": ".__init__()"
     },
     {
@@ -1926,7 +1935,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/text_view/text_view.py",
       "source_location": "L11",
       "id": "text_view_text_view_dstextview_copy_to_clipboard",
-      "community": 6,
+      "community": 8,
       "norm_label": ".copy_to_clipboard()"
     },
     {
@@ -1935,7 +1944,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/containers/group_box.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_design_system_components_containers_group_box_py",
-      "community": 6,
+      "community": 8,
       "norm_label": "group_box.py"
     },
     {
@@ -1944,7 +1953,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/containers/group_box.py",
       "source_location": "L5",
       "id": "containers_group_box_dsgroupbox",
-      "community": 6,
+      "community": 8,
       "norm_label": "dsgroupbox"
     },
     {
@@ -1953,7 +1962,7 @@
       "source_file": "",
       "source_location": "",
       "id": "qgroupbox",
-      "community": 6,
+      "community": 8,
       "norm_label": "qgroupbox"
     },
     {
@@ -1962,7 +1971,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/containers/group_box.py",
       "source_location": "L7",
       "id": "containers_group_box_dsgroupbox_init",
-      "community": 6,
+      "community": 8,
       "norm_label": ".__init__()"
     },
     {
@@ -1971,7 +1980,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/containers/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_design_system_components_containers_init_py",
-      "community": 6,
+      "community": 8,
       "norm_label": "__init__.py"
     },
     {
@@ -1980,7 +1989,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/inputs/text_input.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_design_system_components_inputs_text_input_py",
-      "community": 6,
+      "community": 8,
       "norm_label": "text_input.py"
     },
     {
@@ -1989,7 +1998,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/inputs/text_input.py",
       "source_location": "L5",
       "id": "inputs_text_input_dstextinput",
-      "community": 8,
+      "community": 5,
       "norm_label": "dstextinput"
     },
     {
@@ -1998,7 +2007,7 @@
       "source_file": "",
       "source_location": "",
       "id": "qlineedit",
-      "community": 8,
+      "community": 5,
       "norm_label": "qlineedit"
     },
     {
@@ -2007,7 +2016,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/inputs/text_input.py",
       "source_location": "L7",
       "id": "inputs_text_input_dstextinput_init",
-      "community": 8,
+      "community": 5,
       "norm_label": ".__init__()"
     },
     {
@@ -2016,7 +2025,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/inputs/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_design_system_components_inputs_init_py",
-      "community": 6,
+      "community": 8,
       "norm_label": "__init__.py"
     },
     {
@@ -2025,7 +2034,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/inputs/date_input.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_design_system_components_inputs_date_input_py",
-      "community": 6,
+      "community": 8,
       "norm_label": "date_input.py"
     },
     {
@@ -2034,7 +2043,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/inputs/date_input.py",
       "source_location": "L5",
       "id": "inputs_date_input_dsdateinput",
-      "community": 6,
+      "community": 8,
       "norm_label": "dsdateinput"
     },
     {
@@ -2043,7 +2052,7 @@
       "source_file": "",
       "source_location": "",
       "id": "qdateedit",
-      "community": 6,
+      "community": 8,
       "norm_label": "qdateedit"
     },
     {
@@ -2052,7 +2061,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/inputs/date_input.py",
       "source_location": "L7",
       "id": "inputs_date_input_dsdateinput_init",
-      "community": 6,
+      "community": 8,
       "norm_label": ".__init__()"
     },
     {
@@ -2061,7 +2070,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/handlers/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_design_system_handlers_init_py",
-      "community": 6,
+      "community": 8,
       "norm_label": "__init__.py"
     },
     {
@@ -2070,7 +2079,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/handlers/loading_handler.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_design_system_handlers_loading_handler_py",
-      "community": 6,
+      "community": 8,
       "norm_label": "loading_handler.py"
     },
     {
@@ -2079,7 +2088,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/handlers/loading_handler.py",
       "source_location": "L4",
       "id": "handlers_loading_handler_dsloadinghandler",
-      "community": 6,
+      "community": 8,
       "norm_label": "dsloadinghandler"
     },
     {
@@ -2088,7 +2097,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/handlers/loading_handler.py",
       "source_location": "L9",
       "id": "handlers_loading_handler_dsloadinghandler_setup_loading",
-      "community": 6,
+      "community": 8,
       "norm_label": "._setup_loading()"
     },
     {
@@ -2097,7 +2106,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/handlers/loading_handler.py",
       "source_location": "L16",
       "id": "handlers_loading_handler_dsloadinghandler_start_loading",
-      "community": 6,
+      "community": 8,
       "norm_label": "._start_loading()"
     },
     {
@@ -2106,7 +2115,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/handlers/loading_handler.py",
       "source_location": "L20",
       "id": "handlers_loading_handler_dsloadinghandler_stop_loading",
-      "community": 6,
+      "community": 8,
       "norm_label": "._stop_loading()"
     },
     {
@@ -2115,7 +2124,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/handlers/loading_handler.py",
       "source_location": "L23",
       "id": "handlers_loading_handler_dsloadinghandler_loading_tick",
-      "community": 6,
+      "community": 8,
       "norm_label": "._loading_tick()"
     },
     {
@@ -2124,7 +2133,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/handlers/loading_handler.py",
       "source_location": "L28",
       "id": "handlers_loading_handler_dsloadinghandler_on_loading_tick",
-      "community": 6,
+      "community": 8,
       "norm_label": "._on_loading_tick()"
     },
     {
@@ -2132,7 +2141,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/handlers/loading_handler.py",
       "source_location": "L5",
-      "community": 6,
+      "community": 8,
       "norm_label": "mixin que adiciona comportamento de loading animado a qualquer componente qobjec",
       "id": "handlers_loading_handler_rationale_5"
     },
@@ -2141,7 +2150,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/handlers/loading_handler.py",
       "source_location": "L10",
-      "community": 6,
+      "community": 8,
       "norm_label": "deve ser chamado no __init__ do componente, apos o super().__init__().",
       "id": "handlers_loading_handler_rationale_10"
     },
@@ -2150,7 +2159,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/handlers/loading_handler.py",
       "source_location": "L29",
-      "community": 6,
+      "community": 8,
       "norm_label": "implementar no componente: o que fazer com cada frame do spinner.",
       "id": "handlers_loading_handler_rationale_29"
     },
@@ -2169,7 +2178,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_init_py",
-      "community": 27,
+      "community": 26,
       "norm_label": "__init__.py"
     },
     {
@@ -2178,7 +2187,7 @@
       "source_file": "features/home/source/controller.py",
       "source_location": "L1",
       "id": "features_home_source_controller_py",
-      "community": 13,
+      "community": 12,
       "norm_label": "controller.py"
     },
     {
@@ -2187,7 +2196,7 @@
       "source_file": "features/home/source/controller.py",
       "source_location": "L6",
       "id": "source_controller_homecontroller",
-      "community": 13,
+      "community": 12,
       "norm_label": "homecontroller"
     },
     {
@@ -2196,7 +2205,7 @@
       "source_file": "features/home/source/controller.py",
       "source_location": "L7",
       "id": "source_controller_homecontroller_init",
-      "community": 13,
+      "community": 12,
       "norm_label": ".__init__()"
     },
     {
@@ -2205,7 +2214,7 @@
       "source_file": "features/home/source/controller.py",
       "source_location": "L14",
       "id": "source_controller_homecontroller_setup_view",
-      "community": 13,
+      "community": 12,
       "norm_label": ".setup_view()"
     },
     {
@@ -2214,7 +2223,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/source/models.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_source_models_py",
-      "community": 13,
+      "community": 12,
       "norm_label": "models.py"
     },
     {
@@ -2223,7 +2232,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/source/models.py",
       "source_location": "L7",
       "id": "source_models_homefeaturesmodel",
-      "community": 13,
+      "community": 12,
       "norm_label": "homefeaturesmodel"
     },
     {
@@ -2232,7 +2241,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/source/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_source_init_py",
-      "community": 28,
+      "community": 27,
       "norm_label": "__init__.py"
     },
     {
@@ -2241,7 +2250,7 @@
       "source_file": "features/home/source/view.py",
       "source_location": "L1",
       "id": "features_home_source_view_py",
-      "community": 13,
+      "community": 12,
       "norm_label": "view.py"
     },
     {
@@ -2250,7 +2259,7 @@
       "source_file": "features/home/source/view.py",
       "source_location": "L11",
       "id": "source_view_homeview",
-      "community": 13,
+      "community": 12,
       "norm_label": "homeview"
     },
     {
@@ -2259,7 +2268,7 @@
       "source_file": "features/home/source/view.py",
       "source_location": "L12",
       "id": "source_view_homeview_init",
-      "community": 13,
+      "community": 12,
       "norm_label": ".__init__()"
     },
     {
@@ -2268,7 +2277,7 @@
       "source_file": "features/home/source/view.py",
       "source_location": "L16",
       "id": "source_view_homeview_paintevent",
-      "community": 13,
+      "community": 12,
       "norm_label": ".paintevent()"
     },
     {
@@ -2277,7 +2286,7 @@
       "source_file": "features/home/source/view.py",
       "source_location": "L20",
       "id": "source_view_homeview_setup_layout",
-      "community": 13,
+      "community": 12,
       "norm_label": ".setup_layout()"
     },
     {
@@ -2286,7 +2295,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_sub_features_init_py",
-      "community": 29,
+      "community": 28,
       "norm_label": "__init__.py"
     },
     {
@@ -2295,7 +2304,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_sub_features_delivery_init_py",
-      "community": 30,
+      "community": 29,
       "norm_label": "__init__.py"
     },
     {
@@ -2304,7 +2313,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/data/mapper.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_sub_features_delivery_data_mapper_py",
-      "community": 1,
+      "community": 0,
       "norm_label": "mapper.py"
     },
     {
@@ -2313,7 +2322,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/data/mapper.py",
       "source_location": "L9",
       "id": "data_mapper_errormapper",
-      "community": 1,
+      "community": 0,
       "norm_label": "errormapper"
     },
     {
@@ -2322,7 +2331,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/data/mapper.py",
       "source_location": "L11",
       "id": "data_mapper_from_response",
-      "community": 1,
+      "community": 0,
       "norm_label": "from_response()"
     },
     {
@@ -2331,7 +2340,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/data/mapper.py",
       "source_location": "L24",
       "id": "data_mapper_deliveriesmapper",
-      "community": 1,
+      "community": 0,
       "norm_label": "deliveriesmapper"
     },
     {
@@ -2340,7 +2349,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/data/mapper.py",
       "source_location": "L36",
       "id": "data_mapper_paymentsmapper",
-      "community": 1,
+      "community": 0,
       "norm_label": "paymentsmapper"
     },
     {
@@ -2348,7 +2357,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/data/mapper.py",
       "source_location": "L1",
-      "community": 1,
+      "community": 0,
       "norm_label": "mappers de httpresponse para domain models e de httpresponseerror para errormode",
       "id": "data_mapper_rationale_1"
     },
@@ -2357,7 +2366,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/data/mapper.py",
       "source_location": "L12",
-      "community": 31,
+      "community": 30,
       "norm_label": "le o json do backend; cai em http_error generico se o corpo nao for json valido.",
       "id": "data_mapper_rationale_12"
     },
@@ -2493,7 +2502,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/domain/use_case.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_sub_features_delivery_domain_use_case_py",
-      "community": 1,
+      "community": 0,
       "norm_label": "use_case.py"
     },
     {
@@ -2502,7 +2511,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/domain/use_case.py",
       "source_location": "L9",
       "id": "domain_use_case_deliveryusecase",
-      "community": 1,
+      "community": 0,
       "norm_label": "deliveryusecase"
     },
     {
@@ -2511,7 +2520,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/domain/use_case.py",
       "source_location": "L10",
       "id": "domain_use_case_deliveryusecase_init",
-      "community": 1,
+      "community": 0,
       "norm_label": ".__init__()"
     },
     {
@@ -2520,7 +2529,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/domain/use_case.py",
       "source_location": "L13",
       "id": "domain_use_case_deliveryusecase_get_orders",
-      "community": 1,
+      "community": 0,
       "norm_label": ".get_orders()"
     },
     {
@@ -2528,7 +2537,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/domain/use_case.py",
       "source_location": "L1",
-      "community": 1,
+      "community": 0,
       "norm_label": "regra de negocios: validacao matematica de cpf.",
       "id": "domain_use_case_rationale_1"
     },
@@ -2537,7 +2546,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/domain/use_case.py",
       "source_location": "L14",
-      "community": 1,
+      "community": 0,
       "norm_label": "busca deliveries e payments em paralelo e retorna o modelo consolidado.",
       "id": "domain_use_case_rationale_14"
     },
@@ -2547,7 +2556,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/domain/signals.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_sub_features_delivery_domain_signals_py",
-      "community": 1,
+      "community": 0,
       "norm_label": "signals.py"
     },
     {
@@ -2556,7 +2565,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/domain/signals.py",
       "source_location": "L8",
       "id": "domain_signals_deliverysignals",
-      "community": 1,
+      "community": 0,
       "norm_label": "deliverysignals"
     },
     {
@@ -2564,7 +2573,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/domain/signals.py",
       "source_location": "L1",
-      "community": 1,
+      "community": 0,
       "norm_label": "canal de comunicacao entre o viewmodel e o controller.",
       "id": "domain_signals_rationale_1"
     },
@@ -2574,7 +2583,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/domain/models.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_sub_features_delivery_domain_models_py",
-      "community": 1,
+      "community": 0,
       "norm_label": "models.py"
     },
     {
@@ -2583,7 +2592,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/domain/models.py",
       "source_location": "L7",
       "id": "domain_models_deliverycount",
-      "community": 1,
+      "community": 0,
       "norm_label": "deliverycount"
     },
     {
@@ -2592,7 +2601,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/domain/models.py",
       "source_location": "L13",
       "id": "domain_models_deliveriessummary",
-      "community": 1,
+      "community": 0,
       "norm_label": "deliveriessummary"
     },
     {
@@ -2601,7 +2610,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/domain/models.py",
       "source_location": "L20",
       "id": "domain_models_pendentorder",
-      "community": 1,
+      "community": 0,
       "norm_label": "pendentorder"
     },
     {
@@ -2610,7 +2619,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/domain/models.py",
       "source_location": "L29",
       "id": "domain_models_deliverymodel",
-      "community": 1,
+      "community": 0,
       "norm_label": "deliverymodel"
     },
     {
@@ -2619,7 +2628,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/domain/models.py",
       "source_location": "L35",
       "id": "domain_models_deliveryviewdata",
-      "community": 1,
+      "community": 0,
       "norm_label": "deliveryviewdata"
     },
     {
@@ -2627,7 +2636,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/domain/models.py",
       "source_location": "L1",
-      "community": 8,
+      "community": 0,
       "norm_label": "models utilizados no modulo",
       "id": "domain_models_rationale_1"
     },
@@ -2637,7 +2646,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/domain/events.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_sub_features_delivery_domain_events_py",
-      "community": 14,
+      "community": 13,
       "norm_label": "events.py"
     },
     {
@@ -2646,7 +2655,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/domain/events.py",
       "source_location": "L6",
       "id": "domain_events_featureevents",
-      "community": 14,
+      "community": 13,
       "norm_label": "featureevents"
     },
     {
@@ -2654,7 +2663,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/domain/events.py",
       "source_location": "L1",
-      "community": 14,
+      "community": 13,
       "norm_label": "eventos de observabilidade da feature cpf validation.",
       "id": "domain_events_rationale_1"
     },
@@ -2664,7 +2673,7 @@
       "source_file": "features/home/sub_features/delivery/domain/__init__.py",
       "source_location": "L1",
       "id": "features_home_sub_features_delivery_domain_init_py",
-      "community": 32,
+      "community": 31,
       "norm_label": "__init__.py"
     },
     {
@@ -2673,7 +2682,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/presentation/controller.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_sub_features_delivery_presentation_controller_py",
-      "community": 1,
+      "community": 0,
       "norm_label": "controller.py"
     },
     {
@@ -2762,7 +2771,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/presentation/controller.py",
       "source_location": "L1",
-      "community": 1,
+      "community": 0,
       "norm_label": "controller da feature cpf validation: conecta signals da view ao viewmodel e tra",
       "id": "presentation_controller_rationale_1"
     },
@@ -2790,7 +2799,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/presentation/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_sub_features_delivery_presentation_init_py",
-      "community": 1,
+      "community": 0,
       "norm_label": "__init__.py"
     },
     {
@@ -2799,7 +2808,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/presentation/viewmodel.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_sub_features_delivery_presentation_viewmodel_py",
-      "community": 1,
+      "community": 0,
       "norm_label": "viewmodel.py"
     },
     {
@@ -2808,7 +2817,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/presentation/viewmodel.py",
       "source_location": "L12",
       "id": "presentation_viewmodel_deliveryviewmodel",
-      "community": 1,
+      "community": 0,
       "norm_label": "deliveryviewmodel"
     },
     {
@@ -2817,7 +2826,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/presentation/viewmodel.py",
       "source_location": "L13",
       "id": "presentation_viewmodel_deliveryviewmodel_init",
-      "community": 1,
+      "community": 0,
       "norm_label": ".__init__()"
     },
     {
@@ -2826,7 +2835,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/presentation/viewmodel.py",
       "source_location": "L17",
       "id": "presentation_viewmodel_deliveryviewmodel_on_generate",
-      "community": 1,
+      "community": 0,
       "norm_label": ".on_generate()"
     },
     {
@@ -2835,7 +2844,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/presentation/viewmodel.py",
       "source_location": "L20",
       "id": "presentation_viewmodel_deliveryviewmodel_fetch",
-      "community": 1,
+      "community": 0,
       "norm_label": "._fetch()"
     },
     {
@@ -2844,7 +2853,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/presentation/viewmodel.py",
       "source_location": "L31",
       "id": "presentation_viewmodel_deliveryviewmodel_build_view_data",
-      "community": 1,
+      "community": 0,
       "norm_label": "._build_view_data()"
     },
     {
@@ -2853,7 +2862,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/presentation/viewmodel.py",
       "source_location": "L37",
       "id": "presentation_viewmodel_deliveryviewmodel_build_report",
-      "community": 1,
+      "community": 0,
       "norm_label": "._build_report()"
     },
     {
@@ -2861,7 +2870,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/presentation/viewmodel.py",
       "source_location": "L1",
-      "community": 8,
+      "community": 0,
       "norm_label": "viewmodel da feature cpf validation: executa o usecase e emite resultado via sig",
       "id": "presentation_viewmodel_rationale_1"
     },
@@ -2870,7 +2879,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/presentation/viewmodel.py",
       "source_location": "L21",
-      "community": 1,
+      "community": 0,
       "norm_label": "roda o usecase, monta o viewdata e emite sucesso ou erro \u2014 sempre via signal par",
       "id": "presentation_viewmodel_rationale_21"
     },
@@ -2880,7 +2889,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/presentation/view.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_sub_features_delivery_presentation_view_py",
-      "community": 1,
+      "community": 0,
       "norm_label": "view.py"
     },
     {
@@ -2889,7 +2898,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/presentation/view.py",
       "source_location": "L15",
       "id": "presentation_view_deliveryview",
-      "community": 6,
+      "community": 8,
       "norm_label": "deliveryview"
     },
     {
@@ -2898,7 +2907,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/presentation/view.py",
       "source_location": "L21",
       "id": "presentation_view_deliveryview_init",
-      "community": 6,
+      "community": 8,
       "norm_label": ".__init__()"
     },
     {
@@ -2907,7 +2916,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/presentation/view.py",
       "source_location": "L19",
       "id": "presentation_view_view_title",
-      "community": 1,
+      "community": 0,
       "norm_label": "view_title()"
     },
     {
@@ -2916,7 +2925,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/presentation/view.py",
       "source_location": "L31",
       "id": "presentation_view_deliveryview_setup_ui",
-      "community": 6,
+      "community": 8,
       "norm_label": "._setup_ui()"
     },
     {
@@ -2925,7 +2934,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/presentation/view.py",
       "source_location": "L36",
       "id": "presentation_view_deliveryview_setup_components",
-      "community": 6,
+      "community": 8,
       "norm_label": "._setup_components()"
     },
     {
@@ -2934,7 +2943,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/presentation/view.py",
       "source_location": "L61",
       "id": "presentation_view_deliveryview_setup_layout",
-      "community": 6,
+      "community": 8,
       "norm_label": "._setup_layout()"
     },
     {
@@ -2943,7 +2952,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/presentation/view.py",
       "source_location": "L84",
       "id": "presentation_view_deliveryview_update_buttons_state",
-      "community": 6,
+      "community": 8,
       "norm_label": "._update_buttons_state()"
     },
     {
@@ -2961,7 +2970,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/presentation/view.py",
       "source_location": "L94",
       "id": "presentation_view_deliveryview_update_data",
-      "community": 6,
+      "community": 8,
       "norm_label": ".update_data()"
     },
     {
@@ -2970,7 +2979,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/presentation/view.py",
       "source_location": "L100",
       "id": "presentation_view_deliveryview_activate_button_state",
-      "community": 6,
+      "community": 8,
       "norm_label": ".activate_button_state()"
     },
     {
@@ -2979,7 +2988,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/presentation/view.py",
       "source_location": "L103",
       "id": "presentation_view_deliveryview_clear_content",
-      "community": 6,
+      "community": 8,
       "norm_label": ".clear_content()"
     },
     {
@@ -2988,7 +2997,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/presentation/view.py",
       "source_location": "L108",
       "id": "presentation_view_deliveryview_prepare_to_fetch",
-      "community": 6,
+      "community": 8,
       "norm_label": ".prepare_to_fetch()"
     },
     {
@@ -2996,7 +3005,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/presentation/view.py",
       "source_location": "L1",
-      "community": 1,
+      "community": 0,
       "norm_label": "view da feature cpf validation: dialog para validacao de cpf.",
       "id": "presentation_view_rationale_1"
     },
@@ -3006,7 +3015,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_sub_features_summary_init_py",
-      "community": 1,
+      "community": 0,
       "norm_label": "__init__.py"
     },
     {
@@ -3015,7 +3024,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/data/mapper.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_sub_features_summary_data_mapper_py",
-      "community": 1,
+      "community": 0,
       "norm_label": "mapper.py"
     },
     {
@@ -3024,7 +3033,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/data/mapper.py",
       "source_location": "L23",
       "id": "data_mapper_orderssummarymapper",
-      "community": 1,
+      "community": 0,
       "norm_label": "orderssummarymapper"
     },
     {
@@ -3033,7 +3042,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/data/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_sub_features_summary_data_init_py",
-      "community": 1,
+      "community": 0,
       "norm_label": "__init__.py"
     },
     {
@@ -3069,7 +3078,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/data/repository.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_sub_features_summary_data_repository_py",
-      "community": 1,
+      "community": 0,
       "norm_label": "repository.py"
     },
     {
@@ -3078,7 +3087,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/data/repository.py",
       "source_location": "L12",
       "id": "data_repository_summaryrepository",
-      "community": 1,
+      "community": 0,
       "norm_label": "summaryrepository"
     },
     {
@@ -3096,7 +3105,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/domain/use_case.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_sub_features_summary_domain_use_case_py",
-      "community": 1,
+      "community": 0,
       "norm_label": "use_case.py"
     },
     {
@@ -3105,7 +3114,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/domain/use_case.py",
       "source_location": "L9",
       "id": "domain_use_case_summaryusecase",
-      "community": 1,
+      "community": 0,
       "norm_label": "summaryusecase"
     },
     {
@@ -3114,7 +3123,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/domain/use_case.py",
       "source_location": "L10",
       "id": "domain_use_case_summaryusecase_init",
-      "community": 1,
+      "community": 0,
       "norm_label": ".__init__()"
     },
     {
@@ -3123,7 +3132,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/domain/use_case.py",
       "source_location": "L13",
       "id": "domain_use_case_summaryusecase_get_summary",
-      "community": 1,
+      "community": 0,
       "norm_label": ".get_summary()"
     },
     {
@@ -3132,7 +3141,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/domain/use_case.py",
       "source_location": "L17",
       "id": "domain_use_case_summaryusecase_build_summary",
-      "community": 1,
+      "community": 0,
       "norm_label": "._build_summary()"
     },
     {
@@ -3141,7 +3150,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/domain/use_case.py",
       "source_location": "L51",
       "id": "domain_use_case_to_sorted_counts",
-      "community": 1,
+      "community": 0,
       "norm_label": "_to_sorted_counts()"
     },
     {
@@ -3150,7 +3159,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/domain/signals.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_sub_features_summary_domain_signals_py",
-      "community": 1,
+      "community": 0,
       "norm_label": "signals.py"
     },
     {
@@ -3159,7 +3168,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/domain/signals.py",
       "source_location": "L8",
       "id": "domain_signals_summarysignals",
-      "community": 1,
+      "community": 0,
       "norm_label": "summarysignals"
     },
     {
@@ -3168,7 +3177,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/domain/models.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_sub_features_summary_domain_models_py",
-      "community": 1,
+      "community": 0,
       "norm_label": "models.py"
     },
     {
@@ -3177,7 +3186,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/domain/models.py",
       "source_location": "L7",
       "id": "domain_models_productcount",
-      "community": 1,
+      "community": 0,
       "norm_label": "productcount"
     },
     {
@@ -3186,7 +3195,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/domain/models.py",
       "source_location": "L13",
       "id": "domain_models_orderdetail",
-      "community": 1,
+      "community": 0,
       "norm_label": "orderdetail"
     },
     {
@@ -3195,7 +3204,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/domain/models.py",
       "source_location": "L22",
       "id": "domain_models_daysummary",
-      "community": 1,
+      "community": 0,
       "norm_label": "daysummary"
     },
     {
@@ -3204,7 +3213,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/domain/models.py",
       "source_location": "L29",
       "id": "domain_models_productssummary",
-      "community": 1,
+      "community": 0,
       "norm_label": "productssummary"
     },
     {
@@ -3213,7 +3222,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/domain/models.py",
       "source_location": "L38",
       "id": "domain_models_productsviewdata",
-      "community": 1,
+      "community": 0,
       "norm_label": "productsviewdata"
     },
     {
@@ -3222,7 +3231,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/domain/events.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_sub_features_summary_domain_events_py",
-      "community": 14,
+      "community": 13,
       "norm_label": "events.py"
     },
     {
@@ -3231,7 +3240,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/domain/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_sub_features_summary_domain_init_py",
-      "community": 33,
+      "community": 32,
       "norm_label": "__init__.py"
     },
     {
@@ -3240,7 +3249,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/presentation/controller.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_sub_features_summary_presentation_controller_py",
-      "community": 1,
+      "community": 0,
       "norm_label": "controller.py"
     },
     {
@@ -3339,7 +3348,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/presentation/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_sub_features_summary_presentation_init_py",
-      "community": 34,
+      "community": 33,
       "norm_label": "__init__.py"
     },
     {
@@ -3348,7 +3357,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/presentation/viewmodel.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_sub_features_summary_presentation_viewmodel_py",
-      "community": 1,
+      "community": 0,
       "norm_label": "viewmodel.py"
     },
     {
@@ -3357,7 +3366,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/presentation/viewmodel.py",
       "source_location": "L14",
       "id": "presentation_viewmodel_summaryviewmodel",
-      "community": 1,
+      "community": 0,
       "norm_label": "summaryviewmodel"
     },
     {
@@ -3366,7 +3375,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/presentation/viewmodel.py",
       "source_location": "L15",
       "id": "presentation_viewmodel_summaryviewmodel_init",
-      "community": 1,
+      "community": 0,
       "norm_label": ".__init__()"
     },
     {
@@ -3375,7 +3384,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/presentation/viewmodel.py",
       "source_location": "L19",
       "id": "presentation_viewmodel_summaryviewmodel_on_generate",
-      "community": 1,
+      "community": 0,
       "norm_label": ".on_generate()"
     },
     {
@@ -3384,7 +3393,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/presentation/viewmodel.py",
       "source_location": "L22",
       "id": "presentation_viewmodel_summaryviewmodel_fetch",
-      "community": 1,
+      "community": 0,
       "norm_label": "._fetch()"
     },
     {
@@ -3393,7 +3402,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/presentation/viewmodel.py",
       "source_location": "L32",
       "id": "presentation_viewmodel_summaryviewmodel_build_view_data",
-      "community": 1,
+      "community": 0,
       "norm_label": "._build_view_data()"
     },
     {
@@ -3402,7 +3411,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/presentation/viewmodel.py",
       "source_location": "L38",
       "id": "presentation_viewmodel_summaryviewmodel_build_report",
-      "community": 1,
+      "community": 0,
       "norm_label": "._build_report()"
     },
     {
@@ -3411,7 +3420,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/presentation/viewmodel.py",
       "source_location": "L61",
       "id": "presentation_viewmodel_products_lines",
-      "community": 1,
+      "community": 0,
       "norm_label": "_products_lines()"
     },
     {
@@ -3420,7 +3429,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/presentation/view.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_sub_features_summary_presentation_view_py",
-      "community": 1,
+      "community": 0,
       "norm_label": "view.py"
     },
     {
@@ -3537,7 +3546,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_sheets_init_py",
-      "community": 35,
+      "community": 34,
       "norm_label": "__init__.py"
     },
     {
@@ -3708,7 +3717,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/domain/use_case.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_sheets_domain_use_case_py",
-      "community": 5,
+      "community": 9,
       "norm_label": "use_case.py"
     },
     {
@@ -3717,7 +3726,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/domain/use_case.py",
       "source_location": "L7",
       "id": "domain_use_case_sheetsusecase",
-      "community": 5,
+      "community": 9,
       "norm_label": "sheetsusecase"
     },
     {
@@ -3726,7 +3735,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/domain/use_case.py",
       "source_location": "L8",
       "id": "domain_use_case_sheetsusecase_init",
-      "community": 5,
+      "community": 9,
       "norm_label": ".__init__()"
     },
     {
@@ -3735,7 +3744,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/domain/use_case.py",
       "source_location": "L11",
       "id": "domain_use_case_sheetsusecase_connect",
-      "community": 5,
+      "community": 9,
       "norm_label": ".connect()"
     },
     {
@@ -3744,7 +3753,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/domain/use_case.py",
       "source_location": "L17",
       "id": "domain_use_case_sheetsusecase_select",
-      "community": 5,
+      "community": 9,
       "norm_label": ".select()"
     },
     {
@@ -3753,7 +3762,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/domain/use_case.py",
       "source_location": "L22",
       "id": "domain_use_case_sheetsusecase_load_all",
-      "community": 5,
+      "community": 9,
       "norm_label": ".load_all()"
     },
     {
@@ -3762,7 +3771,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/domain/use_case.py",
       "source_location": "L25",
       "id": "domain_use_case_sheetsusecase_find_by_link",
-      "community": 5,
+      "community": 9,
       "norm_label": ".find_by_link()"
     },
     {
@@ -3771,7 +3780,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/domain/use_case.py",
       "source_location": "L28",
       "id": "domain_use_case_sheetsusecase_remove",
-      "community": 5,
+      "community": 9,
       "norm_label": ".remove()"
     },
     {
@@ -3780,7 +3789,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/domain/use_case.py",
       "source_location": "L35",
       "id": "domain_use_case_sheetsusecase_update_name",
-      "community": 5,
+      "community": 9,
       "norm_label": ".update_name()"
     },
     {
@@ -3789,7 +3798,7 @@
       "source_file": "features/sheets/domain/signals.py",
       "source_location": "L1",
       "id": "features_sheets_domain_signals_py",
-      "community": 1,
+      "community": 0,
       "norm_label": "signals.py"
     },
     {
@@ -3798,7 +3807,7 @@
       "source_file": "features/sheets/domain/signals.py",
       "source_location": "L6",
       "id": "domain_signals_sheetssignals",
-      "community": 1,
+      "community": 0,
       "norm_label": "sheetssignals"
     },
     {
@@ -3807,7 +3816,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/domain/models.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_sheets_domain_models_py",
-      "community": 5,
+      "community": 9,
       "norm_label": "models.py"
     },
     {
@@ -3825,7 +3834,7 @@
       "source_file": "features/sheets/domain/events.py",
       "source_location": "L1",
       "id": "features_sheets_domain_events_py",
-      "community": 14,
+      "community": 13,
       "norm_label": "events.py"
     },
     {
@@ -3834,7 +3843,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/domain/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_sheets_domain_init_py",
-      "community": 36,
+      "community": 35,
       "norm_label": "__init__.py"
     },
     {
@@ -3843,7 +3852,7 @@
       "source_file": "features/sheets/presentation/controller.py",
       "source_location": "L1",
       "id": "features_sheets_presentation_controller_py",
-      "community": 1,
+      "community": 0,
       "norm_label": "controller.py"
     },
     {
@@ -3987,7 +3996,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/presentation/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_sheets_presentation_init_py",
-      "community": 37,
+      "community": 36,
       "norm_label": "__init__.py"
     },
     {
@@ -3996,7 +4005,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/presentation/viewmodel.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_sheets_presentation_viewmodel_py",
-      "community": 5,
+      "community": 9,
       "norm_label": "viewmodel.py"
     },
     {
@@ -4005,7 +4014,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/presentation/viewmodel.py",
       "source_location": "L11",
       "id": "presentation_viewmodel_sheetsviewmodel",
-      "community": 5,
+      "community": 9,
       "norm_label": "sheetsviewmodel"
     },
     {
@@ -4014,7 +4023,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/presentation/viewmodel.py",
       "source_location": "L12",
       "id": "presentation_viewmodel_sheetsviewmodel_init",
-      "community": 5,
+      "community": 9,
       "norm_label": ".__init__()"
     },
     {
@@ -4032,7 +4041,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/presentation/viewmodel.py",
       "source_location": "L21",
       "id": "presentation_viewmodel_sheetsviewmodel_find_by_link",
-      "community": 5,
+      "community": 9,
       "norm_label": ".find_by_link()"
     },
     {
@@ -4041,7 +4050,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/presentation/viewmodel.py",
       "source_location": "L26",
       "id": "presentation_viewmodel_sheetsviewmodel_update_name",
-      "community": 5,
+      "community": 9,
       "norm_label": ".update_name()"
     },
     {
@@ -4050,7 +4059,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/presentation/viewmodel.py",
       "source_location": "L38",
       "id": "presentation_viewmodel_sheetsviewmodel_connect",
-      "community": 5,
+      "community": 9,
       "norm_label": ".connect()"
     },
     {
@@ -4059,7 +4068,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/presentation/viewmodel.py",
       "source_location": "L49",
       "id": "presentation_viewmodel_sheetsviewmodel_select",
-      "community": 5,
+      "community": 9,
       "norm_label": ".select()"
     },
     {
@@ -4068,7 +4077,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/presentation/viewmodel.py",
       "source_location": "L59",
       "id": "presentation_viewmodel_sheetsviewmodel_remove",
-      "community": 5,
+      "community": 9,
       "norm_label": ".remove()"
     },
     {
@@ -4077,7 +4086,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/presentation/view/sheet_create_view.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_sheets_presentation_view_sheet_create_view_py",
-      "community": 8,
+      "community": 5,
       "norm_label": "sheet_create_view.py"
     },
     {
@@ -4086,7 +4095,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/presentation/view/sheet_create_view.py",
       "source_location": "L8",
       "id": "view_sheet_create_view_sheetcreateview",
-      "community": 8,
+      "community": 5,
       "norm_label": "sheetcreateview"
     },
     {
@@ -4095,7 +4104,7 @@
       "source_file": "",
       "source_location": "",
       "id": "qdialog",
-      "community": 8,
+      "community": 5,
       "norm_label": "qdialog"
     },
     {
@@ -4104,7 +4113,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/presentation/view/sheet_create_view.py",
       "source_location": "L9",
       "id": "view_sheet_create_view_sheetcreateview_init",
-      "community": 8,
+      "community": 5,
       "norm_label": ".__init__()"
     },
     {
@@ -4113,7 +4122,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/presentation/view/sheet_create_view.py",
       "source_location": "L14",
       "id": "view_sheet_create_view_link",
-      "community": 8,
+      "community": 5,
       "norm_label": "link()"
     },
     {
@@ -4122,7 +4131,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/presentation/view/sheet_create_view.py",
       "source_location": "L18",
       "id": "view_sheet_create_view_name",
-      "community": 8,
+      "community": 5,
       "norm_label": "name()"
     },
     {
@@ -4131,7 +4140,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/presentation/view/sheet_create_view.py",
       "source_location": "L21",
       "id": "view_sheet_create_view_sheetcreateview_setup_ui",
-      "community": 8,
+      "community": 5,
       "norm_label": "._setup_ui()"
     },
     {
@@ -4140,7 +4149,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/presentation/view/sheet_create_view.py",
       "source_location": "L25",
       "id": "view_sheet_create_view_sheetcreateview_setup_components",
-      "community": 8,
+      "community": 5,
       "norm_label": "._setup_components()"
     },
     {
@@ -4149,7 +4158,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/presentation/view/sheet_create_view.py",
       "source_location": "L41",
       "id": "view_sheet_create_view_sheetcreateview_setup_layout",
-      "community": 8,
+      "community": 5,
       "norm_label": "._setup_layout()"
     },
     {
@@ -4257,7 +4266,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/presentation/view/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_sheets_presentation_view_init_py",
-      "community": 8,
+      "community": 5,
       "norm_label": "__init__.py"
     },
     {
@@ -4266,7 +4275,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_auth_init_py",
-      "community": 38,
+      "community": 37,
       "norm_label": "__init__.py"
     },
     {
@@ -4428,7 +4437,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/domain/use_case.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_auth_domain_use_case_py",
-      "community": 15,
+      "community": 0,
       "norm_label": "use_case.py"
     },
     {
@@ -4437,7 +4446,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/domain/use_case.py",
       "source_location": "L8",
       "id": "domain_use_case_authusecase",
-      "community": 15,
+      "community": 17,
       "norm_label": "authusecase"
     },
     {
@@ -4446,7 +4455,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/domain/use_case.py",
       "source_location": "L9",
       "id": "domain_use_case_authusecase_init",
-      "community": 15,
+      "community": 17,
       "norm_label": ".__init__()"
     },
     {
@@ -4455,7 +4464,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/domain/use_case.py",
       "source_location": "L12",
       "id": "domain_use_case_authusecase_configure",
-      "community": 15,
+      "community": 17,
       "norm_label": ".configure()"
     },
     {
@@ -4464,7 +4473,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/domain/use_case.py",
       "source_location": "L17",
       "id": "domain_use_case_authusecase_clear",
-      "community": 15,
+      "community": 17,
       "norm_label": ".clear()"
     },
     {
@@ -4472,7 +4481,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/domain/use_case.py",
       "source_location": "L13",
-      "community": 15,
+      "community": 17,
       "norm_label": "le o arquivo json, salva em storage seguro e autentica o backend.",
       "id": "domain_use_case_rationale_13"
     },
@@ -4481,7 +4490,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/domain/use_case.py",
       "source_location": "L18",
-      "community": 15,
+      "community": 17,
       "norm_label": "remove credenciais do storage e desautentica o backend.",
       "id": "domain_use_case_rationale_18"
     },
@@ -4491,7 +4500,7 @@
       "source_file": "features/auth/domain/signals.py",
       "source_location": "L1",
       "id": "features_auth_domain_signals_py",
-      "community": 1,
+      "community": 0,
       "norm_label": "signals.py"
     },
     {
@@ -4500,7 +4509,7 @@
       "source_file": "features/auth/domain/signals.py",
       "source_location": "L8",
       "id": "domain_signals_authsignals",
-      "community": 1,
+      "community": 0,
       "norm_label": "authsignals"
     },
     {
@@ -4509,7 +4518,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/domain/events.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_auth_domain_events_py",
-      "community": 14,
+      "community": 13,
       "norm_label": "events.py"
     },
     {
@@ -4518,7 +4527,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/domain/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_auth_domain_init_py",
-      "community": 39,
+      "community": 38,
       "norm_label": "__init__.py"
     },
     {
@@ -4545,7 +4554,7 @@
       "source_file": "",
       "source_location": "",
       "id": "errormodel",
-      "community": 1,
+      "community": 0,
       "norm_label": "errormodel"
     },
     {
@@ -4599,7 +4608,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/presentation/controller.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_auth_presentation_controller_py",
-      "community": 1,
+      "community": 0,
       "norm_label": "controller.py"
     },
     {
@@ -4608,7 +4617,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/presentation/controller.py",
       "source_location": "L17",
       "id": "presentation_controller_authcontroller",
-      "community": 15,
+      "community": 4,
       "norm_label": "authcontroller"
     },
     {
@@ -4617,7 +4626,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/presentation/controller.py",
       "source_location": "L18",
       "id": "presentation_controller_authcontroller_init",
-      "community": 15,
+      "community": 4,
       "norm_label": ".__init__()"
     },
     {
@@ -4626,7 +4635,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/presentation/controller.py",
       "source_location": "L24",
       "id": "presentation_controller_authcontroller_setup_actions",
-      "community": 15,
+      "community": 4,
       "norm_label": "._setup_actions()"
     },
     {
@@ -4635,7 +4644,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/presentation/controller.py",
       "source_location": "L32",
       "id": "presentation_controller_authcontroller_on_configure",
-      "community": 15,
+      "community": 4,
       "norm_label": "._on_configure()"
     },
     {
@@ -4644,7 +4653,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/presentation/controller.py",
       "source_location": "L39",
       "id": "presentation_controller_authcontroller_on_clear",
-      "community": 15,
+      "community": 4,
       "norm_label": "._on_clear()"
     },
     {
@@ -4653,7 +4662,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/presentation/controller.py",
       "source_location": "L49",
       "id": "presentation_controller_authcontroller_on_configured",
-      "community": 15,
+      "community": 4,
       "norm_label": "._on_configured()"
     },
     {
@@ -4662,7 +4671,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/presentation/controller.py",
       "source_location": "L52",
       "id": "presentation_controller_authcontroller_on_cleared",
-      "community": 15,
+      "community": 4,
       "norm_label": "._on_cleared()"
     },
     {
@@ -4680,7 +4689,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/presentation/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_auth_presentation_init_py",
-      "community": 1,
+      "community": 0,
       "norm_label": "__init__.py"
     },
     {
@@ -4689,7 +4698,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/presentation/viewmodel.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_auth_presentation_viewmodel_py",
-      "community": 15,
+      "community": 0,
       "norm_label": "viewmodel.py"
     },
     {
@@ -4698,7 +4707,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/presentation/viewmodel.py",
       "source_location": "L12",
       "id": "presentation_viewmodel_authviewmodel",
-      "community": 15,
+      "community": 4,
       "norm_label": "authviewmodel"
     },
     {
@@ -4707,7 +4716,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/presentation/viewmodel.py",
       "source_location": "L13",
       "id": "presentation_viewmodel_authviewmodel_init",
-      "community": 15,
+      "community": 17,
       "norm_label": ".__init__()"
     },
     {
@@ -4716,7 +4725,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/presentation/viewmodel.py",
       "source_location": "L18",
       "id": "presentation_viewmodel_authviewmodel_configure",
-      "community": 15,
+      "community": 4,
       "norm_label": ".configure()"
     },
     {
@@ -4725,7 +4734,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/presentation/viewmodel.py",
       "source_location": "L29",
       "id": "presentation_viewmodel_authviewmodel_clear",
-      "community": 15,
+      "community": 4,
       "norm_label": ".clear()"
     },
     {
@@ -4734,7 +4743,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/presentation/view.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_auth_presentation_view_py",
-      "community": 1,
+      "community": 0,
       "norm_label": "view.py"
     },
     {
@@ -4770,7 +4779,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_cpf_validation_init_py",
-      "community": 40,
+      "community": 39,
       "norm_label": "__init__.py"
     },
     {
@@ -4779,7 +4788,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/domain/use_case.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_cpf_validation_domain_use_case_py",
-      "community": 8,
+      "community": 0,
       "norm_label": "use_case.py"
     },
     {
@@ -4788,7 +4797,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/domain/use_case.py",
       "source_location": "L6",
       "id": "domain_use_case_is_valid_cpf",
-      "community": 8,
+      "community": 0,
       "norm_label": "_is_valid_cpf()"
     },
     {
@@ -4797,7 +4806,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/domain/use_case.py",
       "source_location": "L29",
       "id": "domain_use_case_cpfvalidationusecase",
-      "community": 8,
+      "community": 0,
       "norm_label": "cpfvalidationusecase"
     },
     {
@@ -4806,7 +4815,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/domain/use_case.py",
       "source_location": "L30",
       "id": "domain_use_case_cpfvalidationusecase_validate",
-      "community": 8,
+      "community": 0,
       "norm_label": ".validate()"
     },
     {
@@ -4814,7 +4823,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/domain/use_case.py",
       "source_location": "L7",
-      "community": 8,
+      "community": 0,
       "norm_label": "valida um cpf pela regra dos dois digitos verificadores (algoritmo da receita fe",
       "id": "domain_use_case_rationale_7"
     },
@@ -4824,7 +4833,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/domain/signals.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_cpf_validation_domain_signals_py",
-      "community": 1,
+      "community": 0,
       "norm_label": "signals.py"
     },
     {
@@ -4833,7 +4842,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/domain/signals.py",
       "source_location": "L8",
       "id": "domain_signals_cpfvalidationsignals",
-      "community": 1,
+      "community": 0,
       "norm_label": "cpfvalidationsignals"
     },
     {
@@ -4842,7 +4851,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/domain/models.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_cpf_validation_domain_models_py",
-      "community": 8,
+      "community": 0,
       "norm_label": "models.py"
     },
     {
@@ -4851,7 +4860,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/domain/models.py",
       "source_location": "L7",
       "id": "domain_models_cpfvalidationresult",
-      "community": 8,
+      "community": 0,
       "norm_label": "cpfvalidationresult"
     },
     {
@@ -4860,7 +4869,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/domain/events.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_cpf_validation_domain_events_py",
-      "community": 14,
+      "community": 13,
       "norm_label": "events.py"
     },
     {
@@ -4869,7 +4878,7 @@
       "source_file": "features/cpf_validation/domain/__init__.py",
       "source_location": "L1",
       "id": "features_cpf_validation_domain_init_py",
-      "community": 41,
+      "community": 40,
       "norm_label": "__init__.py"
     },
     {
@@ -4878,7 +4887,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/presentation/controller.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_cpf_validation_presentation_controller_py",
-      "community": 8,
+      "community": 0,
       "norm_label": "controller.py"
     },
     {
@@ -4887,7 +4896,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/presentation/controller.py",
       "source_location": "L12",
       "id": "presentation_controller_cpfvalidationcontroller",
-      "community": 8,
+      "community": 5,
       "norm_label": "cpfvalidationcontroller"
     },
     {
@@ -4896,7 +4905,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/presentation/controller.py",
       "source_location": "L13",
       "id": "presentation_controller_cpfvalidationcontroller_init",
-      "community": 8,
+      "community": 5,
       "norm_label": ".__init__()"
     },
     {
@@ -4905,7 +4914,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/presentation/controller.py",
       "source_location": "L18",
       "id": "presentation_controller_cpfvalidationcontroller_setup_actions",
-      "community": 8,
+      "community": 5,
       "norm_label": "._setup_actions()"
     },
     {
@@ -4914,7 +4923,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/presentation/controller.py",
       "source_location": "L22",
       "id": "presentation_controller_cpfvalidationcontroller_on_validate",
-      "community": 8,
+      "community": 5,
       "norm_label": ".on_validate()"
     },
     {
@@ -4923,7 +4932,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/presentation/controller.py",
       "source_location": "L29",
       "id": "presentation_controller_cpfvalidationcontroller_handle_result",
-      "community": 8,
+      "community": 5,
       "norm_label": ".handle_result()"
     },
     {
@@ -4932,7 +4941,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/presentation/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_cpf_validation_presentation_init_py",
-      "community": 8,
+      "community": 0,
       "norm_label": "__init__.py"
     },
     {
@@ -4941,7 +4950,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/presentation/viewmodel.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_cpf_validation_presentation_viewmodel_py",
-      "community": 8,
+      "community": 0,
       "norm_label": "viewmodel.py"
     },
     {
@@ -4950,7 +4959,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/presentation/viewmodel.py",
       "source_location": "L7",
       "id": "presentation_viewmodel_cpfvalidationviewmodel",
-      "community": 8,
+      "community": 0,
       "norm_label": "cpfvalidationviewmodel"
     },
     {
@@ -4959,7 +4968,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/presentation/viewmodel.py",
       "source_location": "L8",
       "id": "presentation_viewmodel_cpfvalidationviewmodel_init",
-      "community": 8,
+      "community": 0,
       "norm_label": ".__init__()"
     },
     {
@@ -4968,7 +4977,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/presentation/viewmodel.py",
       "source_location": "L11",
       "id": "presentation_viewmodel_cpfvalidationviewmodel_on_validate",
-      "community": 8,
+      "community": 0,
       "norm_label": ".on_validate()"
     },
     {
@@ -4977,7 +4986,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/presentation/view.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_cpf_validation_presentation_view_py",
-      "community": 8,
+      "community": 0,
       "norm_label": "view.py"
     },
     {
@@ -4986,7 +4995,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/presentation/view.py",
       "source_location": "L14",
       "id": "presentation_view_cpfvalidationview",
-      "community": 8,
+      "community": 5,
       "norm_label": "cpfvalidationview"
     },
     {
@@ -4995,7 +5004,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/presentation/view.py",
       "source_location": "L20",
       "id": "presentation_view_cpfvalidationview_init",
-      "community": 8,
+      "community": 5,
       "norm_label": ".__init__()"
     },
     {
@@ -5004,7 +5013,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/presentation/view.py",
       "source_location": "L25",
       "id": "presentation_view_menu_title",
-      "community": 8,
+      "community": 0,
       "norm_label": "menu_title()"
     },
     {
@@ -5013,7 +5022,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/presentation/view.py",
       "source_location": "L28",
       "id": "presentation_view_cpfvalidationview_setup_ui",
-      "community": 8,
+      "community": 5,
       "norm_label": "._setup_ui()"
     },
     {
@@ -5022,7 +5031,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/presentation/view.py",
       "source_location": "L32",
       "id": "presentation_view_cpfvalidationview_setup_components",
-      "community": 8,
+      "community": 5,
       "norm_label": "._setup_components()"
     },
     {
@@ -5031,7 +5040,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/presentation/view.py",
       "source_location": "L46",
       "id": "presentation_view_cpfvalidationview_setup_layout",
-      "community": 8,
+      "community": 5,
       "norm_label": "._setup_layout()"
     },
     {
@@ -5040,7 +5049,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/presentation/view.py",
       "source_location": "L63",
       "id": "presentation_view_cpfvalidationview_get_cpf",
-      "community": 8,
+      "community": 5,
       "norm_label": ".get_cpf()"
     },
     {
@@ -5049,7 +5058,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/presentation/view.py",
       "source_location": "L66",
       "id": "presentation_view_cpfvalidationview_update_result",
-      "community": 8,
+      "community": 5,
       "norm_label": ".update_result()"
     },
     {
@@ -5058,7 +5067,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/status_bar/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_status_bar_init_py",
-      "community": 42,
+      "community": 41,
       "norm_label": "__init__.py"
     },
     {
@@ -5067,7 +5076,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/status_bar/domain/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_status_bar_domain_init_py",
-      "community": 12,
+      "community": 11,
       "norm_label": "__init__.py"
     },
     {
@@ -5076,7 +5085,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/status_bar/domain/state.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_status_bar_domain_state_py",
-      "community": 12,
+      "community": 11,
       "norm_label": "state.py"
     },
     {
@@ -5085,7 +5094,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/status_bar/domain/state.py",
       "source_location": "L4",
       "id": "domain_state_statusbarstate",
-      "community": 12,
+      "community": 11,
       "norm_label": "statusbarstate"
     },
     {
@@ -5094,7 +5103,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/status_bar/domain/state.py",
       "source_location": "L11",
       "id": "domain_state_color",
-      "community": 12,
+      "community": 11,
       "norm_label": "color()"
     },
     {
@@ -5103,7 +5112,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/status_bar/presentation/controller.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_status_bar_presentation_controller_py",
-      "community": 12,
+      "community": 11,
       "norm_label": "controller.py"
     },
     {
@@ -5112,7 +5121,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/status_bar/presentation/controller.py",
       "source_location": "L9",
       "id": "presentation_controller_statusbarcontroller",
-      "community": 12,
+      "community": 11,
       "norm_label": "statusbarcontroller"
     },
     {
@@ -5121,7 +5130,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/status_bar/presentation/controller.py",
       "source_location": "L11",
       "id": "presentation_controller_statusbarcontroller_init",
-      "community": 12,
+      "community": 11,
       "norm_label": ".__init__()"
     },
     {
@@ -5130,7 +5139,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/status_bar/presentation/controller.py",
       "source_location": "L19",
       "id": "presentation_controller_statusbarcontroller_setup_signals",
-      "community": 12,
+      "community": 11,
       "norm_label": "._setup_signals()"
     },
     {
@@ -5139,7 +5148,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/status_bar/presentation/controller.py",
       "source_location": "L31",
       "id": "presentation_controller_statusbarcontroller_on_init_finished",
-      "community": 12,
+      "community": 11,
       "norm_label": "._on_init_finished()"
     },
     {
@@ -5148,7 +5157,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/status_bar/presentation/controller.py",
       "source_location": "L40",
       "id": "presentation_controller_statusbarcontroller_on_credentials_configured",
-      "community": 12,
+      "community": 11,
       "norm_label": "._on_credentials_configured()"
     },
     {
@@ -5157,7 +5166,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/status_bar/presentation/controller.py",
       "source_location": "L43",
       "id": "presentation_controller_statusbarcontroller_on_credentials_cleared",
-      "community": 12,
+      "community": 11,
       "norm_label": "._on_credentials_cleared()"
     },
     {
@@ -5166,7 +5175,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/status_bar/presentation/controller.py",
       "source_location": "L47",
       "id": "presentation_controller_statusbarcontroller_on_sheet_removed",
-      "community": 12,
+      "community": 11,
       "norm_label": "._on_sheet_removed()"
     },
     {
@@ -5175,7 +5184,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/status_bar/presentation/controller.py",
       "source_location": "L51",
       "id": "presentation_controller_statusbarcontroller_on_sheet_updated",
-      "community": 12,
+      "community": 11,
       "norm_label": "._on_sheet_updated()"
     },
     {
@@ -5184,7 +5193,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/status_bar/presentation/controller.py",
       "source_location": "L55",
       "id": "presentation_controller_statusbarcontroller_on_request_started",
-      "community": 12,
+      "community": 11,
       "norm_label": "._on_request_started()"
     },
     {
@@ -5193,7 +5202,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/status_bar/presentation/controller.py",
       "source_location": "L60",
       "id": "presentation_controller_statusbarcontroller_on_request_finished",
-      "community": 12,
+      "community": 11,
       "norm_label": "._on_request_finished()"
     },
     {
@@ -5202,7 +5211,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/status_bar/presentation/controller.py",
       "source_location": "L67",
       "id": "presentation_controller_statusbarcontroller_set_base",
-      "community": 12,
+      "community": 11,
       "norm_label": "._set_base()"
     },
     {
@@ -5211,7 +5220,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/status_bar/presentation/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_status_bar_presentation_init_py",
-      "community": 12,
+      "community": 11,
       "norm_label": "__init__.py"
     },
     {
@@ -5220,7 +5229,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/status_bar/presentation/view.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_status_bar_presentation_view_py",
-      "community": 12,
+      "community": 11,
       "norm_label": "view.py"
     },
     {
@@ -5229,7 +5238,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/status_bar/presentation/view.py",
       "source_location": "L9",
       "id": "presentation_view_statusbarview",
-      "community": 12,
+      "community": 11,
       "norm_label": "statusbarview"
     },
     {
@@ -5238,7 +5247,7 @@
       "source_file": "",
       "source_location": "",
       "id": "qstatusbar",
-      "community": 12,
+      "community": 11,
       "norm_label": "qstatusbar"
     },
     {
@@ -5247,7 +5256,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/status_bar/presentation/view.py",
       "source_location": "L11",
       "id": "presentation_view_statusbarview_init",
-      "community": 12,
+      "community": 11,
       "norm_label": ".__init__()"
     },
     {
@@ -5256,7 +5265,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/status_bar/presentation/view.py",
       "source_location": "L24",
       "id": "presentation_view_statusbarview_set_state",
-      "community": 12,
+      "community": 11,
       "norm_label": ".set_state()"
     },
     {
@@ -5265,7 +5274,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/status_bar/presentation/view.py",
       "source_location": "L30",
       "id": "presentation_view_statusbarview_notify_done",
-      "community": 12,
+      "community": 11,
       "norm_label": ".notify_done()"
     },
     {
@@ -5274,7 +5283,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/status_bar/presentation/view.py",
       "source_location": "L34",
       "id": "presentation_view_statusbarview_restore",
-      "community": 12,
+      "community": 11,
       "norm_label": "._restore()"
     },
     {
@@ -5283,7 +5292,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/status_bar/presentation/view.py",
       "source_location": "L38",
       "id": "presentation_view_statusbarview_apply_color",
-      "community": 12,
+      "community": 11,
       "norm_label": "._apply_color()"
     },
     {
@@ -5292,7 +5301,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_init_py",
-      "community": 43,
+      "community": 42,
       "norm_label": "__init__.py"
     },
     {
@@ -5301,7 +5310,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/_server.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_server_py",
-      "community": 17,
+      "community": 15,
       "norm_label": "_server.py"
     },
     {
@@ -5310,7 +5319,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/_server.py",
       "source_location": "L15",
       "id": "backend_server_handle_data_source_error",
-      "community": 17,
+      "community": 15,
       "norm_label": "handle_data_source_error()"
     },
     {
@@ -5319,7 +5328,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/_server.py",
       "source_location": "L21",
       "id": "backend_server_handle_backend_error",
-      "community": 17,
+      "community": 15,
       "norm_label": "handle_backend_error()"
     },
     {
@@ -5328,7 +5337,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/_server.py",
       "source_location": "L26",
       "id": "backend_server_handle_unexpected_error",
-      "community": 17,
+      "community": 15,
       "norm_label": "handle_unexpected_error()"
     },
     {
@@ -5337,7 +5346,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/_server.py",
       "source_location": "L34",
       "id": "backend_server_backendserver",
-      "community": 17,
+      "community": 15,
       "norm_label": "backendserver"
     },
     {
@@ -5346,7 +5355,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/_server.py",
       "source_location": "L35",
       "id": "backend_server_backendserver_execute",
-      "community": 17,
+      "community": 15,
       "norm_label": ".execute()"
     },
     {
@@ -5355,7 +5364,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_google_sheets.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_data_source_google_sheets_py",
-      "community": 0,
+      "community": 1,
       "norm_label": "_google_sheets.py"
     },
     {
@@ -5364,7 +5373,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_google_sheets.py",
       "source_location": "L15",
       "id": "data_source_google_sheets_googlesheetsdatasource",
-      "community": 0,
+      "community": 1,
       "norm_label": "googlesheetsdatasource"
     },
     {
@@ -5373,7 +5382,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_google_sheets.py",
       "source_location": "L18",
       "id": "data_source_google_sheets_googlesheetsdatasource_init",
-      "community": 0,
+      "community": 1,
       "norm_label": ".__init__()"
     },
     {
@@ -5382,7 +5391,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_google_sheets.py",
       "source_location": "L26",
       "id": "data_source_google_sheets_googlesheetsdatasource_is_ready",
-      "community": 0,
+      "community": 1,
       "norm_label": ".is_ready()"
     },
     {
@@ -5391,7 +5400,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_google_sheets.py",
       "source_location": "L29",
       "id": "data_source_google_sheets_googlesheetsdatasource_set_credentials",
-      "community": 0,
+      "community": 1,
       "norm_label": ".set_credentials()"
     },
     {
@@ -5400,7 +5409,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_google_sheets.py",
       "source_location": "L37",
       "id": "data_source_google_sheets_googlesheetsdatasource_clear_credentials",
-      "community": 0,
+      "community": 1,
       "norm_label": ".clear_credentials()"
     },
     {
@@ -5409,7 +5418,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_google_sheets.py",
       "source_location": "L41",
       "id": "data_source_google_sheets_googlesheetsdatasource_clear_sheet",
-      "community": 0,
+      "community": 1,
       "norm_label": ".clear_sheet()"
     },
     {
@@ -5418,7 +5427,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_google_sheets.py",
       "source_location": "L45",
       "id": "data_source_google_sheets_googlesheetsdatasource_set_sheet",
-      "community": 0,
+      "community": 1,
       "norm_label": ".set_sheet()"
     },
     {
@@ -5427,7 +5436,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_google_sheets.py",
       "source_location": "L51",
       "id": "data_source_google_sheets_googlesheetsdatasource_fetch_orders_by_date",
-      "community": 0,
+      "community": 1,
       "norm_label": ".fetch_orders_by_date()"
     },
     {
@@ -5436,7 +5445,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_google_sheets.py",
       "source_location": "L57",
       "id": "data_source_google_sheets_googlesheetsdatasource_fetch_orders_by_period",
-      "community": 0,
+      "community": 1,
       "norm_label": ".fetch_orders_by_period()"
     },
     {
@@ -5445,7 +5454,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_google_sheets.py",
       "source_location": "L67",
       "id": "data_source_google_sheets_googlesheetsdatasource_setup_vm",
-      "community": 0,
+      "community": 1,
       "norm_label": "._setup_vm()"
     },
     {
@@ -5453,7 +5462,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_google_sheets.py",
       "source_location": "L16",
-      "community": 0,
+      "community": 1,
       "norm_label": "implementacao de datasourceprotocol para google sheets via gspread.",
       "id": "data_source_google_sheets_rationale_16"
     },
@@ -5463,7 +5472,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_data_source_init_py",
-      "community": 0,
+      "community": 1,
       "norm_label": "__init__.py"
     },
     {
@@ -5535,7 +5544,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_protocol.py",
       "source_location": "L28",
       "id": "data_source_protocol_datasourceprotocol_fetch_orders_by_date",
-      "community": 11,
+      "community": 6,
       "norm_label": ".fetch_orders_by_date()"
     },
     {
@@ -5606,7 +5615,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_protocol.py",
       "source_location": "L29",
-      "community": 11,
+      "community": 6,
       "norm_label": "retorna pedidos da data informada (dd/mm/yyyy).",
       "id": "data_source_protocol_rationale_29"
     },
@@ -5625,7 +5634,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/sheet_mapper.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_data_source_sheet_mapper_py",
-      "community": 0,
+      "community": 1,
       "norm_label": "sheet_mapper.py"
     },
     {
@@ -5634,7 +5643,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/sheet_mapper.py",
       "source_location": "L9",
       "id": "data_source_sheet_mapper_sheettabs",
-      "community": 0,
+      "community": 3,
       "norm_label": "sheettabs"
     },
     {
@@ -5643,7 +5652,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/sheet_mapper.py",
       "source_location": "L14",
       "id": "data_source_sheet_mapper_sheetcols",
-      "community": 0,
+      "community": 3,
       "norm_label": "sheetcols"
     },
     {
@@ -5652,7 +5661,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/sheet_mapper.py",
       "source_location": "L62",
       "id": "data_source_sheet_mapper_productcols",
-      "community": 0,
+      "community": 3,
       "norm_label": "productcols"
     },
     {
@@ -5661,7 +5670,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/sheet_mapper.py",
       "source_location": "L70",
       "id": "data_source_sheet_mapper_productcols_slot",
-      "community": 0,
+      "community": 3,
       "norm_label": ".slot()"
     },
     {
@@ -5670,7 +5679,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/sheet_mapper.py",
       "source_location": "L74",
       "id": "data_source_sheet_mapper_paymentcols",
-      "community": 0,
+      "community": 7,
       "norm_label": "paymentcols"
     },
     {
@@ -5687,7 +5696,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/sheet_mapper.py",
       "source_location": "L1",
-      "community": 0,
+      "community": 1,
       "norm_label": "mapeamento de colunas e tabs da planilha.",
       "id": "data_source_sheet_mapper_rationale_1"
     },
@@ -5696,7 +5705,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/sheet_mapper.py",
       "source_location": "L15",
-      "community": 0,
+      "community": 3,
       "norm_label": "colunas fixas da aba cadastro, agrupadas por dominio.",
       "id": "data_source_sheet_mapper_rationale_15"
     },
@@ -5705,7 +5714,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/sheet_mapper.py",
       "source_location": "L63",
-      "community": 0,
+      "community": 3,
       "norm_label": "colunas dos slots de produto (1\u20137). usar com .slot(n).",
       "id": "data_source_sheet_mapper_rationale_63"
     },
@@ -5714,7 +5723,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/sheet_mapper.py",
       "source_location": "L75",
-      "community": 0,
+      "community": 7,
       "norm_label": "colunas das parcelas de pagamento (1\u20136). usar com .slot(n).",
       "id": "data_source_sheet_mapper_rationale_75"
     },
@@ -5724,7 +5733,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_normalizer.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_data_source_normalizer_py",
-      "community": 0,
+      "community": 1,
       "norm_label": "_normalizer.py"
     },
     {
@@ -5733,7 +5742,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_normalizer.py",
       "source_location": "L6",
       "id": "data_source_normalizer_sheetnormalizer",
-      "community": 0,
+      "community": 1,
       "norm_label": "sheetnormalizer"
     },
     {
@@ -5742,7 +5751,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_normalizer.py",
       "source_location": "L20",
       "id": "data_source_normalizer_normalize",
-      "community": 0,
+      "community": 1,
       "norm_label": "normalize()"
     },
     {
@@ -5751,7 +5760,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_normalizer.py",
       "source_location": "L28",
       "id": "data_source_normalizer_rename_keys",
-      "community": 0,
+      "community": 1,
       "norm_label": "_rename_keys()"
     },
     {
@@ -5760,7 +5769,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_normalizer.py",
       "source_location": "L32",
       "id": "data_source_normalizer_fix_prod4",
-      "community": 0,
+      "community": 1,
       "norm_label": "_fix_prod4()"
     },
     {
@@ -5769,7 +5778,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_normalizer.py",
       "source_location": "L52",
       "id": "data_source_normalizer_rename_at",
-      "community": 0,
+      "community": 1,
       "norm_label": "_rename_at()"
     },
     {
@@ -5777,7 +5786,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_normalizer.py",
       "source_location": "L1",
-      "community": 0,
+      "community": 1,
       "norm_label": "normaliza headers inconsistentes da planilha para os valores canonicos dos enums",
       "id": "data_source_normalizer_rationale_1"
     },
@@ -5786,7 +5795,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_normalizer.py",
       "source_location": "L7",
-      "community": 0,
+      "community": 1,
       "norm_label": "traduz headers reais da planilha para os nomes canonicos definidos nos enums.",
       "id": "data_source_normalizer_rationale_7"
     },
@@ -5795,7 +5804,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_normalizer.py",
       "source_location": "L33",
-      "community": 44,
+      "community": 43,
       "norm_label": "renomeia a coluna que segue prod3 para prod4, independente do header atual.",
       "id": "data_source_normalizer_rationale_33"
     },
@@ -5805,7 +5814,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_viewmodel.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_data_source_viewmodel_py",
-      "community": 0,
+      "community": 1,
       "norm_label": "_viewmodel.py"
     },
     {
@@ -5814,7 +5823,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_viewmodel.py",
       "source_location": "L9",
       "id": "data_source_viewmodel_sheetsviewmodel",
-      "community": 0,
+      "community": 1,
       "norm_label": "_sheetsviewmodel"
     },
     {
@@ -5823,7 +5832,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_viewmodel.py",
       "source_location": "L12",
       "id": "data_source_viewmodel_sheetsviewmodel_init",
-      "community": 0,
+      "community": 1,
       "norm_label": ".__init__()"
     },
     {
@@ -5832,7 +5841,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_viewmodel.py",
       "source_location": "L19",
       "id": "data_source_viewmodel_database",
-      "community": 0,
+      "community": 1,
       "norm_label": "database()"
     },
     {
@@ -5841,7 +5850,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_viewmodel.py",
       "source_location": "L22",
       "id": "data_source_viewmodel_sheetsviewmodel_prewarm",
-      "community": 0,
+      "community": 1,
       "norm_label": ".prewarm()"
     },
     {
@@ -5850,7 +5859,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_viewmodel.py",
       "source_location": "L28",
       "id": "data_source_viewmodel_sheetsviewmodel_load_schema",
-      "community": 0,
+      "community": 1,
       "norm_label": "._load_schema()"
     },
     {
@@ -5859,7 +5868,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_viewmodel.py",
       "source_location": "L42",
       "id": "data_source_viewmodel_fetch",
-      "community": 0,
+      "community": 1,
       "norm_label": "fetch()"
     },
     {
@@ -5867,7 +5876,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_viewmodel.py",
       "source_location": "L10",
-      "community": 0,
+      "community": 1,
       "norm_label": "encapsula o acesso a planilha: schema cacheado, prewarm e fetch.",
       "id": "data_source_viewmodel_rationale_10"
     },
@@ -5876,7 +5885,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_viewmodel.py",
       "source_location": "L29",
-      "community": 0,
+      "community": 1,
       "norm_label": "carrega cabecalho e indice da coluna data na primeira chamada; no-op nas seguint",
       "id": "data_source_viewmodel_rationale_29"
     },
@@ -5885,7 +5894,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_viewmodel.py",
       "source_location": "L43",
-      "community": 45,
+      "community": 44,
       "norm_label": "busca pedidos por datas usando dois passes para minimizar chamadas a api.",
       "id": "data_source_viewmodel_rationale_43"
     },
@@ -5895,7 +5904,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_utils.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_data_source_utils_py",
-      "community": 0,
+      "community": 1,
       "norm_label": "_utils.py"
     },
     {
@@ -5904,7 +5913,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_utils.py",
       "source_location": "L5",
       "id": "data_source_utils_normalize_date",
-      "community": 0,
+      "community": 1,
       "norm_label": "normalize_date()"
     },
     {
@@ -5913,7 +5922,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_utils.py",
       "source_location": "L15",
       "id": "data_source_utils_to_dicts",
-      "community": 0,
+      "community": 1,
       "norm_label": "to_dicts()"
     },
     {
@@ -5922,7 +5931,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_utils.py",
       "source_location": "L21",
       "id": "data_source_utils_to_ranges",
-      "community": 0,
+      "community": 1,
       "norm_label": "to_ranges()"
     },
     {
@@ -5931,7 +5940,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_utils.py",
       "source_location": "L34",
       "id": "data_source_utils_date_range",
-      "community": 0,
+      "community": 1,
       "norm_label": "date_range()"
     },
     {
@@ -5939,7 +5948,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_utils.py",
       "source_location": "L6",
-      "community": 0,
+      "community": 1,
       "norm_label": "normaliza uma data para dd/mm/yyyy aceitando os formatos dd/mm/yy e dd/mm/yyyy.",
       "id": "data_source_utils_rationale_6"
     },
@@ -5948,7 +5957,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_utils.py",
       "source_location": "L16",
-      "community": 0,
+      "community": 1,
       "norm_label": "converte linhas da planilha em lista de dicts usando o cabecalho como chaves (lo",
       "id": "data_source_utils_rationale_16"
     },
@@ -5957,7 +5966,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_utils.py",
       "source_location": "L22",
-      "community": 0,
+      "community": 1,
       "norm_label": "agrupa numeros de linha consecutivos em ranges a1 notation e divide em batches d",
       "id": "data_source_utils_rationale_22"
     },
@@ -5966,7 +5975,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_utils.py",
       "source_location": "L35",
-      "community": 0,
+      "community": 1,
       "norm_label": "retorna o conjunto de todas as datas (dd/mm/yyyy) entre start e end, inclusive.",
       "id": "data_source_utils_rationale_35"
     },
@@ -5976,7 +5985,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_handler.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_data_source_errors_handler_py",
-      "community": 0,
+      "community": 1,
       "norm_label": "_handler.py"
     },
     {
@@ -5985,7 +5994,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_handler.py",
       "source_location": "L14",
       "id": "errors_handler_is_valid_date",
-      "community": 0,
+      "community": 1,
       "norm_label": "_is_valid_date()"
     },
     {
@@ -5994,7 +6003,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_handler.py",
       "source_location": "L18",
       "id": "errors_handler_parse_date",
-      "community": 0,
+      "community": 1,
       "norm_label": "_parse_date()"
     },
     {
@@ -6003,7 +6012,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_handler.py",
       "source_location": "L22",
       "id": "errors_handler_sheetsguard",
-      "community": 0,
+      "community": 1,
       "norm_label": "_sheetsguard"
     },
     {
@@ -6012,7 +6021,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_handler.py",
       "source_location": "L27",
       "id": "errors_handler_credentials_file",
-      "community": 0,
+      "community": 1,
       "norm_label": "credentials_file()"
     },
     {
@@ -6021,7 +6030,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_handler.py",
       "source_location": "L34",
       "id": "errors_handler_local_storage",
-      "community": 0,
+      "community": 1,
       "norm_label": "local_storage()"
     },
     {
@@ -6030,7 +6039,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_handler.py",
       "source_location": "L41",
       "id": "errors_handler_authentication",
-      "community": 0,
+      "community": 1,
       "norm_label": "authentication()"
     },
     {
@@ -6039,7 +6048,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_handler.py",
       "source_location": "L55",
       "id": "errors_handler_sheetsguard_validate_credentials",
-      "community": 0,
+      "community": 1,
       "norm_label": ".validate_credentials()"
     },
     {
@@ -6048,7 +6057,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_handler.py",
       "source_location": "L59",
       "id": "errors_handler_sheetsguard_validate_sheet_id",
-      "community": 0,
+      "community": 1,
       "norm_label": ".validate_sheet_id()"
     },
     {
@@ -6057,7 +6066,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_handler.py",
       "source_location": "L63",
       "id": "errors_handler_sheetsguard_validate_date",
-      "community": 0,
+      "community": 1,
       "norm_label": ".validate_date()"
     },
     {
@@ -6066,7 +6075,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_handler.py",
       "source_location": "L67",
       "id": "errors_handler_sheetsguard_validate_date_range",
-      "community": 0,
+      "community": 1,
       "norm_label": ".validate_date_range()"
     },
     {
@@ -6075,7 +6084,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_handler.py",
       "source_location": "L77",
       "id": "errors_handler_handle_api",
-      "community": 0,
+      "community": 1,
       "norm_label": "handle_api()"
     },
     {
@@ -6084,7 +6093,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_handler.py",
       "source_location": "L95",
       "id": "errors_handler_handle_sheet_setup",
-      "community": 0,
+      "community": 1,
       "norm_label": "handle_sheet_setup()"
     },
     {
@@ -6093,7 +6102,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_data_source_errors_errors_py",
-      "community": 0,
+      "community": 1,
       "norm_label": "_errors.py"
     },
     {
@@ -6102,7 +6111,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L1",
       "id": "errors_errors_datasourceerror",
-      "community": 0,
+      "community": 1,
       "norm_label": "datasourceerror"
     },
     {
@@ -6111,7 +6120,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L7",
       "id": "errors_errors_credentialsfilenotfounderror",
-      "community": 0,
+      "community": 1,
       "norm_label": "credentialsfilenotfounderror"
     },
     {
@@ -6120,7 +6129,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L12",
       "id": "errors_errors_credentialsfilenotfounderror_init",
-      "community": 0,
+      "community": 1,
       "norm_label": ".__init__()"
     },
     {
@@ -6129,7 +6138,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L17",
       "id": "errors_errors_credentialssaveerror",
-      "community": 0,
+      "community": 1,
       "norm_label": "credentialssaveerror"
     },
     {
@@ -6138,7 +6147,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L22",
       "id": "errors_errors_credentialssaveerror_init",
-      "community": 0,
+      "community": 1,
       "norm_label": ".__init__()"
     },
     {
@@ -6147,7 +6156,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L26",
       "id": "errors_errors_credentialsfilecorruptederror",
-      "community": 0,
+      "community": 1,
       "norm_label": "credentialsfilecorruptederror"
     },
     {
@@ -6156,7 +6165,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L31",
       "id": "errors_errors_credentialsfilecorruptederror_init",
-      "community": 0,
+      "community": 1,
       "norm_label": ".__init__()"
     },
     {
@@ -6165,7 +6174,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L35",
       "id": "errors_errors_credentialsformaterror",
-      "community": 0,
+      "community": 1,
       "norm_label": "credentialsformaterror"
     },
     {
@@ -6174,7 +6183,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L40",
       "id": "errors_errors_credentialsformaterror_init",
-      "community": 0,
+      "community": 1,
       "norm_label": ".__init__()"
     },
     {
@@ -6183,7 +6192,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L44",
       "id": "errors_errors_invalidcredentialserror",
-      "community": 0,
+      "community": 1,
       "norm_label": "invalidcredentialserror"
     },
     {
@@ -6192,7 +6201,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L49",
       "id": "errors_errors_invalidcredentialserror_init",
-      "community": 0,
+      "community": 1,
       "norm_label": ".__init__()"
     },
     {
@@ -6201,7 +6210,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L53",
       "id": "errors_errors_networkunavailableerror",
-      "community": 0,
+      "community": 1,
       "norm_label": "networkunavailableerror"
     },
     {
@@ -6210,7 +6219,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L58",
       "id": "errors_errors_networkunavailableerror_init",
-      "community": 0,
+      "community": 1,
       "norm_label": ".__init__()"
     },
     {
@@ -6219,7 +6228,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L62",
       "id": "errors_errors_networktimeouterror",
-      "community": 0,
+      "community": 1,
       "norm_label": "networktimeouterror"
     },
     {
@@ -6228,7 +6237,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L67",
       "id": "errors_errors_networktimeouterror_init",
-      "community": 0,
+      "community": 1,
       "norm_label": ".__init__()"
     },
     {
@@ -6237,7 +6246,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L71",
       "id": "errors_errors_tokenexpirederror",
-      "community": 0,
+      "community": 1,
       "norm_label": "tokenexpirederror"
     },
     {
@@ -6246,7 +6255,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L76",
       "id": "errors_errors_tokenexpirederror_init",
-      "community": 0,
+      "community": 1,
       "norm_label": ".__init__()"
     },
     {
@@ -6255,7 +6264,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L80",
       "id": "errors_errors_sheetidinvaliderror",
-      "community": 0,
+      "community": 1,
       "norm_label": "sheetidinvaliderror"
     },
     {
@@ -6264,7 +6273,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L85",
       "id": "errors_errors_sheetidinvaliderror_init",
-      "community": 0,
+      "community": 1,
       "norm_label": ".__init__()"
     },
     {
@@ -6273,7 +6282,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L90",
       "id": "errors_errors_sheetnotfounderror",
-      "community": 0,
+      "community": 1,
       "norm_label": "sheetnotfounderror"
     },
     {
@@ -6282,7 +6291,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L95",
       "id": "errors_errors_sheetnotfounderror_init",
-      "community": 0,
+      "community": 1,
       "norm_label": ".__init__()"
     },
     {
@@ -6291,7 +6300,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L99",
       "id": "errors_errors_sheetaccessdeniederror",
-      "community": 0,
+      "community": 1,
       "norm_label": "sheetaccessdeniederror"
     },
     {
@@ -6300,7 +6309,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L104",
       "id": "errors_errors_sheetaccessdeniederror_init",
-      "community": 0,
+      "community": 1,
       "norm_label": ".__init__()"
     },
     {
@@ -6309,7 +6318,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L108",
       "id": "errors_errors_invaliddateformaterror",
-      "community": 0,
+      "community": 1,
       "norm_label": "invaliddateformaterror"
     },
     {
@@ -6318,7 +6327,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L113",
       "id": "errors_errors_invaliddateformaterror_init",
-      "community": 0,
+      "community": 1,
       "norm_label": ".__init__()"
     },
     {
@@ -6327,7 +6336,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L118",
       "id": "errors_errors_invaliddaterangeerror",
-      "community": 0,
+      "community": 1,
       "norm_label": "invaliddaterangeerror"
     },
     {
@@ -6336,7 +6345,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L123",
       "id": "errors_errors_invaliddaterangeerror_init",
-      "community": 0,
+      "community": 1,
       "norm_label": ".__init__()"
     },
     {
@@ -6345,7 +6354,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L129",
       "id": "errors_errors_apiquotaexceedederror",
-      "community": 0,
+      "community": 1,
       "norm_label": "apiquotaexceedederror"
     },
     {
@@ -6354,7 +6363,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L134",
       "id": "errors_errors_apiquotaexceedederror_init",
-      "community": 0,
+      "community": 1,
       "norm_label": ".__init__()"
     },
     {
@@ -6363,7 +6372,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L138",
       "id": "errors_errors_apiunexpectedresponseerror",
-      "community": 0,
+      "community": 1,
       "norm_label": "apiunexpectedresponseerror"
     },
     {
@@ -6372,7 +6381,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L143",
       "id": "errors_errors_apiunexpectedresponseerror_init",
-      "community": 0,
+      "community": 1,
       "norm_label": ".__init__()"
     },
     {
@@ -6381,7 +6390,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L148",
       "id": "errors_errors_unexpectedsheetstructureerror",
-      "community": 0,
+      "community": 1,
       "norm_label": "unexpectedsheetstructureerror"
     },
     {
@@ -6390,7 +6399,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L153",
       "id": "errors_errors_unexpectedsheetstructureerror_init",
-      "community": 0,
+      "community": 1,
       "norm_label": ".__init__()"
     },
     {
@@ -6399,7 +6408,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L159",
       "id": "errors_errors_prewarmfailederror",
-      "community": 0,
+      "community": 1,
       "norm_label": "prewarmfailederror"
     },
     {
@@ -6408,7 +6417,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L164",
       "id": "errors_errors_prewarmfailederror_init",
-      "community": 0,
+      "community": 1,
       "norm_label": ".__init__()"
     },
     {
@@ -6417,7 +6426,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L169",
       "id": "errors_errors_datasourcenotreadyerror",
-      "community": 0,
+      "community": 1,
       "norm_label": "datasourcenotreadyerror"
     },
     {
@@ -6426,7 +6435,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L174",
       "id": "errors_errors_datasourcenotreadyerror_init",
-      "community": 0,
+      "community": 1,
       "norm_label": ".__init__()"
     },
     {
@@ -6435,7 +6444,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_features_init_py",
-      "community": 46,
+      "community": 45,
       "norm_label": "__init__.py"
     },
     {
@@ -6534,7 +6543,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_features_orders_init_py",
-      "community": 0,
+      "community": 1,
       "norm_label": "__init__.py"
     },
     {
@@ -6543,7 +6552,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/__init__.py",
       "source_location": "L14",
       "id": "orders_init_check_connection",
-      "community": 0,
+      "community": 1,
       "norm_label": "check_connection()"
     },
     {
@@ -6758,7 +6767,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/shared/mapper.py",
       "source_location": "L16",
-      "community": 47,
+      "community": 46,
       "norm_label": "monta um order completo a partir de uma linha do dataframe.",
       "id": "shared_mapper_rationale_16"
     },
@@ -6777,7 +6786,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_features_orders_subfeatures_init_py",
-      "community": 11,
+      "community": 6,
       "norm_label": "__init__.py"
     },
     {
@@ -6786,7 +6795,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/payments/service.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_features_orders_subfeatures_payments_service_py",
-      "community": 11,
+      "community": 6,
       "norm_label": "service.py"
     },
     {
@@ -6795,7 +6804,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/payments/service.py",
       "source_location": "L10",
       "id": "payments_service_paymentsmapper",
-      "community": 11,
+      "community": 6,
       "norm_label": "paymentsmapper"
     },
     {
@@ -6804,7 +6813,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/payments/service.py",
       "source_location": "L14",
       "id": "payments_service_to_response",
-      "community": 11,
+      "community": 6,
       "norm_label": "to_response()"
     },
     {
@@ -6813,7 +6822,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/payments/service.py",
       "source_location": "L21",
       "id": "payments_service_paymentsservice",
-      "community": 11,
+      "community": 6,
       "norm_label": "paymentsservice"
     },
     {
@@ -6822,7 +6831,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/payments/service.py",
       "source_location": "L24",
       "id": "payments_service_paymentsservice_init",
-      "community": 11,
+      "community": 6,
       "norm_label": ".__init__()"
     },
     {
@@ -6831,7 +6840,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/payments/service.py",
       "source_location": "L27",
       "id": "payments_service_paymentsservice_get_pendent",
-      "community": 11,
+      "community": 6,
       "norm_label": ".get_pendent()"
     },
     {
@@ -6839,7 +6848,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/payments/service.py",
       "source_location": "L1",
-      "community": 11,
+      "community": 6,
       "norm_label": "service e mapper de pagamentos pendentes.",
       "id": "payments_service_rationale_1"
     },
@@ -6848,7 +6857,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/payments/service.py",
       "source_location": "L11",
-      "community": 11,
+      "community": 6,
       "norm_label": "serializa o resultado do paymentsservice para dict json-ready.",
       "id": "payments_service_rationale_11"
     },
@@ -6857,7 +6866,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/payments/service.py",
       "source_location": "L22",
-      "community": 11,
+      "community": 6,
       "norm_label": "filtra pedidos com pagamento pendente e monta os objetos de dominio.",
       "id": "payments_service_rationale_22"
     },
@@ -6866,7 +6875,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/payments/service.py",
       "source_location": "L28",
-      "community": 11,
+      "community": 6,
       "norm_label": "retorna pedidos com amount_pendent > 0 para a data informada.",
       "id": "payments_service_rationale_28"
     },
@@ -6876,7 +6885,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/payments/route.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_features_orders_subfeatures_payments_route_py",
-      "community": 11,
+      "community": 6,
       "norm_label": "route.py"
     },
     {
@@ -6885,7 +6894,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/payments/route.py",
       "source_location": "L12",
       "id": "payments_route_get_payments_pendent",
-      "community": 11,
+      "community": 6,
       "norm_label": "get_payments_pendent()"
     },
     {
@@ -6893,7 +6902,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/payments/route.py",
       "source_location": "L1",
-      "community": 11,
+      "community": 6,
       "norm_label": "rota de pagamentos \u2014 get /orders/payments-pendent.",
       "id": "payments_route_rationale_1"
     },
@@ -6903,7 +6912,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/payments/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_features_orders_subfeatures_payments_init_py",
-      "community": 48,
+      "community": 47,
       "norm_label": "__init__.py"
     },
     {
@@ -6912,7 +6921,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/payments/repository.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_features_orders_subfeatures_payments_repository_py",
-      "community": 11,
+      "community": 6,
       "norm_label": "repository.py"
     },
     {
@@ -6921,7 +6930,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/payments/repository.py",
       "source_location": "L11",
       "id": "payments_repository_paymentsrepository",
-      "community": 11,
+      "community": 6,
       "norm_label": "paymentsrepository"
     },
     {
@@ -6930,7 +6939,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/payments/repository.py",
       "source_location": "L17",
       "id": "payments_repository_paymentsrepository_get_by_date",
-      "community": 11,
+      "community": 6,
       "norm_label": ".get_by_date()"
     },
     {
@@ -6939,7 +6948,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/payments/repository.py",
       "source_location": "L25",
       "id": "payments_repository_to_dataframe",
-      "community": 11,
+      "community": 6,
       "norm_label": "_to_dataframe()"
     },
     {
@@ -6948,7 +6957,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/payments/repository.py",
       "source_location": "L51",
       "id": "payments_repository_cast_numeric",
-      "community": 11,
+      "community": 6,
       "norm_label": "_cast_numeric()"
     },
     {
@@ -6956,7 +6965,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/payments/repository.py",
       "source_location": "L1",
-      "community": 11,
+      "community": 6,
       "norm_label": "repositorio de pagamentos \u2014 busca e prepara dados da planilha para o paymentsser",
       "id": "payments_repository_rationale_1"
     },
@@ -6965,7 +6974,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/payments/repository.py",
       "source_location": "L12",
-      "community": 11,
+      "community": 6,
       "norm_label": "acessa o data source e entrega um dataframe tipado para o paymentsservice.",
       "id": "payments_repository_rationale_12"
     },
@@ -6974,7 +6983,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/payments/repository.py",
       "source_location": "L18",
-      "community": 11,
+      "community": 6,
       "norm_label": "retorna todos os pedidos de uma data com colunas numericas convertidas para floa",
       "id": "payments_repository_rationale_18"
     },
@@ -6983,7 +6992,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/payments/repository.py",
       "source_location": "L26",
-      "community": 49,
+      "community": 48,
       "norm_label": "converte list[dict] em dataframe com cast numerico de todas as colunas de valor.",
       "id": "payments_repository_rationale_26"
     },
@@ -6992,7 +7001,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/payments/repository.py",
       "source_location": "L52",
-      "community": 50,
+      "community": 49,
       "norm_label": "faz cast numerico de uma coluna se ela existir no dataframe.",
       "id": "payments_repository_rationale_52"
     },
@@ -7092,7 +7101,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/summary/route.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_features_orders_subfeatures_summary_route_py",
-      "community": 11,
+      "community": 6,
       "norm_label": "route.py"
     },
     {
@@ -7101,7 +7110,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/summary/route.py",
       "source_location": "L12",
       "id": "summary_route_get_orders",
-      "community": 11,
+      "community": 6,
       "norm_label": "get_orders()"
     },
     {
@@ -7109,7 +7118,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/summary/route.py",
       "source_location": "L1",
-      "community": 11,
+      "community": 6,
       "norm_label": "rota de pedidos \u2014 get /orders.",
       "id": "summary_route_rationale_1"
     },
@@ -7119,7 +7128,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/summary/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_features_orders_subfeatures_summary_init_py",
-      "community": 51,
+      "community": 50,
       "norm_label": "__init__.py"
     },
     {
@@ -7199,7 +7208,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/summary/repository.py",
       "source_location": "L26",
-      "community": 52,
+      "community": 51,
       "norm_label": "converte list[dict] em dataframe com cast numerico de todas as colunas de valor.",
       "id": "summary_repository_rationale_26"
     },
@@ -7208,7 +7217,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/summary/repository.py",
       "source_location": "L51",
-      "community": 53,
+      "community": 52,
       "norm_label": "faz cast numerico de uma coluna se ela existir no dataframe.",
       "id": "summary_repository_rationale_51"
     },
@@ -7218,7 +7227,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/deliveries/service.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_features_orders_subfeatures_deliveries_service_py",
-      "community": 9,
+      "community": 6,
       "norm_label": "service.py"
     },
     {
@@ -7227,7 +7236,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/deliveries/service.py",
       "source_location": "L10",
       "id": "deliveries_service_deliveriesmapper",
-      "community": 9,
+      "community": 6,
       "norm_label": "deliveriesmapper"
     },
     {
@@ -7236,7 +7245,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/deliveries/service.py",
       "source_location": "L14",
       "id": "deliveries_service_to_response",
-      "community": 11,
+      "community": 6,
       "norm_label": "to_response()"
     },
     {
@@ -7245,7 +7254,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/deliveries/service.py",
       "source_location": "L18",
       "id": "deliveries_service_deliveriesservice",
-      "community": 9,
+      "community": 6,
       "norm_label": "deliveriesservice"
     },
     {
@@ -7254,7 +7263,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/deliveries/service.py",
       "source_location": "L21",
       "id": "deliveries_service_deliveriesservice_init",
-      "community": 9,
+      "community": 6,
       "norm_label": ".__init__()"
     },
     {
@@ -7263,7 +7272,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/deliveries/service.py",
       "source_location": "L24",
       "id": "deliveries_service_deliveriesservice_get_by_date",
-      "community": 9,
+      "community": 6,
       "norm_label": ".get_by_date()"
     },
     {
@@ -7271,7 +7280,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/deliveries/service.py",
       "source_location": "L1",
-      "community": 9,
+      "community": 6,
       "norm_label": "service e mapper de entregas \u2014 agrupa pedidos do dia por tipo de entrega.",
       "id": "deliveries_service_rationale_1"
     },
@@ -7280,7 +7289,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/deliveries/service.py",
       "source_location": "L11",
-      "community": 9,
+      "community": 6,
       "norm_label": "serializa deliveriessummary para dict json-ready.",
       "id": "deliveries_service_rationale_11"
     },
@@ -7289,7 +7298,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/deliveries/service.py",
       "source_location": "L19",
-      "community": 9,
+      "community": 6,
       "norm_label": "aplica regra de negocio sobre os pedidos do dia e retorna o resumo de entregas.",
       "id": "deliveries_service_rationale_19"
     },
@@ -7298,7 +7307,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/deliveries/service.py",
       "source_location": "L25",
-      "community": 9,
+      "community": 6,
       "norm_label": "retorna contagem de pedidos agrupada por tipo de entrega para a data informada.",
       "id": "deliveries_service_rationale_25"
     },
@@ -7308,7 +7317,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/deliveries/models.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_features_orders_subfeatures_deliveries_models_py",
-      "community": 9,
+      "community": 6,
       "norm_label": "models.py"
     },
     {
@@ -7317,7 +7326,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/deliveries/models.py",
       "source_location": "L7",
       "id": "deliveries_models_deliverytypecount",
-      "community": 9,
+      "community": 6,
       "norm_label": "deliverytypecount"
     },
     {
@@ -7326,7 +7335,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/deliveries/models.py",
       "source_location": "L13",
       "id": "deliveries_models_deliveriessummary",
-      "community": 9,
+      "community": 6,
       "norm_label": "deliveriessummary"
     },
     {
@@ -7334,7 +7343,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/deliveries/models.py",
       "source_location": "L1",
-      "community": 9,
+      "community": 6,
       "norm_label": "models de dominio da feature de entregas.",
       "id": "deliveries_models_rationale_1"
     },
@@ -7344,7 +7353,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/deliveries/route.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_features_orders_subfeatures_deliveries_route_py",
-      "community": 11,
+      "community": 6,
       "norm_label": "route.py"
     },
     {
@@ -7353,7 +7362,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/deliveries/route.py",
       "source_location": "L12",
       "id": "deliveries_route_get_deliveries",
-      "community": 11,
+      "community": 6,
       "norm_label": "get_deliveries()"
     },
     {
@@ -7361,7 +7370,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/deliveries/route.py",
       "source_location": "L1",
-      "community": 11,
+      "community": 6,
       "norm_label": "rota de entregas \u2014 get /orders/deliveries.",
       "id": "deliveries_route_rationale_1"
     },
@@ -7371,7 +7380,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/deliveries/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_features_orders_subfeatures_deliveries_init_py",
-      "community": 54,
+      "community": 53,
       "norm_label": "__init__.py"
     },
     {
@@ -7380,7 +7389,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/deliveries/repository.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_features_orders_subfeatures_deliveries_repository_py",
-      "community": 9,
+      "community": 6,
       "norm_label": "repository.py"
     },
     {
@@ -7389,7 +7398,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/deliveries/repository.py",
       "source_location": "L8",
       "id": "deliveries_repository_deliveriesrepository",
-      "community": 9,
+      "community": 6,
       "norm_label": "deliveriesrepository"
     },
     {
@@ -7398,7 +7407,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/deliveries/repository.py",
       "source_location": "L14",
       "id": "deliveries_repository_deliveriesrepository_get_by_date",
-      "community": 11,
+      "community": 6,
       "norm_label": ".get_by_date()"
     },
     {
@@ -7406,7 +7415,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/deliveries/repository.py",
       "source_location": "L1",
-      "community": 9,
+      "community": 6,
       "norm_label": "repositorio de entregas \u2014 busca e prepara dados da planilha para o deliveriesser",
       "id": "deliveries_repository_rationale_1"
     },
@@ -7415,7 +7424,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/deliveries/repository.py",
       "source_location": "L9",
-      "community": 9,
+      "community": 6,
       "norm_label": "acessa o data source e entrega um dataframe para o deliveriesservice.      nao f",
       "id": "deliveries_repository_rationale_9"
     },
@@ -7424,7 +7433,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/deliveries/repository.py",
       "source_location": "L15",
-      "community": 11,
+      "community": 6,
       "norm_label": "retorna todos os pedidos de uma data como dataframe bruto.",
       "id": "deliveries_repository_rationale_15"
     },
@@ -7515,7 +7524,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/utils/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_utils_init_py",
-      "community": 19,
+      "community": 18,
       "norm_label": "__init__.py"
     },
     {
@@ -7524,7 +7533,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/utils/numbers.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_utils_numbers_py",
-      "community": 19,
+      "community": 18,
       "norm_label": "numbers.py"
     },
     {
@@ -7533,7 +7542,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/utils/numbers.py",
       "source_location": "L4",
       "id": "utils_numbers_normalize_decimal",
-      "community": 19,
+      "community": 18,
       "norm_label": "normalize_decimal()"
     },
     {
@@ -7541,7 +7550,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/utils/numbers.py",
       "source_location": "L1",
-      "community": 19,
+      "community": 18,
       "norm_label": "utilitarios de formatacao numerica.",
       "id": "utils_numbers_rationale_1"
     },
@@ -7550,7 +7559,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/utils/numbers.py",
       "source_location": "L5",
-      "community": 19,
+      "community": 18,
       "norm_label": "converte numero no formato brasileiro para o formato ingles.      remove o separ",
       "id": "utils_numbers_rationale_5"
     },
@@ -7560,7 +7569,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/errors/_errors.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_errors_errors_py",
-      "community": 17,
+      "community": 15,
       "norm_label": "_errors.py"
     },
     {
@@ -7569,7 +7578,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/errors/_errors.py",
       "source_location": "L1",
       "id": "errors_errors_backenderror",
-      "community": 17,
+      "community": 15,
       "norm_label": "backenderror"
     },
     {
@@ -7578,7 +7587,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/errors/_errors.py",
       "source_location": "L7",
       "id": "errors_errors_backenderror_to_dict",
-      "community": 17,
+      "community": 15,
       "norm_label": ".to_dict()"
     },
     {
@@ -7587,7 +7596,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/errors/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_errors_init_py",
-      "community": 17,
+      "community": 15,
       "norm_label": "__init__.py"
     },
     {
@@ -7596,7 +7605,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/errors/_mapper.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_errors_mapper_py",
-      "community": 17,
+      "community": 15,
       "norm_label": "_mapper.py"
     },
     {
@@ -7605,7 +7614,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/errors/_mapper.py",
       "source_location": "L26",
       "id": "errors_mapper_translate",
-      "community": 17,
+      "community": 15,
       "norm_label": "translate()"
     },
     {
@@ -7614,7 +7623,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/errors/_mapper.py",
       "source_location": "L35",
       "id": "errors_mapper_generic_mapper",
-      "community": 17,
+      "community": 15,
       "norm_label": "generic_mapper()"
     },
     {
@@ -7623,7 +7632,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/assets/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_assets_init_py",
-      "community": 55,
+      "community": 54,
       "norm_label": "__init__.py"
     },
     {
@@ -7632,8 +7641,26 @@
       "source_file": "assets/strings.py",
       "source_location": "L1",
       "id": "assets_strings_py",
-      "community": 56,
+      "community": 55,
       "norm_label": "strings.py"
+    },
+    {
+      "label": "Contrato que qualquer client precisa cumprir.",
+      "file_type": "rationale",
+      "source_file": "core/network/_client.py",
+      "source_location": "L14",
+      "community": 3,
+      "norm_label": "contrato que qualquer client precisa cumprir.",
+      "id": "network_client_rationale_14"
+    },
+    {
+      "label": "Roteia requests para o backend local (in-process).     Nenhuma rede envolvida \u2014",
+      "file_type": "rationale",
+      "source_file": "core/network/_client.py",
+      "source_location": "L21",
+      "community": 3,
+      "norm_label": "roteia requests para o backend local (in-process).     nenhuma rede envolvida \u2014",
+      "id": "network_client_rationale_21"
     }
   ],
   "links": [
@@ -9069,6 +9096,42 @@
       "relation": "uses",
       "confidence": "INFERRED",
       "source_file": "core/network/_client.py",
+      "source_location": "L7",
+      "weight": 0.8,
+      "_src": "network_client_rationale_13",
+      "_tgt": "network_response_httpresponse",
+      "source": "network_response_httpresponse",
+      "target": "network_client_rationale_13",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "uses",
+      "confidence": "INFERRED",
+      "source_file": "core/network/_client.py",
+      "source_location": "L7",
+      "weight": 0.8,
+      "_src": "network_client_rationale_20",
+      "_tgt": "network_response_httpresponse",
+      "source": "network_response_httpresponse",
+      "target": "network_client_rationale_20",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/_server.py",
+      "source_location": "L42",
+      "weight": 1.0,
+      "_src": "network_response_httpresponse",
+      "_tgt": "backend_server_backendserver_execute",
+      "source": "network_response_httpresponse",
+      "target": "backend_server_backendserver_execute"
+    },
+    {
+      "relation": "uses",
+      "confidence": "INFERRED",
+      "source_file": "core/network/_client.py",
       "source_location": "L8",
       "weight": 0.8,
       "_src": "network_response_httpresponse",
@@ -9088,18 +9151,6 @@
       "confidence_score": 0.5,
       "source": "network_response_httpresponse",
       "target": "network_client_rationale_21"
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "confidence_score": 0.8,
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/_server.py",
-      "source_location": "L42",
-      "weight": 1.0,
-      "_src": "network_response_httpresponse",
-      "_tgt": "backend_server_backendserver_execute",
-      "source": "network_response_httpresponse",
-      "target": "backend_server_backendserver_execute"
     },
     {
       "relation": "rationale_for",
@@ -9261,6 +9312,42 @@
       "relation": "uses",
       "confidence": "INFERRED",
       "source_file": "core/network/_client.py",
+      "source_location": "L6",
+      "weight": 0.8,
+      "_src": "network_client_rationale_13",
+      "_tgt": "network_request_httprequest",
+      "source": "network_request_httprequest",
+      "target": "network_client_rationale_13",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "uses",
+      "confidence": "INFERRED",
+      "source_file": "core/network/_client.py",
+      "source_location": "L6",
+      "weight": 0.8,
+      "_src": "network_client_rationale_20",
+      "_tgt": "network_request_httprequest",
+      "source": "network_request_httprequest",
+      "target": "network_client_rationale_20",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/api.py",
+      "source_location": "L17",
+      "weight": 1.0,
+      "_src": "network_request_httprequest",
+      "_tgt": "network_api_api_init",
+      "source": "network_request_httprequest",
+      "target": "network_api_api_init"
+    },
+    {
+      "relation": "uses",
+      "confidence": "INFERRED",
+      "source_file": "core/network/_client.py",
       "source_location": "L7",
       "weight": 0.8,
       "_src": "network_request_httprequest",
@@ -9280,18 +9367,6 @@
       "confidence_score": 0.5,
       "source": "network_request_httprequest",
       "target": "network_client_rationale_21"
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "confidence_score": 0.8,
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/api.py",
-      "source_location": "L17",
-      "weight": 1.0,
-      "_src": "network_request_httprequest",
-      "_tgt": "network_api_api_init",
-      "source": "network_request_httprequest",
-      "target": "network_api_api_init"
     },
     {
       "relation": "imports_from",
@@ -9573,7 +9648,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "core/network/_client.py",
-      "source_location": "L13",
+      "source_location": "L12",
       "weight": 1.0,
       "_src": "core_network_client_py",
       "_tgt": "network_client_httpclientcontract",
@@ -9585,7 +9660,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "core/network/_client.py",
-      "source_location": "L20",
+      "source_location": "L19",
       "weight": 1.0,
       "_src": "core_network_client_py",
       "_tgt": "network_client_localclient",
@@ -9609,7 +9684,7 @@
       "relation": "inherits",
       "confidence": "EXTRACTED",
       "source_file": "core/network/_client.py",
-      "source_location": "L13",
+      "source_location": "L12",
       "weight": 1.0,
       "_src": "network_client_httpclientcontract",
       "_tgt": "protocol",
@@ -9621,7 +9696,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "core/network/_client.py",
-      "source_location": "L15",
+      "source_location": "L14",
       "weight": 1.0,
       "_src": "network_client_httpclientcontract",
       "_tgt": "network_client_httpclientcontract_execute",
@@ -9633,12 +9708,12 @@
       "relation": "rationale_for",
       "confidence": "EXTRACTED",
       "source_file": "core/network/_client.py",
-      "source_location": "L14",
+      "source_location": "L13",
       "weight": 1.0,
-      "_src": "network_client_rationale_14",
+      "_src": "network_client_rationale_13",
       "_tgt": "network_client_httpclientcontract",
       "source": "network_client_httpclientcontract",
-      "target": "network_client_rationale_14",
+      "target": "network_client_rationale_13",
       "confidence_score": 1.0
     },
     {
@@ -9657,7 +9732,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "core/network/_client.py",
-      "source_location": "L25",
+      "source_location": "L24",
       "weight": 1.0,
       "_src": "network_client_localclient",
       "_tgt": "network_client_localclient_init",
@@ -9669,7 +9744,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "core/network/_client.py",
-      "source_location": "L28",
+      "source_location": "L27",
       "weight": 1.0,
       "_src": "network_client_localclient",
       "_tgt": "network_client_localclient_execute",
@@ -9681,12 +9756,12 @@
       "relation": "rationale_for",
       "confidence": "EXTRACTED",
       "source_file": "core/network/_client.py",
-      "source_location": "L21",
+      "source_location": "L20",
       "weight": 1.0,
-      "_src": "network_client_rationale_21",
+      "_src": "network_client_rationale_20",
       "_tgt": "network_client_localclient",
       "source": "network_client_localclient",
-      "target": "network_client_rationale_21",
+      "target": "network_client_rationale_20",
       "confidence_score": 1.0
     },
     {
@@ -11070,6 +11145,18 @@
       "confidence_score": 1.0
     },
     {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "app/handler.py",
+      "source_location": "L39",
+      "weight": 1.0,
+      "_src": "app_handler_menuhandler",
+      "_tgt": "app_handler_menuhandler_create_url_action",
+      "source": "app_handler_menuhandler",
+      "target": "app_handler_menuhandler_create_url_action",
+      "confidence_score": 1.0
+    },
+    {
       "relation": "calls",
       "confidence": "INFERRED",
       "confidence_score": 0.8,
@@ -11179,6 +11266,18 @@
     },
     {
       "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "app/handler.py",
+      "source_location": "L35",
+      "weight": 1.0,
+      "_src": "app_handler_menuhandler_create_help_menu",
+      "_tgt": "app_handler_menuhandler_create_url_action",
+      "source": "app_handler_menuhandler_create_help_menu",
+      "target": "app_handler_menuhandler_create_url_action",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "app/handler.py",
@@ -11199,6 +11298,18 @@
       "_src": "app_handler_menuhandler_create_help_menu",
       "_tgt": "auth_route_connect",
       "source": "app_handler_menuhandler_create_help_menu",
+      "target": "auth_route_connect"
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "app/handler.py",
+      "source_location": "L41",
+      "weight": 1.0,
+      "_src": "app_handler_menuhandler_create_url_action",
+      "_tgt": "auth_route_connect",
+      "source": "app_handler_menuhandler_create_url_action",
       "target": "auth_route_connect"
     },
     {

--- a/maria_cacau/app/handler.py
+++ b/maria_cacau/app/handler.py
@@ -32,14 +32,11 @@ class MenuHandler:
         help_menu = QMenu(strings.MNU_AJUDA, menubar)
         menubar.addAction(help_menu.menuAction())
 
-        doc_action = QAction(strings.ACT_DOCUMENTACAO, help_menu)
-        doc_action.triggered.connect(
-            lambda: QDesktopServices.openUrl(QUrl(strings.URL_DOCUMENTACAO))
-        )
-        help_menu.addAction(doc_action)
-
-        report_action = QAction(strings.ACT_REPORTAR_PROBLEMA, help_menu)
-        report_action.triggered.connect(
-            lambda: QDesktopServices.openUrl(QUrl(strings.URL_REPORTAR_PROBLEMA))
-        )
-        help_menu.addAction(report_action)
+        self._create_url_action(help_menu, strings.ACT_DOCUMENTACAO, strings.URL_DOCUMENTACAO)
+        self._create_url_action(help_menu, strings.ACT_LANÇAMENTO, strings.URL_LANÇAMENTO)
+        self._create_url_action(help_menu, strings.ACT_REPORTAR_PROBLEMA, strings.URL_REPORTAR_PROBLEMA)
+    
+    def _create_url_action(self, menu: QMenu, title: str, url: str) -> None:
+        action = QAction(title, menu)
+        action.triggered.connect(lambda: QDesktopServices.openUrl(QUrl(url)))
+        menu.addAction(action)

--- a/maria_cacau/assets/strings.py
+++ b/maria_cacau/assets/strings.py
@@ -43,6 +43,8 @@ ACT_DOCUMENTACAO          = "Documentação"
 URL_DOCUMENTACAO          = "https://github.com/Maria-Cacau/.github/wiki"
 ACT_REPORTAR_PROBLEMA     = "Reportar problema"
 URL_REPORTAR_PROBLEMA     = "https://github.com/Maria-Cacau/.github/wiki/troubleshooting"
+ACT_LANÇAMENTO            = "Atualizações"
+URL_LANÇAMENTO            = "https://github.com/Maria-Cacau/Maria-Cacau-App/releases"
 
 # ── Diálogos ──────────────────────────────────────────────────────────────────
 

--- a/maria_cacau/core/network/_client.py
+++ b/maria_cacau/core/network/_client.py
@@ -3,7 +3,6 @@
 from typing import Protocol
 
 from . import _observability as observability
-
 from ._request import HTTPRequest
 from ._response import HTTPResponse
 

--- a/maria_cacau/features/home/source/view.py
+++ b/maria_cacau/features/home/source/view.py
@@ -1,7 +1,7 @@
-from maria_cacau import asset
-
 from PyQt6.QtGui import QPainter, QPixmap
 from PyQt6.QtWidgets import QHBoxLayout, QWidget
+
+from maria_cacau import asset
 
 from .models import HomeFeaturesModel
 


### PR DESCRIPTION
## Overview

Esta branch adiciona o item **"Atualizações"** ao menu de Ajuda da aplicação, permitindo que o usuário acesse diretamente a página de releases no GitHub. A intenção é facilitar que o usuário verifique se está na versão mais recente e leia o changelog sem precisar sair do app para buscar manualmente.

Aproveitando a adição, o `MenuHandler` foi refatorado para centralizar a criação de ações de URL em um método auxiliar (`_create_url_action`), eliminando repetição e tornando a inclusão de novos itens de menu trivial no futuro.

## Ajustes feitos

- Novo item "Atualizações" no menu Ajuda, apontando para a página de releases do repositório
- Strings do novo item centralizadas em `strings.py` seguindo a convenção do projeto
- Refatoração do `MenuHandler` com método auxiliar para criação de ações de URL
- Correção de ordenação de imports (`isort`)