### PR TITLE
Bugfix: Ordenação do resumo das datas

### DIFF
--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,12 +1,12 @@
-# Graph Report - Maria-Cacau-App  (2026-05-21)
+# Graph Report - Maria-Cacau-App  (2026-06-25)
 
 ## Corpus Check
-- 174 files · ~18,932 words
+- 175 files · ~18,333 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 851 nodes · 1390 edges · 30 communities detected
-- Extraction: 76% EXTRACTED · 24% INFERRED · 0% AMBIGUOUS · INFERRED: 337 edges (avg confidence: 0.78)
+- 863 nodes · 1422 edges · 39 communities detected
+- Extraction: 74% EXTRACTED · 26% INFERRED · 0% AMBIGUOUS · INFERRED: 368 edges (avg confidence: 0.77)
 - Token cost: 0 input · 0 output
 
 ## Community Hubs (Navigation)
@@ -32,14 +32,23 @@
 - [[_COMMUNITY_Community 19|Community 19]]
 - [[_COMMUNITY_Community 20|Community 20]]
 - [[_COMMUNITY_Community 21|Community 21]]
-- [[_COMMUNITY_Community 30|Community 30]]
-- [[_COMMUNITY_Community 43|Community 43]]
-- [[_COMMUNITY_Community 44|Community 44]]
+- [[_COMMUNITY_Community 22|Community 22]]
+- [[_COMMUNITY_Community 23|Community 23]]
+- [[_COMMUNITY_Community 32|Community 32]]
+- [[_COMMUNITY_Community 45|Community 45]]
 - [[_COMMUNITY_Community 46|Community 46]]
 - [[_COMMUNITY_Community 48|Community 48]]
-- [[_COMMUNITY_Community 49|Community 49]]
+- [[_COMMUNITY_Community 50|Community 50]]
 - [[_COMMUNITY_Community 51|Community 51]]
-- [[_COMMUNITY_Community 52|Community 52]]
+- [[_COMMUNITY_Community 53|Community 53]]
+- [[_COMMUNITY_Community 54|Community 54]]
+- [[_COMMUNITY_Community 58|Community 58]]
+- [[_COMMUNITY_Community 59|Community 59]]
+- [[_COMMUNITY_Community 60|Community 60]]
+- [[_COMMUNITY_Community 61|Community 61]]
+- [[_COMMUNITY_Community 62|Community 62]]
+- [[_COMMUNITY_Community 63|Community 63]]
+- [[_COMMUNITY_Community 64|Community 64]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `DataSourceError` - 20 edges
@@ -47,8 +56,8 @@
 3. `SheetsController` - 19 edges
 4. `DSChart` - 15 edges
 5. `call()` - 14 edges
-6. `SummaryView` - 14 edges
-7. `from_response()` - 13 edges
+6. `from_response()` - 14 edges
+7. `SummaryView` - 14 edges
 8. `DeliveryView` - 13 edges
 9. `StatusBarController` - 12 edges
 10. `unexpected_error()` - 11 edges
@@ -69,47 +78,47 @@
 
 ### Community 0 - "Community 0"
 Cohesion: 0.03
-Nodes (47): _EventBus, DeliveriesMapper, ErrorMapper, from_response(), OrdersSummaryMapper, PaymentsMapper, Mappers de HTTPResponse para domain models e de HTTPResponseError para ErrorMode, SummaryRepository (+39 more)
+Nodes (59): GoogleSheetsDataSource, Implementação de DataSourceProtocol para Google Sheets via gspread., _fix_prod4(), normalize(), Normaliza headers inconsistentes da planilha para os valores canônicos dos enums, Traduz headers reais da planilha para os nomes canônicos definidos nos enums., _rename_at(), _rename_keys() (+51 more)
 
 ### Community 1 - "Community 1"
 Cohesion: 0.04
-Nodes (48): GoogleSheetsDataSource, Implementação de DataSourceProtocol para Google Sheets via gspread., _fix_prod4(), normalize(), Normaliza headers inconsistentes da planilha para os valores canônicos dos enums, Traduz headers reais da planilha para os nomes canônicos definidos nos enums., _rename_at(), _rename_keys() (+40 more)
+Nodes (37): OrdersSummaryAPI, DeliveriesMapper, ErrorMapper, from_response(), OrdersSummaryMapper, PaymentsMapper, Mappers de HTTPResponse para domain models e de HTTPResponseError para ErrorMode, SummaryRepository (+29 more)
 
 ### Community 2 - "Community 2"
 Cohesion: 0.05
-Nodes (26): API, ConnectAuthAPI, DeliveriesAPI, DisconnectAuthAPI, OrdersSummaryAPI, path(), PaymentsPendentAPI, Endpoints do backend consumidos pela feature Auth. (+18 more)
+Nodes (25): API, ConnectAuthAPI, DeliveriesAPI, DisconnectAuthAPI, path(), PaymentsPendentAPI, Endpoints do backend consumidos pela feature Auth., RemoveSheetAPI (+17 more)
 
 ### Community 3 - "Community 3"
-Cohesion: 0.04
-Nodes (45): ABC, ProductCols, Colunas fixas da aba Cadastro, agrupadas por domínio., Colunas dos slots de produto (1–7). Usar com .slot(n)., SheetCols, SheetTabs, API, entity() (+37 more)
+Cohesion: 0.05
+Nodes (12): MenuHandler, connect(), SheetsUseCase, Erro genérico para exceções não tratadas., unexpected_error(), AuthController, SheetsController, AuthView (+4 more)
 
 ### Community 4 - "Community 4"
 Cohesion: 0.05
-Nodes (16): DSDialog, DSDialogIcon, DSDialogModel, DSComboBox, asset(), Metadados centralizados do pacote maria-cacau., Resolve um path relativo à pasta assets, funciona em dev e no .exe compilado., AuthController (+8 more)
+Nodes (39): ABC, API, entity(), Comunicação alto nivel para chamadas de api, HTTPClientContract, LocalClient, Realiza as request de fato, Contrato que qualquer client precisa cumprir. (+31 more)
 
 ### Community 5 - "Community 5"
 Cohesion: 0.06
-Nodes (12): MenuHandler, connect(), DSTextInput, CpfValidationController, SheetsController, AuthView, CpfValidationView, QDialog (+4 more)
+Nodes (11): DSDialog, DSDialogIcon, DSDialogModel, DSComboBox, DeliveryController, Inicia a consulta: trava a view, dispara o ViewModel e registra o timestamp para, Recebe o resultado do ViewModel, atualiza a view e loga a duração da consulta., SummaryController (+3 more)
 
 ### Community 6 - "Community 6"
 Cohesion: 0.05
-Nodes (35): Retorna pedidos da data informada (DD/MM/YYYY)., DeliveriesSummary, DeliveryTypeCount, Models de domínio da feature de entregas., DeliveriesRepository, Repositório de entregas — busca e prepara dados da planilha para o DeliveriesSer, Retorna todos os pedidos de uma data como DataFrame bruto., Acessa o data source e entrega um DataFrame para o DeliveriesService.      Não f (+27 more)
+Nodes (30): BackendServer, handle_backend_error(), handle_data_source_error(), handle_unexpected_error(), DeliveriesSummary, DeliveryTypeCount, Models de domínio da feature de entregas., DeliveriesRepository (+22 more)
 
 ### Community 7 - "Community 7"
-Cohesion: 0.06
-Nodes (36): Retorna pedidos no intervalo de datas informado (DD/MM/YYYY)., PaymentCols, Colunas das parcelas de pagamento (1–6). Usar com .slot(n)., _customer(), _customization(), _delivery(), _financial(), OrderMapper (+28 more)
+Cohesion: 0.07
+Nodes (16): _EventBus, CpfValidationResult, Models utilizados no módulo, AuthSignals, CpfValidationSignals, DeliverySignals, Canal de comunicação entre o ViewModel e o Controller., SheetsSignals (+8 more)
 
 ### Community 8 - "Community 8"
-Cohesion: 0.06
-Nodes (14): DSButton, DSGroupBox, DSLoadingHandler, DSLoadingHandler, Deve ser chamado no __init__ do componente, após o super().__init__()., Implementar no componente: o que fazer com cada frame do spinner., Mixin que adiciona comportamento de loading animado a qualquer componente QObjec, DSDateInput (+6 more)
+Cohesion: 0.07
+Nodes (12): DSButton, DSGroupBox, DSLoadingHandler, DSLoadingHandler, Deve ser chamado no __init__ do componente, após o super().__init__()., Implementar no componente: o que fazer com cada frame do spinner., Mixin que adiciona comportamento de loading animado a qualquer componente QObjec, DeliveryView (+4 more)
 
 ### Community 9 - "Community 9"
-Cohesion: 0.07
-Nodes (16): SheetsUseCase, AppError, certificado_limpo(), certificado_ok(), planilha_conectada(), planilha_ok(), Códigos de erro da aplicação com estrutura AppError., Confirmação de certificado configurado com sucesso. (+8 more)
+Cohesion: 0.06
+Nodes (15): Rotas de autenticação, AuthService, Service de autenticação — gerencia o estado de conexão do DataSource., DataSourceProtocol, Autentica com o dict da service account e guarda o client em memória., Remove o client autenticado da memória. Mantém o sheet_id., Remove a planilha ativa da memória. Mantém as credenciais., Define a planilha ativa e dispara prewarm em background. (+7 more)
 
 ### Community 10 - "Community 10"
-Cohesion: 0.07
-Nodes (14): Rotas de autenticação, AuthService, Service de autenticação — gerencia o estado de conexão do DataSource., DataSourceProtocol, Autentica com o dict da service account e guarda o client em memória., Remove o client autenticado da memória. Mantém o sheet_id., Remove a planilha ativa da memória. Mantém as credenciais., Define a planilha ativa e dispara prewarm em background. (+6 more)
+Cohesion: 0.12
+Nodes (25): asset(), Metadados centralizados do pacote maria-cacau., Resolve um path relativo à pasta assets, funciona em dev e no .exe compilado., _customer(), _customization(), _delivery(), _financial(), OrderMapper (+17 more)
 
 ### Community 11 - "Community 11"
 Cohesion: 0.1
@@ -124,106 +133,156 @@ Cohesion: 0.13
 Nodes (11): DSButtonState, AppEvent, _Observability, Observabilidade centralizada do app., Services, FeatureEvents, Eventos de observabilidade da feature CPF Validation., Enum (+3 more)
 
 ### Community 14 - "Community 14"
+Cohesion: 0.14
+Nodes (13): Retorna pedidos no intervalo de datas informado (DD/MM/YYYY)., _cast_numeric(), OrdersSummaryRepository, Repositório de pedidos por período — busca e prepara dados da planilha para o Or, Acessa o data source e entrega um DataFrame tipado para o OrdersService.      Ún, Retorna todos os pedidos de um período com colunas numéricas convertidas para fl, _to_dataframe(), OrdersMapper (+5 more)
+
+### Community 15 - "Community 15"
+Cohesion: 0.12
+Nodes (6): DSDateInput, DSTextInput, QDateEdit, QDialog, QLineEdit, SheetCreateView
+
+### Community 16 - "Community 16"
 Cohesion: 0.21
 Nodes (4): DSChartType, DSChart, Widget de gráfico reutilizável (barras ou pizza) usando seaborn + matplotlib., _short_label()
 
-### Community 15 - "Community 15"
-Cohesion: 0.24
-Nodes (7): BackendServer, handle_backend_error(), handle_data_source_error(), handle_unexpected_error(), BackendError, generic_mapper(), translate()
+### Community 17 - "Community 17"
+Cohesion: 0.17
+Nodes (12): AppError, certificado_limpo(), certificado_ok(), planilha_conectada(), planilha_ok(), Códigos de erro da aplicação com estrutura AppError., Confirmação de certificado configurado com sucesso., Confirmação de credenciais removidas com sucesso. (+4 more)
 
-### Community 16 - "Community 16"
+### Community 18 - "Community 18"
+Cohesion: 0.15
+Nodes (11): _cast_numeric(), PaymentsRepository, Repositório de pagamentos — busca e prepara dados da planilha para o PaymentsSer, Acessa o data source e entrega um DataFrame tipado para o PaymentsService., Retorna todos os pedidos de uma data com colunas numéricas convertidas para floa, _to_dataframe(), PaymentsMapper, PaymentsService (+3 more)
+
+### Community 19 - "Community 19"
 Cohesion: 0.31
 Nodes (2): Backend de armazenamento seguro via arquivo protegido no diretório do usuário., SecurityStorage
 
-### Community 17 - "Community 17"
-Cohesion: 0.29
-Nodes (3): AuthUseCase, Lê o arquivo JSON, salva em storage seguro e autentica o backend., Remove credenciais do storage e desautentica o backend.
-
-### Community 18 - "Community 18"
-Cohesion: 0.4
-Nodes (3): normalize_decimal(), Utilitários de formatação numérica., Converte número no formato brasileiro para o formato inglês.      Remove o separ
-
-### Community 19 - "Community 19"
+### Community 20 - "Community 20"
 Cohesion: 0.5
 Nodes (1): AppSession
 
-### Community 20 - "Community 20"
+### Community 21 - "Community 21"
+Cohesion: 0.5
+Nodes (3): normalize_decimal(), Utilitários de formatação numérica., Converte número no formato brasileiro para o formato inglês.      Remove o separ
+
+### Community 22 - "Community 22"
 Cohesion: 1.0
 Nodes (1): r"""Indica se a resposta foi bem sucedida (status code 2xx).
 
-### Community 21 - "Community 21"
+### Community 23 - "Community 23"
 Cohesion: 1.0
 Nodes (1): O tipo precisa aceitar **kwargs (dataclass ou similar).
 
-### Community 30 - "Community 30"
+### Community 32 - "Community 32"
 Cohesion: 1.0
 Nodes (1): Lê o JSON do backend; cai em http_error genérico se o corpo não for JSON válido.
 
-### Community 43 - "Community 43"
+### Community 45 - "Community 45"
 Cohesion: 1.0
 Nodes (1): Renomeia a coluna que segue prod3 para prod4, independente do header atual.
 
-### Community 44 - "Community 44"
+### Community 46 - "Community 46"
 Cohesion: 1.0
 Nodes (1): Busca pedidos por datas usando dois passes para minimizar chamadas à API.
 
-### Community 46 - "Community 46"
+### Community 48 - "Community 48"
 Cohesion: 1.0
 Nodes (1): Monta um Order completo a partir de uma linha do DataFrame.
 
-### Community 48 - "Community 48"
+### Community 50 - "Community 50"
 Cohesion: 1.0
 Nodes (1): Converte list[dict] em DataFrame com cast numérico de todas as colunas de valor.
-
-### Community 49 - "Community 49"
-Cohesion: 1.0
-Nodes (1): Faz cast numérico de uma coluna se ela existir no DataFrame.
 
 ### Community 51 - "Community 51"
 Cohesion: 1.0
+Nodes (1): Faz cast numérico de uma coluna se ela existir no DataFrame.
+
+### Community 53 - "Community 53"
+Cohesion: 1.0
 Nodes (1): Converte list[dict] em DataFrame com cast numérico de todas as colunas de valor.
 
-### Community 52 - "Community 52"
+### Community 54 - "Community 54"
 Cohesion: 1.0
 Nodes (1): Faz cast numérico de uma coluna se ela existir no DataFrame.
 
+### Community 58 - "Community 58"
+Cohesion: 1.0
+Nodes (1): Normaliza uma data para DD/MM/YYYY aceitando os formatos DD/MM/YY e DD/MM/YYYY.
+
+### Community 59 - "Community 59"
+Cohesion: 1.0
+Nodes (1): Converte linhas da planilha em lista de dicts usando o cabeçalho como chaves (lo
+
+### Community 60 - "Community 60"
+Cohesion: 1.0
+Nodes (1): Agrupa números de linha consecutivos em ranges A1 notation e divide em batches d
+
+### Community 61 - "Community 61"
+Cohesion: 1.0
+Nodes (1): Retorna o conjunto de todas as datas (DD/MM/YYYY) entre start e end, inclusive.
+
+### Community 62 - "Community 62"
+Cohesion: 1.0
+Nodes (1): Serializa o resultado do OrdersService para dict JSON-ready.
+
+### Community 63 - "Community 63"
+Cohesion: 1.0
+Nodes (1): Busca e monta os pedidos de um período.
+
+### Community 64 - "Community 64"
+Cohesion: 1.0
+Nodes (1): Retorna todos os pedidos do período informado.
+
 ## Knowledge Gaps
-- **113 isolated node(s):** `Metadados centralizados do pacote maria-cacau.`, `Resolve um path relativo à pasta assets, funciona em dev e no .exe compilado.`, `Entry point da aplicação. Execute com: python -m maria_cacau`, `Observabilidade centralizada do app.`, `Erros mapeados usados no módulo` (+108 more)
+- **116 isolated node(s):** `Metadados centralizados do pacote maria-cacau.`, `Resolve um path relativo à pasta assets, funciona em dev e no .exe compilado.`, `Entry point da aplicação. Execute com: python -m maria_cacau`, `Observabilidade centralizada do app.`, `Erros mapeados usados no módulo` (+111 more)
   These have ≤1 connection - possible missing edges or undocumented components.
-- **Thin community `Community 16`** (9 nodes): `Backend de armazenamento seguro via arquivo protegido no diretório do usuário.`, `SecurityStorage`, `.clean_all()`, `.delete()`, `.__init__()`, `._path()`, `.retrieve()`, `.save()`, `security.py`
+- **Thin community `Community 19`** (9 nodes): `Backend de armazenamento seguro via arquivo protegido no diretório do usuário.`, `SecurityStorage`, `.clean_all()`, `.delete()`, `.__init__()`, `._path()`, `.retrieve()`, `.save()`, `security.py`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 19`** (4 nodes): `AppSession`, `.__init__()`, `__init__.py`, `session.py`
+- **Thin community `Community 20`** (4 nodes): `AppSession`, `.__init__()`, `__init__.py`, `session.py`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 20`** (1 nodes): `r"""Indica se a resposta foi bem sucedida (status code 2xx).`
+- **Thin community `Community 22`** (1 nodes): `r"""Indica se a resposta foi bem sucedida (status code 2xx).`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 21`** (1 nodes): `O tipo precisa aceitar **kwargs (dataclass ou similar).`
+- **Thin community `Community 23`** (1 nodes): `O tipo precisa aceitar **kwargs (dataclass ou similar).`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 30`** (1 nodes): `Lê o JSON do backend; cai em http_error genérico se o corpo não for JSON válido.`
+- **Thin community `Community 32`** (1 nodes): `Lê o JSON do backend; cai em http_error genérico se o corpo não for JSON válido.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 43`** (1 nodes): `Renomeia a coluna que segue prod3 para prod4, independente do header atual.`
+- **Thin community `Community 45`** (1 nodes): `Renomeia a coluna que segue prod3 para prod4, independente do header atual.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 44`** (1 nodes): `Busca pedidos por datas usando dois passes para minimizar chamadas à API.`
+- **Thin community `Community 46`** (1 nodes): `Busca pedidos por datas usando dois passes para minimizar chamadas à API.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 46`** (1 nodes): `Monta um Order completo a partir de uma linha do DataFrame.`
+- **Thin community `Community 48`** (1 nodes): `Monta um Order completo a partir de uma linha do DataFrame.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 48`** (1 nodes): `Converte list[dict] em DataFrame com cast numérico de todas as colunas de valor.`
+- **Thin community `Community 50`** (1 nodes): `Converte list[dict] em DataFrame com cast numérico de todas as colunas de valor.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 49`** (1 nodes): `Faz cast numérico de uma coluna se ela existir no DataFrame.`
+- **Thin community `Community 51`** (1 nodes): `Faz cast numérico de uma coluna se ela existir no DataFrame.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 51`** (1 nodes): `Converte list[dict] em DataFrame com cast numérico de todas as colunas de valor.`
+- **Thin community `Community 53`** (1 nodes): `Converte list[dict] em DataFrame com cast numérico de todas as colunas de valor.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 52`** (1 nodes): `Faz cast numérico de uma coluna se ela existir no DataFrame.`
+- **Thin community `Community 54`** (1 nodes): `Faz cast numérico de uma coluna se ela existir no DataFrame.`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 58`** (1 nodes): `Normaliza uma data para DD/MM/YYYY aceitando os formatos DD/MM/YY e DD/MM/YYYY.`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 59`** (1 nodes): `Converte linhas da planilha em lista de dicts usando o cabeçalho como chaves (lo`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 60`** (1 nodes): `Agrupa números de linha consecutivos em ranges A1 notation e divide em batches d`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 61`** (1 nodes): `Retorna o conjunto de todas as datas (DD/MM/YYYY) entre start e end, inclusive.`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 62`** (1 nodes): `Serializa o resultado do OrdersService para dict JSON-ready.`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 63`** (1 nodes): `Busca e monta os pedidos de um período.`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 64`** (1 nodes): `Retorna todos os pedidos do período informado.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions
 _Questions this graph is uniquely positioned to answer:_
 
-- **Why does `SheetsController` connect `Community 5` to `Community 0`, `Community 2`, `Community 4`, `Community 9`, `Community 10`, `Community 13`?**
-  _High betweenness centrality (0.107) - this node is a cross-community bridge._
-- **Why does `connect()` connect `Community 5` to `Community 4`, `Community 8`, `Community 10`, `Community 11`, `Community 12`?**
+- **Why does `connect()` connect `Community 3` to `Community 5`, `Community 7`, `Community 8`, `Community 9`, `Community 11`, `Community 12`, `Community 15`?**
   _High betweenness centrality (0.101) - this node is a cross-community bridge._
-- **Why does `call()` connect `Community 2` to `Community 3`, `Community 15`?**
-  _High betweenness centrality (0.080) - this node is a cross-community bridge._
+- **Why does `SheetsController` connect `Community 3` to `Community 2`, `Community 5`, `Community 7`, `Community 9`, `Community 13`?**
+  _High betweenness centrality (0.099) - this node is a cross-community bridge._
+- **Why does `from_response()` connect `Community 1` to `Community 10`, `Community 2`, `Community 4`, `Community 6`?**
+  _High betweenness centrality (0.098) - this node is a cross-community bridge._
 - **Are the 19 inferred relationships involving `connect()` (e.g. with `.__init__()` and `._create_features_menu()`) actually correct?**
   _`connect()` has 19 INFERRED edges - model-reasoned connections that need verification._
 - **Are the 4 inferred relationships involving `SheetsController` (e.g. with `FeatureEvents` and `SheetModel`) actually correct?**
@@ -231,4 +290,4 @@ _Questions this graph is uniquely positioned to answer:_
 - **Are the 2 inferred relationships involving `DSChart` (e.g. with `._setup_components()` and `._setup_components()`) actually correct?**
   _`DSChart` has 2 INFERRED edges - model-reasoned connections that need verification._
 - **What connects `Metadados centralizados do pacote maria-cacau.`, `Resolve um path relativo à pasta assets, funciona em dev e no .exe compilado.`, `Entry point da aplicação. Execute com: python -m maria_cacau` to the rest of the system?**
-  _113 weakly-connected nodes found - possible documentation gaps or missing edges._
+  _116 weakly-connected nodes found - possible documentation gaps or missing edges._

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -6,19 +6,19 @@
     {
       "label": "__init__.py",
       "file_type": "code",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/__init__.py",
+      "source_file": "__init__.py",
       "source_location": "L1",
-      "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_init_py",
-      "community": 4,
+      "id": "init_py",
+      "community": 10,
       "norm_label": "__init__.py"
     },
     {
       "label": "asset()",
       "file_type": "code",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/__init__.py",
+      "source_file": "__init__.py",
       "source_location": "L17",
       "id": "maria_cacau_init_asset",
-      "community": 4,
+      "community": 10,
       "norm_label": "asset()"
     },
     {
@@ -26,7 +26,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/__init__.py",
       "source_location": "L1",
-      "community": 4,
+      "community": 10,
       "norm_label": "metadados centralizados do pacote maria-cacau.",
       "id": "maria_cacau_init_rationale_1"
     },
@@ -35,7 +35,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/__init__.py",
       "source_location": "L18",
-      "community": 4,
+      "community": 10,
       "norm_label": "resolve um path relativo a pasta assets, funciona em dev e no .exe compilado.",
       "id": "maria_cacau_init_rationale_18"
     },
@@ -99,7 +99,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/session.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_core_session_py",
-      "community": 19,
+      "community": 20,
       "norm_label": "session.py"
     },
     {
@@ -108,7 +108,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/session.py",
       "source_location": "L1",
       "id": "core_session_appsession",
-      "community": 19,
+      "community": 20,
       "norm_label": "appsession"
     },
     {
@@ -117,7 +117,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/session.py",
       "source_location": "L2",
       "id": "core_session_appsession_init",
-      "community": 19,
+      "community": 20,
       "norm_label": ".__init__()"
     },
     {
@@ -126,7 +126,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_core_init_py",
-      "community": 19,
+      "community": 20,
       "norm_label": "__init__.py"
     },
     {
@@ -171,7 +171,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/observability.py",
       "source_location": "L28",
       "id": "core_observability_observability_log",
-      "community": 4,
+      "community": 5,
       "norm_label": ".log()"
     },
     {
@@ -189,7 +189,7 @@
       "source_file": "core/bus.py",
       "source_location": "L1",
       "id": "core_bus_py",
-      "community": 0,
+      "community": 7,
       "norm_label": "bus.py"
     },
     {
@@ -198,7 +198,7 @@
       "source_file": "core/bus.py",
       "source_location": "L4",
       "id": "core_bus_eventbus",
-      "community": 0,
+      "community": 7,
       "norm_label": "_eventbus"
     },
     {
@@ -207,7 +207,7 @@
       "source_file": "",
       "source_location": "",
       "id": "qobject",
-      "community": 0,
+      "community": 7,
       "norm_label": "qobject"
     },
     {
@@ -216,7 +216,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/_errors.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_core_network_errors_py",
-      "community": 3,
+      "community": 4,
       "norm_label": "_errors.py"
     },
     {
@@ -225,7 +225,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/_errors.py",
       "source_location": "L9",
       "id": "network_errors_networkerror",
-      "community": 3,
+      "community": 4,
       "norm_label": "networkerror"
     },
     {
@@ -243,7 +243,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/_errors.py",
       "source_location": "L14",
       "id": "network_errors_networknotconfigurederror",
-      "community": 3,
+      "community": 4,
       "norm_label": "networknotconfigurederror"
     },
     {
@@ -252,7 +252,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/_errors.py",
       "source_location": "L16",
       "id": "network_errors_networknotconfigurederror_init",
-      "community": 3,
+      "community": 4,
       "norm_label": ".__init__()"
     },
     {
@@ -261,7 +261,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/_errors.py",
       "source_location": "L19",
       "id": "network_errors_httprequesterror",
-      "community": 3,
+      "community": 4,
       "norm_label": "httprequesterror"
     },
     {
@@ -270,7 +270,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/_errors.py",
       "source_location": "L21",
       "id": "network_errors_httprequesterror_init",
-      "community": 3,
+      "community": 4,
       "norm_label": ".__init__()"
     },
     {
@@ -279,7 +279,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/_errors.py",
       "source_location": "L25",
       "id": "network_errors_httpresponseerror",
-      "community": 3,
+      "community": 4,
       "norm_label": "httpresponseerror"
     },
     {
@@ -288,7 +288,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/_errors.py",
       "source_location": "L27",
       "id": "network_errors_httpresponseerror_init",
-      "community": 3,
+      "community": 4,
       "norm_label": ".__init__()"
     },
     {
@@ -297,7 +297,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/_errors.py",
       "source_location": "L34",
       "id": "network_errors_errormessages",
-      "community": 3,
+      "community": 0,
       "norm_label": "errormessages"
     },
     {
@@ -306,7 +306,7 @@
       "source_file": "",
       "source_location": "",
       "id": "strenum",
-      "community": 3,
+      "community": 0,
       "norm_label": "strenum"
     },
     {
@@ -314,7 +314,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/_errors.py",
       "source_location": "L1",
-      "community": 3,
+      "community": 4,
       "norm_label": "erros mapeados usados no modulo",
       "id": "network_errors_rationale_1"
     },
@@ -323,7 +323,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/_errors.py",
       "source_location": "L10",
-      "community": 3,
+      "community": 4,
       "norm_label": "r\"\"\"erro base da camada de network.",
       "id": "network_errors_rationale_10"
     },
@@ -332,7 +332,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/_errors.py",
       "source_location": "L15",
-      "community": 3,
+      "community": 4,
       "norm_label": "configure() nao foi chamado antes de usar a lib.",
       "id": "network_errors_rationale_15"
     },
@@ -341,7 +341,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/_errors.py",
       "source_location": "L20",
-      "community": 3,
+      "community": 4,
       "norm_label": "erro antes de receber resposta (conectividade, timeout, url invalida).",
       "id": "network_errors_rationale_20"
     },
@@ -350,7 +350,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/_errors.py",
       "source_location": "L26",
-      "community": 3,
+      "community": 4,
       "norm_label": "resposta recebida com status de erro (4xx, 5xx).",
       "id": "network_errors_rationale_26"
     },
@@ -360,7 +360,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/_method.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_core_network_method_py",
-      "community": 3,
+      "community": 4,
       "norm_label": "_method.py"
     },
     {
@@ -369,7 +369,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/_method.py",
       "source_location": "L6",
       "id": "network_method_httpmethod",
-      "community": 3,
+      "community": 4,
       "norm_label": "httpmethod"
     },
     {
@@ -377,7 +377,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/_method.py",
       "source_location": "L1",
-      "community": 3,
+      "community": 4,
       "norm_label": "http metodos disponiveis para uso",
       "id": "network_method_rationale_1"
     },
@@ -387,7 +387,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/_response.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_core_network_response_py",
-      "community": 3,
+      "community": 4,
       "norm_label": "_response.py"
     },
     {
@@ -396,7 +396,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/_response.py",
       "source_location": "L6",
       "id": "network_response_httpresponse",
-      "community": 3,
+      "community": 4,
       "norm_label": "httpresponse"
     },
     {
@@ -405,7 +405,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/_response.py",
       "source_location": "L11",
       "id": "network_response_httpresponse_json",
-      "community": 3,
+      "community": 4,
       "norm_label": ".json()"
     },
     {
@@ -414,7 +414,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/_response.py",
       "source_location": "L16",
       "id": "network_response_is_success",
-      "community": 3,
+      "community": 4,
       "norm_label": "is_success()"
     },
     {
@@ -422,7 +422,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/_response.py",
       "source_location": "L12",
-      "community": 3,
+      "community": 4,
       "norm_label": "r\"\"\"decodifica o body para um objeto.",
       "id": "network_response_rationale_12"
     },
@@ -431,7 +431,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/_response.py",
       "source_location": "L17",
-      "community": 20,
+      "community": 22,
       "norm_label": "r\"\"\"indica se a resposta foi bem sucedida (status code 2xx).",
       "id": "network_response_rationale_17"
     },
@@ -441,7 +441,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_core_network_init_py",
-      "community": 3,
+      "community": 4,
       "norm_label": "__init__.py"
     },
     {
@@ -450,7 +450,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/_request.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_core_network_request_py",
-      "community": 3,
+      "community": 4,
       "norm_label": "_request.py"
     },
     {
@@ -459,7 +459,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/_request.py",
       "source_location": "L9",
       "id": "network_request_httprequest",
-      "community": 3,
+      "community": 4,
       "norm_label": "httprequest"
     },
     {
@@ -467,7 +467,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/_request.py",
       "source_location": "L1",
-      "community": 3,
+      "community": 4,
       "norm_label": "dados e parametros de uma request",
       "id": "network_request_rationale_1"
     },
@@ -477,7 +477,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/api.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_core_network_api_py",
-      "community": 3,
+      "community": 4,
       "norm_label": "api.py"
     },
     {
@@ -486,7 +486,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/api.py",
       "source_location": "L14",
       "id": "network_api_api",
-      "community": 3,
+      "community": 4,
       "norm_label": "api"
     },
     {
@@ -495,7 +495,7 @@
       "source_file": "",
       "source_location": "",
       "id": "abc",
-      "community": 3,
+      "community": 4,
       "norm_label": "abc"
     },
     {
@@ -504,7 +504,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/api.py",
       "source_location": "L15",
       "id": "network_api_api_init",
-      "community": 3,
+      "community": 4,
       "norm_label": ".__init__()"
     },
     {
@@ -513,7 +513,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/api.py",
       "source_location": "L21",
       "id": "network_api_path",
-      "community": 3,
+      "community": 4,
       "norm_label": "path()"
     },
     {
@@ -531,7 +531,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/api.py",
       "source_location": "L33",
       "id": "network_api_entity",
-      "community": 3,
+      "community": 4,
       "norm_label": "entity()"
     },
     {
@@ -539,7 +539,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/api.py",
       "source_location": "L1",
-      "community": 3,
+      "community": 4,
       "norm_label": "comunicacao alto nivel para chamadas de api",
       "id": "network_api_rationale_1"
     },
@@ -548,7 +548,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/api.py",
       "source_location": "L34",
-      "community": 21,
+      "community": 23,
       "norm_label": "o tipo precisa aceitar **kwargs (dataclass ou similar).",
       "id": "network_api_rationale_34"
     },
@@ -558,7 +558,7 @@
       "source_file": "core/network/_client.py",
       "source_location": "L1",
       "id": "core_network_client_py",
-      "community": 3,
+      "community": 4,
       "norm_label": "_client.py"
     },
     {
@@ -567,7 +567,7 @@
       "source_file": "core/network/_client.py",
       "source_location": "L12",
       "id": "network_client_httpclientcontract",
-      "community": 3,
+      "community": 4,
       "norm_label": "httpclientcontract"
     },
     {
@@ -576,7 +576,7 @@
       "source_file": "",
       "source_location": "",
       "id": "protocol",
-      "community": 3,
+      "community": 4,
       "norm_label": "protocol"
     },
     {
@@ -585,7 +585,7 @@
       "source_file": "core/network/_client.py",
       "source_location": "L14",
       "id": "network_client_httpclientcontract_execute",
-      "community": 3,
+      "community": 4,
       "norm_label": ".execute()"
     },
     {
@@ -594,7 +594,7 @@
       "source_file": "core/network/_client.py",
       "source_location": "L19",
       "id": "network_client_localclient",
-      "community": 3,
+      "community": 4,
       "norm_label": "localclient"
     },
     {
@@ -603,7 +603,7 @@
       "source_file": "core/network/_client.py",
       "source_location": "L24",
       "id": "network_client_localclient_init",
-      "community": 3,
+      "community": 4,
       "norm_label": ".__init__()"
     },
     {
@@ -612,7 +612,7 @@
       "source_file": "core/network/_client.py",
       "source_location": "L27",
       "id": "network_client_localclient_execute",
-      "community": 13,
+      "community": 4,
       "norm_label": ".execute()"
     },
     {
@@ -620,7 +620,7 @@
       "file_type": "rationale",
       "source_file": "core/network/_client.py",
       "source_location": "L1",
-      "community": 3,
+      "community": 4,
       "norm_label": "realiza as request de fato",
       "id": "network_client_rationale_1"
     },
@@ -629,18 +629,18 @@
       "file_type": "rationale",
       "source_file": "core/network/_client.py",
       "source_location": "L13",
-      "id": "network_client_rationale_13",
-      "community": 3,
-      "norm_label": "contrato que qualquer client precisa cumprir."
+      "community": 4,
+      "norm_label": "contrato que qualquer client precisa cumprir.",
+      "id": "network_client_rationale_13"
     },
     {
       "label": "Roteia requests para o backend local (in-process).     Nenhuma rede envolvida \u2014",
       "file_type": "rationale",
       "source_file": "core/network/_client.py",
       "source_location": "L20",
-      "id": "network_client_rationale_20",
-      "community": 3,
-      "norm_label": "roteia requests para o backend local (in-process).     nenhuma rede envolvida \u2014"
+      "community": 4,
+      "norm_label": "roteia requests para o backend local (in-process).     nenhuma rede envolvida \u2014",
+      "id": "network_client_rationale_20"
     },
     {
       "label": "_observability.py",
@@ -666,7 +666,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/_observability.py",
       "source_location": "L19",
       "id": "network_observability_track",
-      "community": 13,
+      "community": 4,
       "norm_label": "track()"
     },
     {
@@ -684,7 +684,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/_config.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_core_network_config_py",
-      "community": 3,
+      "community": 4,
       "norm_label": "_config.py"
     },
     {
@@ -693,7 +693,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/_config.py",
       "source_location": "L15",
       "id": "network_config_configure",
-      "community": 3,
+      "community": 4,
       "norm_label": "configure()"
     },
     {
@@ -702,7 +702,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/_config.py",
       "source_location": "L20",
       "id": "network_config_override",
-      "community": 3,
+      "community": 4,
       "norm_label": "override()"
     },
     {
@@ -711,7 +711,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/_config.py",
       "source_location": "L25",
       "id": "network_config_clear_override",
-      "community": 3,
+      "community": 4,
       "norm_label": "clear_override()"
     },
     {
@@ -720,7 +720,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/_config.py",
       "source_location": "L30",
       "id": "network_config_get_client",
-      "community": 3,
+      "community": 4,
       "norm_label": "get_client()"
     },
     {
@@ -728,7 +728,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/_config.py",
       "source_location": "L1",
-      "community": 3,
+      "community": 4,
       "norm_label": "configuracoes globais para uso do modulo",
       "id": "network_config_rationale_1"
     },
@@ -737,7 +737,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/_config.py",
       "source_location": "L16",
-      "community": 3,
+      "community": 4,
       "norm_label": "configura o client ativo.",
       "id": "network_config_rationale_16"
     },
@@ -746,7 +746,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/_config.py",
       "source_location": "L21",
-      "community": 3,
+      "community": 4,
       "norm_label": "substitui o client \u2014 util para testes ou wiremock.",
       "id": "network_config_rationale_21"
     },
@@ -755,7 +755,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/_config.py",
       "source_location": "L26",
-      "community": 3,
+      "community": 4,
       "norm_label": "remove o override. volta ao client padrao.",
       "id": "network_config_rationale_26"
     },
@@ -764,7 +764,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/network/_config.py",
       "source_location": "L31",
-      "community": 3,
+      "community": 4,
       "norm_label": "retorna o client ativo (override se existir, padrao caso contrario).",
       "id": "network_config_rationale_31"
     },
@@ -774,7 +774,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/storage/handler.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_core_storage_handler_py",
-      "community": 3,
+      "community": 4,
       "norm_label": "handler.py"
     },
     {
@@ -783,7 +783,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/storage/handler.py",
       "source_location": "L9",
       "id": "storage_handler_storagehandler",
-      "community": 3,
+      "community": 4,
       "norm_label": "storagehandler"
     },
     {
@@ -792,7 +792,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/storage/handler.py",
       "source_location": "L11",
       "id": "storage_handler_save",
-      "community": 3,
+      "community": 4,
       "norm_label": "save()"
     },
     {
@@ -801,7 +801,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/storage/handler.py",
       "source_location": "L14",
       "id": "storage_handler_retrieve",
-      "community": 3,
+      "community": 4,
       "norm_label": "retrieve()"
     },
     {
@@ -810,7 +810,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/storage/handler.py",
       "source_location": "L17",
       "id": "storage_handler_delete",
-      "community": 3,
+      "community": 4,
       "norm_label": "delete()"
     },
     {
@@ -819,7 +819,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/storage/handler.py",
       "source_location": "L20",
       "id": "storage_handler_clean_all",
-      "community": 3,
+      "community": 4,
       "norm_label": "clean_all()"
     },
     {
@@ -827,7 +827,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/storage/handler.py",
       "source_location": "L1",
-      "community": 3,
+      "community": 4,
       "norm_label": "contrato base para todos os backends de armazenamento.",
       "id": "storage_handler_rationale_1"
     },
@@ -837,7 +837,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/storage/security.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_core_storage_security_py",
-      "community": 16,
+      "community": 19,
       "norm_label": "security.py"
     },
     {
@@ -846,7 +846,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/storage/security.py",
       "source_location": "L10",
       "id": "storage_security_securitystorage",
-      "community": 16,
+      "community": 19,
       "norm_label": "securitystorage"
     },
     {
@@ -855,7 +855,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/storage/security.py",
       "source_location": "L11",
       "id": "storage_security_securitystorage_init",
-      "community": 16,
+      "community": 19,
       "norm_label": ".__init__()"
     },
     {
@@ -864,7 +864,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/storage/security.py",
       "source_location": "L15",
       "id": "storage_security_securitystorage_save",
-      "community": 16,
+      "community": 19,
       "norm_label": ".save()"
     },
     {
@@ -873,7 +873,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/storage/security.py",
       "source_location": "L23",
       "id": "storage_security_securitystorage_retrieve",
-      "community": 16,
+      "community": 19,
       "norm_label": ".retrieve()"
     },
     {
@@ -882,7 +882,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/storage/security.py",
       "source_location": "L29",
       "id": "storage_security_securitystorage_delete",
-      "community": 16,
+      "community": 19,
       "norm_label": ".delete()"
     },
     {
@@ -891,7 +891,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/storage/security.py",
       "source_location": "L36",
       "id": "storage_security_securitystorage_clean_all",
-      "community": 16,
+      "community": 19,
       "norm_label": ".clean_all()"
     },
     {
@@ -900,7 +900,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/storage/security.py",
       "source_location": "L40",
       "id": "storage_security_securitystorage_path",
-      "community": 16,
+      "community": 19,
       "norm_label": "._path()"
     },
     {
@@ -908,7 +908,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/storage/security.py",
       "source_location": "L1",
-      "community": 16,
+      "community": 19,
       "norm_label": "backend de armazenamento seguro via arquivo protegido no diretorio do usuario.",
       "id": "storage_security_rationale_1"
     },
@@ -999,7 +999,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/storage/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_core_storage_init_py",
-      "community": 22,
+      "community": 24,
       "norm_label": "__init__.py"
     },
     {
@@ -1008,7 +1008,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/error/models.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_core_error_models_py",
-      "community": 9,
+      "community": 17,
       "norm_label": "models.py"
     },
     {
@@ -1035,7 +1035,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/error/models.py",
       "source_location": "L16",
       "id": "error_models_from_error",
-      "community": 9,
+      "community": 17,
       "norm_label": "from_error()"
     },
     {
@@ -1044,7 +1044,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/error/models.py",
       "source_location": "L23",
       "id": "error_models_errormodel_to_popup",
-      "community": 4,
+      "community": 5,
       "norm_label": ".to_popup()"
     },
     {
@@ -1053,7 +1053,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/error/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_core_error_init_py",
-      "community": 9,
+      "community": 17,
       "norm_label": "__init__.py"
     },
     {
@@ -1062,7 +1062,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/error/errors.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_core_error_errors_py",
-      "community": 9,
+      "community": 17,
       "norm_label": "errors.py"
     },
     {
@@ -1071,7 +1071,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/error/errors.py",
       "source_location": "L8",
       "id": "error_errors_apperror",
-      "community": 9,
+      "community": 17,
       "norm_label": "apperror"
     },
     {
@@ -1080,7 +1080,7 @@
       "source_file": "",
       "source_location": "",
       "id": "namedtuple",
-      "community": 9,
+      "community": 17,
       "norm_label": "namedtuple"
     },
     {
@@ -1089,7 +1089,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/error/errors.py",
       "source_location": "L104",
       "id": "error_errors_certificado_ok",
-      "community": 9,
+      "community": 17,
       "norm_label": "certificado_ok()"
     },
     {
@@ -1098,7 +1098,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/error/errors.py",
       "source_location": "L113",
       "id": "error_errors_certificado_limpo",
-      "community": 9,
+      "community": 17,
       "norm_label": "certificado_limpo()"
     },
     {
@@ -1107,7 +1107,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/error/errors.py",
       "source_location": "L122",
       "id": "error_errors_planilha_conectada",
-      "community": 9,
+      "community": 17,
       "norm_label": "planilha_conectada()"
     },
     {
@@ -1116,7 +1116,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/error/errors.py",
       "source_location": "L131",
       "id": "error_errors_unexpected_error",
-      "community": 9,
+      "community": 3,
       "norm_label": "unexpected_error()"
     },
     {
@@ -1125,7 +1125,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/error/errors.py",
       "source_location": "L140",
       "id": "error_errors_http_error",
-      "community": 0,
+      "community": 1,
       "norm_label": "http_error()"
     },
     {
@@ -1134,7 +1134,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/error/errors.py",
       "source_location": "L149",
       "id": "error_errors_planilha_ok",
-      "community": 9,
+      "community": 17,
       "norm_label": "planilha_ok()"
     },
     {
@@ -1142,7 +1142,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/error/errors.py",
       "source_location": "L1",
-      "community": 9,
+      "community": 17,
       "norm_label": "codigos de erro da aplicacao com estrutura apperror.",
       "id": "error_errors_rationale_1"
     },
@@ -1151,7 +1151,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/error/errors.py",
       "source_location": "L9",
-      "community": 9,
+      "community": 17,
       "norm_label": "estrutura de uma mensagem de erro/info para exibicao no popup.",
       "id": "error_errors_rationale_9"
     },
@@ -1160,7 +1160,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/error/errors.py",
       "source_location": "L105",
-      "community": 9,
+      "community": 17,
       "norm_label": "confirmacao de certificado configurado com sucesso.",
       "id": "error_errors_rationale_105"
     },
@@ -1169,7 +1169,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/error/errors.py",
       "source_location": "L114",
-      "community": 9,
+      "community": 17,
       "norm_label": "confirmacao de credenciais removidas com sucesso.",
       "id": "error_errors_rationale_114"
     },
@@ -1178,7 +1178,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/error/errors.py",
       "source_location": "L123",
-      "community": 9,
+      "community": 17,
       "norm_label": "confirmacao de planilha selecionada com sucesso.",
       "id": "error_errors_rationale_123"
     },
@@ -1187,7 +1187,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/error/errors.py",
       "source_location": "L132",
-      "community": 9,
+      "community": 3,
       "norm_label": "erro generico para excecoes nao tratadas.",
       "id": "error_errors_rationale_132"
     },
@@ -1196,7 +1196,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/error/errors.py",
       "source_location": "L141",
-      "community": 0,
+      "community": 1,
       "norm_label": "erro http sem body json \u2014 resposta de erro nao estruturada do servidor.",
       "id": "error_errors_rationale_141"
     },
@@ -1205,7 +1205,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/core/error/errors.py",
       "source_location": "L150",
-      "community": 9,
+      "community": 17,
       "norm_label": "confirmacao de leitura bem-sucedida da planilha.",
       "id": "error_errors_rationale_150"
     },
@@ -1287,7 +1287,7 @@
       "source_file": "app/handler.py",
       "source_location": "L1",
       "id": "app_handler_py",
-      "community": 5,
+      "community": 3,
       "norm_label": "handler.py"
     },
     {
@@ -1296,7 +1296,7 @@
       "source_file": "app/handler.py",
       "source_location": "L10",
       "id": "app_handler_menuhandler",
-      "community": 5,
+      "community": 3,
       "norm_label": "menuhandler"
     },
     {
@@ -1305,7 +1305,7 @@
       "source_file": "app/handler.py",
       "source_location": "L11",
       "id": "app_handler_menuhandler_init",
-      "community": 5,
+      "community": 3,
       "norm_label": ".__init__()"
     },
     {
@@ -1314,7 +1314,7 @@
       "source_file": "app/handler.py",
       "source_location": "L16",
       "id": "app_handler_menuhandler_setup_menus",
-      "community": 5,
+      "community": 3,
       "norm_label": ".setup_menus()"
     },
     {
@@ -1323,7 +1323,7 @@
       "source_file": "app/handler.py",
       "source_location": "L22",
       "id": "app_handler_menuhandler_create_features_menu",
-      "community": 5,
+      "community": 3,
       "norm_label": "._create_features_menu()"
     },
     {
@@ -1332,7 +1332,7 @@
       "source_file": "app/handler.py",
       "source_location": "L31",
       "id": "app_handler_menuhandler_create_help_menu",
-      "community": 5,
+      "community": 3,
       "norm_label": "._create_help_menu()"
     },
     {
@@ -1341,7 +1341,7 @@
       "source_file": "app/handler.py",
       "source_location": "L39",
       "id": "app_handler_menuhandler_create_url_action",
-      "community": 5,
+      "community": 3,
       "norm_label": "._create_url_action()"
     },
     {
@@ -1413,7 +1413,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/constants.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_design_system_constants_py",
-      "community": 23,
+      "community": 25,
       "norm_label": "constants.py"
     },
     {
@@ -1422,7 +1422,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_design_system_init_py",
-      "community": 24,
+      "community": 26,
       "norm_label": "__init__.py"
     },
     {
@@ -1431,7 +1431,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_design_system_components_init_py",
-      "community": 25,
+      "community": 27,
       "norm_label": "__init__.py"
     },
     {
@@ -1539,7 +1539,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/chart/chart_type.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_design_system_components_chart_chart_type_py",
-      "community": 14,
+      "community": 16,
       "norm_label": "chart_type.py"
     },
     {
@@ -1548,7 +1548,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/chart/chart_type.py",
       "source_location": "L4",
       "id": "chart_chart_type_dscharttype",
-      "community": 14,
+      "community": 16,
       "norm_label": "dscharttype"
     },
     {
@@ -1557,7 +1557,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/chart/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_design_system_components_chart_init_py",
-      "community": 14,
+      "community": 16,
       "norm_label": "__init__.py"
     },
     {
@@ -1566,7 +1566,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/chart/chart_widget.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_design_system_components_chart_chart_widget_py",
-      "community": 14,
+      "community": 16,
       "norm_label": "chart_widget.py"
     },
     {
@@ -1575,7 +1575,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/chart/chart_widget.py",
       "source_location": "L18",
       "id": "chart_chart_widget_short_label",
-      "community": 14,
+      "community": 16,
       "norm_label": "_short_label()"
     },
     {
@@ -1584,7 +1584,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/chart/chart_widget.py",
       "source_location": "L26",
       "id": "chart_chart_widget_dschart",
-      "community": 14,
+      "community": 16,
       "norm_label": "dschart"
     },
     {
@@ -1602,7 +1602,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/chart/chart_widget.py",
       "source_location": "L27",
       "id": "chart_chart_widget_dschart_init",
-      "community": 14,
+      "community": 16,
       "norm_label": ".__init__()"
     },
     {
@@ -1611,7 +1611,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/chart/chart_widget.py",
       "source_location": "L64",
       "id": "chart_chart_widget_dschart_update_data",
-      "community": 14,
+      "community": 16,
       "norm_label": ".update_data()"
     },
     {
@@ -1620,7 +1620,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/chart/chart_widget.py",
       "source_location": "L69",
       "id": "chart_chart_widget_dschart_clear",
-      "community": 14,
+      "community": 16,
       "norm_label": ".clear()"
     },
     {
@@ -1629,7 +1629,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/chart/chart_widget.py",
       "source_location": "L76",
       "id": "chart_chart_widget_dschart_set_type",
-      "community": 14,
+      "community": 16,
       "norm_label": ".set_type()"
     },
     {
@@ -1638,7 +1638,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/chart/chart_widget.py",
       "source_location": "L81",
       "id": "chart_chart_widget_dschart_copy_to_clipboard",
-      "community": 14,
+      "community": 16,
       "norm_label": ".copy_to_clipboard()"
     },
     {
@@ -1647,7 +1647,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/chart/chart_widget.py",
       "source_location": "L91",
       "id": "chart_chart_widget_dschart_save_to_file",
-      "community": 14,
+      "community": 16,
       "norm_label": ".save_to_file()"
     },
     {
@@ -1656,7 +1656,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/chart/chart_widget.py",
       "source_location": "L101",
       "id": "chart_chart_widget_dschart_canvas_dims",
-      "community": 14,
+      "community": 16,
       "norm_label": "._canvas_dims()"
     },
     {
@@ -1665,7 +1665,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/chart/chart_widget.py",
       "source_location": "L109",
       "id": "chart_chart_widget_dschart_render",
-      "community": 14,
+      "community": 16,
       "norm_label": "._render()"
     },
     {
@@ -1674,7 +1674,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/chart/chart_widget.py",
       "source_location": "L115",
       "id": "chart_chart_widget_dschart_render_bar",
-      "community": 14,
+      "community": 16,
       "norm_label": "._render_bar()"
     },
     {
@@ -1683,7 +1683,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/chart/chart_widget.py",
       "source_location": "L153",
       "id": "chart_chart_widget_dschart_render_pie",
-      "community": 14,
+      "community": 16,
       "norm_label": "._render_pie()"
     },
     {
@@ -1692,7 +1692,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/chart/chart_widget.py",
       "source_location": "L196",
       "id": "chart_chart_widget_dschart_empty",
-      "community": 14,
+      "community": 16,
       "norm_label": "._empty()"
     },
     {
@@ -1700,7 +1700,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/chart/chart_widget.py",
       "source_location": "L1",
-      "community": 14,
+      "community": 16,
       "norm_label": "widget de grafico reutilizavel (barras ou pizza) usando seaborn + matplotlib.",
       "id": "chart_chart_widget_rationale_1"
     },
@@ -1755,7 +1755,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/alerts/dialog.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_design_system_components_alerts_dialog_py",
-      "community": 4,
+      "community": 5,
       "norm_label": "dialog.py"
     },
     {
@@ -1764,7 +1764,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/alerts/dialog.py",
       "source_location": "L11",
       "id": "alerts_dialog_dsdialogicon",
-      "community": 4,
+      "community": 5,
       "norm_label": "dsdialogicon"
     },
     {
@@ -1773,7 +1773,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/alerts/dialog.py",
       "source_location": "L18",
       "id": "alerts_dialog_dsdialogmodel",
-      "community": 4,
+      "community": 5,
       "norm_label": "dsdialogmodel"
     },
     {
@@ -1782,7 +1782,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/alerts/dialog.py",
       "source_location": "L25",
       "id": "alerts_dialog_dsdialog",
-      "community": 4,
+      "community": 5,
       "norm_label": "dsdialog"
     },
     {
@@ -1791,7 +1791,7 @@
       "source_file": "",
       "source_location": "",
       "id": "qmessagebox",
-      "community": 4,
+      "community": 5,
       "norm_label": "qmessagebox"
     },
     {
@@ -1800,7 +1800,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/alerts/dialog.py",
       "source_location": "L27",
       "id": "alerts_dialog_dsdialog_init",
-      "community": 4,
+      "community": 5,
       "norm_label": ".__init__()"
     },
     {
@@ -1809,7 +1809,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/alerts/dialog.py",
       "source_location": "L31",
       "id": "alerts_dialog_dsdialog_setup_ui",
-      "community": 4,
+      "community": 5,
       "norm_label": "._setup_ui()"
     },
     {
@@ -1818,7 +1818,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/alerts/dialog.py",
       "source_location": "L42",
       "id": "alerts_dialog_dsdialog_show",
-      "community": 4,
+      "community": 5,
       "norm_label": ".show()"
     },
     {
@@ -1827,7 +1827,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/alerts/dialog.py",
       "source_location": "L50",
       "id": "alerts_dialog_dsdialog_apply_min_width",
-      "community": 4,
+      "community": 5,
       "norm_label": "._apply_min_width()"
     },
     {
@@ -1836,7 +1836,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/alerts/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_design_system_components_alerts_init_py",
-      "community": 4,
+      "community": 5,
       "norm_label": "__init__.py"
     },
     {
@@ -1845,7 +1845,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/combo_box/combo_box.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_design_system_components_combo_box_combo_box_py",
-      "community": 4,
+      "community": 5,
       "norm_label": "combo_box.py"
     },
     {
@@ -1854,7 +1854,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/combo_box/combo_box.py",
       "source_location": "L5",
       "id": "combo_box_combo_box_dscombobox",
-      "community": 4,
+      "community": 5,
       "norm_label": "dscombobox"
     },
     {
@@ -1863,7 +1863,7 @@
       "source_file": "",
       "source_location": "",
       "id": "qcombobox",
-      "community": 4,
+      "community": 5,
       "norm_label": "qcombobox"
     },
     {
@@ -1872,7 +1872,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/combo_box/combo_box.py",
       "source_location": "L7",
       "id": "combo_box_combo_box_dscombobox_init",
-      "community": 4,
+      "community": 5,
       "norm_label": ".__init__()"
     },
     {
@@ -1881,7 +1881,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/combo_box/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_design_system_components_combo_box_init_py",
-      "community": 4,
+      "community": 5,
       "norm_label": "__init__.py"
     },
     {
@@ -1989,7 +1989,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/inputs/text_input.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_design_system_components_inputs_text_input_py",
-      "community": 8,
+      "community": 15,
       "norm_label": "text_input.py"
     },
     {
@@ -1998,7 +1998,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/inputs/text_input.py",
       "source_location": "L5",
       "id": "inputs_text_input_dstextinput",
-      "community": 5,
+      "community": 15,
       "norm_label": "dstextinput"
     },
     {
@@ -2007,7 +2007,7 @@
       "source_file": "",
       "source_location": "",
       "id": "qlineedit",
-      "community": 5,
+      "community": 15,
       "norm_label": "qlineedit"
     },
     {
@@ -2016,7 +2016,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/inputs/text_input.py",
       "source_location": "L7",
       "id": "inputs_text_input_dstextinput_init",
-      "community": 5,
+      "community": 15,
       "norm_label": ".__init__()"
     },
     {
@@ -2025,7 +2025,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/inputs/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_design_system_components_inputs_init_py",
-      "community": 8,
+      "community": 15,
       "norm_label": "__init__.py"
     },
     {
@@ -2034,7 +2034,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/inputs/date_input.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_design_system_components_inputs_date_input_py",
-      "community": 8,
+      "community": 15,
       "norm_label": "date_input.py"
     },
     {
@@ -2043,7 +2043,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/inputs/date_input.py",
       "source_location": "L5",
       "id": "inputs_date_input_dsdateinput",
-      "community": 8,
+      "community": 15,
       "norm_label": "dsdateinput"
     },
     {
@@ -2052,7 +2052,7 @@
       "source_file": "",
       "source_location": "",
       "id": "qdateedit",
-      "community": 8,
+      "community": 15,
       "norm_label": "qdateedit"
     },
     {
@@ -2061,7 +2061,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/inputs/date_input.py",
       "source_location": "L7",
       "id": "inputs_date_input_dsdateinput_init",
-      "community": 8,
+      "community": 15,
       "norm_label": ".__init__()"
     },
     {
@@ -2178,7 +2178,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_init_py",
-      "community": 26,
+      "community": 28,
       "norm_label": "__init__.py"
     },
     {
@@ -2241,7 +2241,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/source/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_source_init_py",
-      "community": 27,
+      "community": 29,
       "norm_label": "__init__.py"
     },
     {
@@ -2295,7 +2295,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_sub_features_init_py",
-      "community": 28,
+      "community": 30,
       "norm_label": "__init__.py"
     },
     {
@@ -2304,7 +2304,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_sub_features_delivery_init_py",
-      "community": 29,
+      "community": 31,
       "norm_label": "__init__.py"
     },
     {
@@ -2313,7 +2313,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/data/mapper.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_sub_features_delivery_data_mapper_py",
-      "community": 0,
+      "community": 1,
       "norm_label": "mapper.py"
     },
     {
@@ -2322,7 +2322,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/data/mapper.py",
       "source_location": "L9",
       "id": "data_mapper_errormapper",
-      "community": 0,
+      "community": 1,
       "norm_label": "errormapper"
     },
     {
@@ -2331,7 +2331,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/data/mapper.py",
       "source_location": "L11",
       "id": "data_mapper_from_response",
-      "community": 0,
+      "community": 1,
       "norm_label": "from_response()"
     },
     {
@@ -2340,7 +2340,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/data/mapper.py",
       "source_location": "L24",
       "id": "data_mapper_deliveriesmapper",
-      "community": 0,
+      "community": 1,
       "norm_label": "deliveriesmapper"
     },
     {
@@ -2349,7 +2349,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/data/mapper.py",
       "source_location": "L36",
       "id": "data_mapper_paymentsmapper",
-      "community": 0,
+      "community": 1,
       "norm_label": "paymentsmapper"
     },
     {
@@ -2357,7 +2357,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/data/mapper.py",
       "source_location": "L1",
-      "community": 0,
+      "community": 1,
       "norm_label": "mappers de httpresponse para domain models e de httpresponseerror para errormode",
       "id": "data_mapper_rationale_1"
     },
@@ -2366,7 +2366,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/data/mapper.py",
       "source_location": "L12",
-      "community": 30,
+      "community": 32,
       "norm_label": "le o json do backend; cai em http_error generico se o corpo nao for json valido.",
       "id": "data_mapper_rationale_12"
     },
@@ -2502,7 +2502,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/domain/use_case.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_sub_features_delivery_domain_use_case_py",
-      "community": 0,
+      "community": 1,
       "norm_label": "use_case.py"
     },
     {
@@ -2511,7 +2511,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/domain/use_case.py",
       "source_location": "L9",
       "id": "domain_use_case_deliveryusecase",
-      "community": 0,
+      "community": 1,
       "norm_label": "deliveryusecase"
     },
     {
@@ -2520,7 +2520,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/domain/use_case.py",
       "source_location": "L10",
       "id": "domain_use_case_deliveryusecase_init",
-      "community": 0,
+      "community": 2,
       "norm_label": ".__init__()"
     },
     {
@@ -2529,7 +2529,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/domain/use_case.py",
       "source_location": "L13",
       "id": "domain_use_case_deliveryusecase_get_orders",
-      "community": 0,
+      "community": 1,
       "norm_label": ".get_orders()"
     },
     {
@@ -2537,7 +2537,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/domain/use_case.py",
       "source_location": "L1",
-      "community": 0,
+      "community": 1,
       "norm_label": "regra de negocios: validacao matematica de cpf.",
       "id": "domain_use_case_rationale_1"
     },
@@ -2546,7 +2546,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/domain/use_case.py",
       "source_location": "L14",
-      "community": 0,
+      "community": 1,
       "norm_label": "busca deliveries e payments em paralelo e retorna o modelo consolidado.",
       "id": "domain_use_case_rationale_14"
     },
@@ -2556,7 +2556,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/domain/signals.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_sub_features_delivery_domain_signals_py",
-      "community": 0,
+      "community": 7,
       "norm_label": "signals.py"
     },
     {
@@ -2565,7 +2565,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/domain/signals.py",
       "source_location": "L8",
       "id": "domain_signals_deliverysignals",
-      "community": 0,
+      "community": 7,
       "norm_label": "deliverysignals"
     },
     {
@@ -2573,7 +2573,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/domain/signals.py",
       "source_location": "L1",
-      "community": 0,
+      "community": 7,
       "norm_label": "canal de comunicacao entre o viewmodel e o controller.",
       "id": "domain_signals_rationale_1"
     },
@@ -2583,7 +2583,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/domain/models.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_sub_features_delivery_domain_models_py",
-      "community": 0,
+      "community": 1,
       "norm_label": "models.py"
     },
     {
@@ -2592,7 +2592,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/domain/models.py",
       "source_location": "L7",
       "id": "domain_models_deliverycount",
-      "community": 0,
+      "community": 1,
       "norm_label": "deliverycount"
     },
     {
@@ -2601,7 +2601,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/domain/models.py",
       "source_location": "L13",
       "id": "domain_models_deliveriessummary",
-      "community": 0,
+      "community": 1,
       "norm_label": "deliveriessummary"
     },
     {
@@ -2610,7 +2610,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/domain/models.py",
       "source_location": "L20",
       "id": "domain_models_pendentorder",
-      "community": 0,
+      "community": 1,
       "norm_label": "pendentorder"
     },
     {
@@ -2619,7 +2619,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/domain/models.py",
       "source_location": "L29",
       "id": "domain_models_deliverymodel",
-      "community": 0,
+      "community": 1,
       "norm_label": "deliverymodel"
     },
     {
@@ -2628,7 +2628,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/domain/models.py",
       "source_location": "L35",
       "id": "domain_models_deliveryviewdata",
-      "community": 0,
+      "community": 1,
       "norm_label": "deliveryviewdata"
     },
     {
@@ -2636,7 +2636,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/domain/models.py",
       "source_location": "L1",
-      "community": 0,
+      "community": 7,
       "norm_label": "models utilizados no modulo",
       "id": "domain_models_rationale_1"
     },
@@ -2673,7 +2673,7 @@
       "source_file": "features/home/sub_features/delivery/domain/__init__.py",
       "source_location": "L1",
       "id": "features_home_sub_features_delivery_domain_init_py",
-      "community": 31,
+      "community": 33,
       "norm_label": "__init__.py"
     },
     {
@@ -2682,7 +2682,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/presentation/controller.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_sub_features_delivery_presentation_controller_py",
-      "community": 0,
+      "community": 1,
       "norm_label": "controller.py"
     },
     {
@@ -2691,7 +2691,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/presentation/controller.py",
       "source_location": "L15",
       "id": "presentation_controller_deliverycontroller",
-      "community": 4,
+      "community": 5,
       "norm_label": "deliverycontroller"
     },
     {
@@ -2700,7 +2700,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/presentation/controller.py",
       "source_location": "L16",
       "id": "presentation_controller_deliverycontroller_init",
-      "community": 4,
+      "community": 5,
       "norm_label": ".__init__()"
     },
     {
@@ -2709,7 +2709,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/presentation/controller.py",
       "source_location": "L22",
       "id": "presentation_controller_deliverycontroller_setupactions",
-      "community": 4,
+      "community": 5,
       "norm_label": "._setupactions()"
     },
     {
@@ -2718,7 +2718,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/presentation/controller.py",
       "source_location": "L33",
       "id": "presentation_controller_deliverycontroller_on_generate_report",
-      "community": 4,
+      "community": 5,
       "norm_label": ".on_generate_report()"
     },
     {
@@ -2727,7 +2727,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/presentation/controller.py",
       "source_location": "L42",
       "id": "presentation_controller_deliverycontroller_on_copy_report",
-      "community": 4,
+      "community": 5,
       "norm_label": ".on_copy_report()"
     },
     {
@@ -2736,7 +2736,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/presentation/controller.py",
       "source_location": "L45",
       "id": "presentation_controller_deliverycontroller_on_copy_graph",
-      "community": 4,
+      "community": 5,
       "norm_label": ".on_copy_graph()"
     },
     {
@@ -2745,7 +2745,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/presentation/controller.py",
       "source_location": "L48",
       "id": "presentation_controller_deliverycontroller_on_download_graph",
-      "community": 4,
+      "community": 5,
       "norm_label": ".on_download_graph()"
     },
     {
@@ -2754,7 +2754,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/presentation/controller.py",
       "source_location": "L53",
       "id": "presentation_controller_deliverycontroller_handle_error",
-      "community": 4,
+      "community": 5,
       "norm_label": ".handle_error()"
     },
     {
@@ -2763,7 +2763,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/presentation/controller.py",
       "source_location": "L57",
       "id": "presentation_controller_deliverycontroller_handle_report_generated",
-      "community": 4,
+      "community": 5,
       "norm_label": ".handle_report_generated()"
     },
     {
@@ -2771,7 +2771,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/presentation/controller.py",
       "source_location": "L1",
-      "community": 0,
+      "community": 1,
       "norm_label": "controller da feature cpf validation: conecta signals da view ao viewmodel e tra",
       "id": "presentation_controller_rationale_1"
     },
@@ -2780,7 +2780,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/presentation/controller.py",
       "source_location": "L34",
-      "community": 4,
+      "community": 5,
       "norm_label": "inicia a consulta: trava a view, dispara o viewmodel e registra o timestamp para",
       "id": "presentation_controller_rationale_34"
     },
@@ -2789,7 +2789,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/presentation/controller.py",
       "source_location": "L58",
-      "community": 4,
+      "community": 5,
       "norm_label": "recebe o resultado do viewmodel, atualiza a view e loga a duracao da consulta.",
       "id": "presentation_controller_rationale_58"
     },
@@ -2799,7 +2799,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/presentation/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_sub_features_delivery_presentation_init_py",
-      "community": 0,
+      "community": 1,
       "norm_label": "__init__.py"
     },
     {
@@ -2808,7 +2808,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/presentation/viewmodel.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_sub_features_delivery_presentation_viewmodel_py",
-      "community": 0,
+      "community": 1,
       "norm_label": "viewmodel.py"
     },
     {
@@ -2817,7 +2817,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/presentation/viewmodel.py",
       "source_location": "L12",
       "id": "presentation_viewmodel_deliveryviewmodel",
-      "community": 0,
+      "community": 1,
       "norm_label": "deliveryviewmodel"
     },
     {
@@ -2826,7 +2826,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/presentation/viewmodel.py",
       "source_location": "L13",
       "id": "presentation_viewmodel_deliveryviewmodel_init",
-      "community": 0,
+      "community": 1,
       "norm_label": ".__init__()"
     },
     {
@@ -2835,7 +2835,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/presentation/viewmodel.py",
       "source_location": "L17",
       "id": "presentation_viewmodel_deliveryviewmodel_on_generate",
-      "community": 0,
+      "community": 1,
       "norm_label": ".on_generate()"
     },
     {
@@ -2844,7 +2844,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/presentation/viewmodel.py",
       "source_location": "L20",
       "id": "presentation_viewmodel_deliveryviewmodel_fetch",
-      "community": 0,
+      "community": 1,
       "norm_label": "._fetch()"
     },
     {
@@ -2853,7 +2853,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/presentation/viewmodel.py",
       "source_location": "L31",
       "id": "presentation_viewmodel_deliveryviewmodel_build_view_data",
-      "community": 0,
+      "community": 1,
       "norm_label": "._build_view_data()"
     },
     {
@@ -2862,7 +2862,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/presentation/viewmodel.py",
       "source_location": "L37",
       "id": "presentation_viewmodel_deliveryviewmodel_build_report",
-      "community": 0,
+      "community": 1,
       "norm_label": "._build_report()"
     },
     {
@@ -2870,7 +2870,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/presentation/viewmodel.py",
       "source_location": "L1",
-      "community": 0,
+      "community": 1,
       "norm_label": "viewmodel da feature cpf validation: executa o usecase e emite resultado via sig",
       "id": "presentation_viewmodel_rationale_1"
     },
@@ -2879,7 +2879,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/presentation/viewmodel.py",
       "source_location": "L21",
-      "community": 0,
+      "community": 1,
       "norm_label": "roda o usecase, monta o viewdata e emite sucesso ou erro \u2014 sempre via signal par",
       "id": "presentation_viewmodel_rationale_21"
     },
@@ -2889,7 +2889,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/presentation/view.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_sub_features_delivery_presentation_view_py",
-      "community": 0,
+      "community": 1,
       "norm_label": "view.py"
     },
     {
@@ -2916,7 +2916,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/presentation/view.py",
       "source_location": "L19",
       "id": "presentation_view_view_title",
-      "community": 0,
+      "community": 1,
       "norm_label": "view_title()"
     },
     {
@@ -2961,7 +2961,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/presentation/view.py",
       "source_location": "L91",
       "id": "presentation_view_deliveryview_get_date",
-      "community": 4,
+      "community": 5,
       "norm_label": ".get_date()"
     },
     {
@@ -3005,7 +3005,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/presentation/view.py",
       "source_location": "L1",
-      "community": 0,
+      "community": 1,
       "norm_label": "view da feature cpf validation: dialog para validacao de cpf.",
       "id": "presentation_view_rationale_1"
     },
@@ -3015,7 +3015,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_sub_features_summary_init_py",
-      "community": 0,
+      "community": 1,
       "norm_label": "__init__.py"
     },
     {
@@ -3024,7 +3024,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/data/mapper.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_sub_features_summary_data_mapper_py",
-      "community": 0,
+      "community": 1,
       "norm_label": "mapper.py"
     },
     {
@@ -3033,7 +3033,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/data/mapper.py",
       "source_location": "L23",
       "id": "data_mapper_orderssummarymapper",
-      "community": 0,
+      "community": 1,
       "norm_label": "orderssummarymapper"
     },
     {
@@ -3042,7 +3042,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/data/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_sub_features_summary_data_init_py",
-      "community": 0,
+      "community": 2,
       "norm_label": "__init__.py"
     },
     {
@@ -3060,7 +3060,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/data/apis.py",
       "source_location": "L6",
       "id": "data_apis_orderssummaryapi",
-      "community": 2,
+      "community": 1,
       "norm_label": "orderssummaryapi"
     },
     {
@@ -3069,7 +3069,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/data/apis.py",
       "source_location": "L11",
       "id": "data_apis_orderssummaryapi_for_period",
-      "community": 2,
+      "community": 1,
       "norm_label": ".for_period()"
     },
     {
@@ -3078,7 +3078,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/data/repository.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_sub_features_summary_data_repository_py",
-      "community": 0,
+      "community": 2,
       "norm_label": "repository.py"
     },
     {
@@ -3087,7 +3087,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/data/repository.py",
       "source_location": "L12",
       "id": "data_repository_summaryrepository",
-      "community": 0,
+      "community": 1,
       "norm_label": "summaryrepository"
     },
     {
@@ -3096,61 +3096,61 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/data/repository.py",
       "source_location": "L13",
       "id": "data_repository_summaryrepository_get_by_period",
-      "community": 2,
+      "community": 1,
       "norm_label": ".get_by_period()"
     },
     {
       "label": "use_case.py",
       "file_type": "code",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/domain/use_case.py",
+      "source_file": "features/home/sub_features/summary/domain/use_case.py",
       "source_location": "L1",
-      "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_sub_features_summary_domain_use_case_py",
-      "community": 0,
+      "id": "features_home_sub_features_summary_domain_use_case_py",
+      "community": 1,
       "norm_label": "use_case.py"
     },
     {
       "label": "SummaryUseCase",
       "file_type": "code",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/domain/use_case.py",
+      "source_file": "features/home/sub_features/summary/domain/use_case.py",
       "source_location": "L9",
       "id": "domain_use_case_summaryusecase",
-      "community": 0,
+      "community": 1,
       "norm_label": "summaryusecase"
     },
     {
       "label": ".__init__()",
       "file_type": "code",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/domain/use_case.py",
+      "source_file": "features/home/sub_features/summary/domain/use_case.py",
       "source_location": "L10",
       "id": "domain_use_case_summaryusecase_init",
-      "community": 0,
+      "community": 1,
       "norm_label": ".__init__()"
     },
     {
       "label": ".get_summary()",
       "file_type": "code",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/domain/use_case.py",
+      "source_file": "features/home/sub_features/summary/domain/use_case.py",
       "source_location": "L13",
       "id": "domain_use_case_summaryusecase_get_summary",
-      "community": 0,
+      "community": 1,
       "norm_label": ".get_summary()"
     },
     {
       "label": "._build_summary()",
       "file_type": "code",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/domain/use_case.py",
+      "source_file": "features/home/sub_features/summary/domain/use_case.py",
       "source_location": "L17",
       "id": "domain_use_case_summaryusecase_build_summary",
-      "community": 0,
+      "community": 1,
       "norm_label": "._build_summary()"
     },
     {
       "label": "_to_sorted_counts()",
       "file_type": "code",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/domain/use_case.py",
+      "source_file": "features/home/sub_features/summary/domain/use_case.py",
       "source_location": "L51",
       "id": "domain_use_case_to_sorted_counts",
-      "community": 0,
+      "community": 1,
       "norm_label": "_to_sorted_counts()"
     },
     {
@@ -3159,7 +3159,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/domain/signals.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_sub_features_summary_domain_signals_py",
-      "community": 0,
+      "community": 1,
       "norm_label": "signals.py"
     },
     {
@@ -3168,7 +3168,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/domain/signals.py",
       "source_location": "L8",
       "id": "domain_signals_summarysignals",
-      "community": 0,
+      "community": 7,
       "norm_label": "summarysignals"
     },
     {
@@ -3177,7 +3177,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/domain/models.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_sub_features_summary_domain_models_py",
-      "community": 0,
+      "community": 1,
       "norm_label": "models.py"
     },
     {
@@ -3186,7 +3186,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/domain/models.py",
       "source_location": "L7",
       "id": "domain_models_productcount",
-      "community": 0,
+      "community": 1,
       "norm_label": "productcount"
     },
     {
@@ -3195,7 +3195,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/domain/models.py",
       "source_location": "L13",
       "id": "domain_models_orderdetail",
-      "community": 0,
+      "community": 1,
       "norm_label": "orderdetail"
     },
     {
@@ -3204,7 +3204,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/domain/models.py",
       "source_location": "L22",
       "id": "domain_models_daysummary",
-      "community": 0,
+      "community": 1,
       "norm_label": "daysummary"
     },
     {
@@ -3213,7 +3213,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/domain/models.py",
       "source_location": "L29",
       "id": "domain_models_productssummary",
-      "community": 0,
+      "community": 1,
       "norm_label": "productssummary"
     },
     {
@@ -3222,7 +3222,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/domain/models.py",
       "source_location": "L38",
       "id": "domain_models_productsviewdata",
-      "community": 0,
+      "community": 1,
       "norm_label": "productsviewdata"
     },
     {
@@ -3240,7 +3240,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/domain/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_sub_features_summary_domain_init_py",
-      "community": 32,
+      "community": 34,
       "norm_label": "__init__.py"
     },
     {
@@ -3249,7 +3249,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/presentation/controller.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_sub_features_summary_presentation_controller_py",
-      "community": 0,
+      "community": 1,
       "norm_label": "controller.py"
     },
     {
@@ -3258,7 +3258,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/presentation/controller.py",
       "source_location": "L15",
       "id": "presentation_controller_summarycontroller",
-      "community": 4,
+      "community": 5,
       "norm_label": "summarycontroller"
     },
     {
@@ -3267,7 +3267,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/presentation/controller.py",
       "source_location": "L16",
       "id": "presentation_controller_summarycontroller_init",
-      "community": 4,
+      "community": 5,
       "norm_label": ".__init__()"
     },
     {
@@ -3276,7 +3276,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/presentation/controller.py",
       "source_location": "L21",
       "id": "presentation_controller_summarycontroller_setup_actions",
-      "community": 4,
+      "community": 5,
       "norm_label": "._setup_actions()"
     },
     {
@@ -3285,7 +3285,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/presentation/controller.py",
       "source_location": "L33",
       "id": "presentation_controller_summarycontroller_on_generate_report",
-      "community": 4,
+      "community": 5,
       "norm_label": ".on_generate_report()"
     },
     {
@@ -3294,7 +3294,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/presentation/controller.py",
       "source_location": "L40",
       "id": "presentation_controller_summarycontroller_on_copy_report",
-      "community": 4,
+      "community": 5,
       "norm_label": ".on_copy_report()"
     },
     {
@@ -3303,7 +3303,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/presentation/controller.py",
       "source_location": "L43",
       "id": "presentation_controller_summarycontroller_on_copy_graph",
-      "community": 4,
+      "community": 5,
       "norm_label": ".on_copy_graph()"
     },
     {
@@ -3312,7 +3312,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/presentation/controller.py",
       "source_location": "L46",
       "id": "presentation_controller_summarycontroller_on_download_graph",
-      "community": 4,
+      "community": 5,
       "norm_label": ".on_download_graph()"
     },
     {
@@ -3321,7 +3321,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/presentation/controller.py",
       "source_location": "L49",
       "id": "presentation_controller_summarycontroller_on_change_chart_type",
-      "community": 4,
+      "community": 5,
       "norm_label": ".on_change_chart_type()"
     },
     {
@@ -3330,7 +3330,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/presentation/controller.py",
       "source_location": "L54",
       "id": "presentation_controller_summarycontroller_handle_error",
-      "community": 4,
+      "community": 5,
       "norm_label": ".handle_error()"
     },
     {
@@ -3339,7 +3339,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/presentation/controller.py",
       "source_location": "L58",
       "id": "presentation_controller_summarycontroller_handle_report_generated",
-      "community": 4,
+      "community": 5,
       "norm_label": ".handle_report_generated()"
     },
     {
@@ -3348,7 +3348,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/presentation/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_sub_features_summary_presentation_init_py",
-      "community": 33,
+      "community": 35,
       "norm_label": "__init__.py"
     },
     {
@@ -3357,7 +3357,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/presentation/viewmodel.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_sub_features_summary_presentation_viewmodel_py",
-      "community": 0,
+      "community": 1,
       "norm_label": "viewmodel.py"
     },
     {
@@ -3366,7 +3366,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/presentation/viewmodel.py",
       "source_location": "L14",
       "id": "presentation_viewmodel_summaryviewmodel",
-      "community": 0,
+      "community": 1,
       "norm_label": "summaryviewmodel"
     },
     {
@@ -3375,7 +3375,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/presentation/viewmodel.py",
       "source_location": "L15",
       "id": "presentation_viewmodel_summaryviewmodel_init",
-      "community": 0,
+      "community": 1,
       "norm_label": ".__init__()"
     },
     {
@@ -3384,7 +3384,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/presentation/viewmodel.py",
       "source_location": "L19",
       "id": "presentation_viewmodel_summaryviewmodel_on_generate",
-      "community": 0,
+      "community": 1,
       "norm_label": ".on_generate()"
     },
     {
@@ -3393,7 +3393,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/presentation/viewmodel.py",
       "source_location": "L22",
       "id": "presentation_viewmodel_summaryviewmodel_fetch",
-      "community": 0,
+      "community": 1,
       "norm_label": "._fetch()"
     },
     {
@@ -3402,7 +3402,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/presentation/viewmodel.py",
       "source_location": "L32",
       "id": "presentation_viewmodel_summaryviewmodel_build_view_data",
-      "community": 0,
+      "community": 1,
       "norm_label": "._build_view_data()"
     },
     {
@@ -3411,7 +3411,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/presentation/viewmodel.py",
       "source_location": "L38",
       "id": "presentation_viewmodel_summaryviewmodel_build_report",
-      "community": 0,
+      "community": 1,
       "norm_label": "._build_report()"
     },
     {
@@ -3420,7 +3420,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/presentation/viewmodel.py",
       "source_location": "L61",
       "id": "presentation_viewmodel_products_lines",
-      "community": 0,
+      "community": 1,
       "norm_label": "_products_lines()"
     },
     {
@@ -3429,7 +3429,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/presentation/view.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_sub_features_summary_presentation_view_py",
-      "community": 0,
+      "community": 1,
       "norm_label": "view.py"
     },
     {
@@ -3438,7 +3438,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/presentation/view.py",
       "source_location": "L16",
       "id": "presentation_view_summaryview",
-      "community": 4,
+      "community": 5,
       "norm_label": "summaryview"
     },
     {
@@ -3447,7 +3447,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/presentation/view.py",
       "source_location": "L23",
       "id": "presentation_view_summaryview_init",
-      "community": 4,
+      "community": 5,
       "norm_label": ".__init__()"
     },
     {
@@ -3456,7 +3456,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/presentation/view.py",
       "source_location": "L33",
       "id": "presentation_view_summaryview_setup_ui",
-      "community": 4,
+      "community": 5,
       "norm_label": "._setup_ui()"
     },
     {
@@ -3465,7 +3465,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/presentation/view.py",
       "source_location": "L38",
       "id": "presentation_view_summaryview_setup_components",
-      "community": 4,
+      "community": 5,
       "norm_label": "._setup_components()"
     },
     {
@@ -3474,7 +3474,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/presentation/view.py",
       "source_location": "L74",
       "id": "presentation_view_summaryview_setup_layout",
-      "community": 4,
+      "community": 5,
       "norm_label": "._setup_layout()"
     },
     {
@@ -3483,7 +3483,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/presentation/view.py",
       "source_location": "L105",
       "id": "presentation_view_summaryview_on_chart_type_changed",
-      "community": 4,
+      "community": 5,
       "norm_label": "._on_chart_type_changed()"
     },
     {
@@ -3492,7 +3492,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/presentation/view.py",
       "source_location": "L109",
       "id": "presentation_view_summaryview_update_buttons_state",
-      "community": 4,
+      "community": 5,
       "norm_label": "._update_buttons_state()"
     },
     {
@@ -3501,7 +3501,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/presentation/view.py",
       "source_location": "L117",
       "id": "presentation_view_summaryview_get_date_range",
-      "community": 4,
+      "community": 5,
       "norm_label": ".get_date_range()"
     },
     {
@@ -3510,7 +3510,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/presentation/view.py",
       "source_location": "L123",
       "id": "presentation_view_summaryview_update_data",
-      "community": 4,
+      "community": 5,
       "norm_label": ".update_data()"
     },
     {
@@ -3519,7 +3519,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/presentation/view.py",
       "source_location": "L129",
       "id": "presentation_view_summaryview_activate_button_state",
-      "community": 4,
+      "community": 5,
       "norm_label": ".activate_button_state()"
     },
     {
@@ -3528,7 +3528,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/presentation/view.py",
       "source_location": "L132",
       "id": "presentation_view_summaryview_clear_content",
-      "community": 4,
+      "community": 5,
       "norm_label": ".clear_content()"
     },
     {
@@ -3537,7 +3537,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/presentation/view.py",
       "source_location": "L137",
       "id": "presentation_view_summaryview_prepare_to_fetch",
-      "community": 4,
+      "community": 5,
       "norm_label": ".prepare_to_fetch()"
     },
     {
@@ -3546,7 +3546,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_sheets_init_py",
-      "community": 34,
+      "community": 36,
       "norm_label": "__init__.py"
     },
     {
@@ -3717,7 +3717,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/domain/use_case.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_sheets_domain_use_case_py",
-      "community": 9,
+      "community": 3,
       "norm_label": "use_case.py"
     },
     {
@@ -3726,7 +3726,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/domain/use_case.py",
       "source_location": "L7",
       "id": "domain_use_case_sheetsusecase",
-      "community": 9,
+      "community": 3,
       "norm_label": "sheetsusecase"
     },
     {
@@ -3735,7 +3735,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/domain/use_case.py",
       "source_location": "L8",
       "id": "domain_use_case_sheetsusecase_init",
-      "community": 9,
+      "community": 3,
       "norm_label": ".__init__()"
     },
     {
@@ -3744,7 +3744,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/domain/use_case.py",
       "source_location": "L11",
       "id": "domain_use_case_sheetsusecase_connect",
-      "community": 9,
+      "community": 3,
       "norm_label": ".connect()"
     },
     {
@@ -3753,7 +3753,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/domain/use_case.py",
       "source_location": "L17",
       "id": "domain_use_case_sheetsusecase_select",
-      "community": 9,
+      "community": 3,
       "norm_label": ".select()"
     },
     {
@@ -3762,7 +3762,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/domain/use_case.py",
       "source_location": "L22",
       "id": "domain_use_case_sheetsusecase_load_all",
-      "community": 9,
+      "community": 3,
       "norm_label": ".load_all()"
     },
     {
@@ -3771,7 +3771,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/domain/use_case.py",
       "source_location": "L25",
       "id": "domain_use_case_sheetsusecase_find_by_link",
-      "community": 9,
+      "community": 3,
       "norm_label": ".find_by_link()"
     },
     {
@@ -3780,7 +3780,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/domain/use_case.py",
       "source_location": "L28",
       "id": "domain_use_case_sheetsusecase_remove",
-      "community": 9,
+      "community": 3,
       "norm_label": ".remove()"
     },
     {
@@ -3789,7 +3789,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/domain/use_case.py",
       "source_location": "L35",
       "id": "domain_use_case_sheetsusecase_update_name",
-      "community": 9,
+      "community": 3,
       "norm_label": ".update_name()"
     },
     {
@@ -3798,7 +3798,7 @@
       "source_file": "features/sheets/domain/signals.py",
       "source_location": "L1",
       "id": "features_sheets_domain_signals_py",
-      "community": 0,
+      "community": 7,
       "norm_label": "signals.py"
     },
     {
@@ -3807,7 +3807,7 @@
       "source_file": "features/sheets/domain/signals.py",
       "source_location": "L6",
       "id": "domain_signals_sheetssignals",
-      "community": 0,
+      "community": 7,
       "norm_label": "sheetssignals"
     },
     {
@@ -3816,7 +3816,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/domain/models.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_sheets_domain_models_py",
-      "community": 9,
+      "community": 3,
       "norm_label": "models.py"
     },
     {
@@ -3843,7 +3843,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/domain/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_sheets_domain_init_py",
-      "community": 35,
+      "community": 37,
       "norm_label": "__init__.py"
     },
     {
@@ -3852,7 +3852,7 @@
       "source_file": "features/sheets/presentation/controller.py",
       "source_location": "L1",
       "id": "features_sheets_presentation_controller_py",
-      "community": 0,
+      "community": 7,
       "norm_label": "controller.py"
     },
     {
@@ -3861,7 +3861,7 @@
       "source_file": "features/sheets/presentation/controller.py",
       "source_location": "L17",
       "id": "presentation_controller_sheetscontroller",
-      "community": 5,
+      "community": 3,
       "norm_label": "sheetscontroller"
     },
     {
@@ -3870,7 +3870,7 @@
       "source_file": "features/sheets/presentation/controller.py",
       "source_location": "L18",
       "id": "presentation_controller_sheetscontroller_init",
-      "community": 5,
+      "community": 3,
       "norm_label": ".__init__()"
     },
     {
@@ -3879,7 +3879,7 @@
       "source_file": "features/sheets/presentation/controller.py",
       "source_location": "L25",
       "id": "presentation_controller_sheetscontroller_setup_actions",
-      "community": 5,
+      "community": 3,
       "norm_label": "._setup_actions()"
     },
     {
@@ -3888,7 +3888,7 @@
       "source_file": "features/sheets/presentation/controller.py",
       "source_location": "L36",
       "id": "presentation_controller_sheetscontroller_load_saved_sheets",
-      "community": 5,
+      "community": 3,
       "norm_label": "._load_saved_sheets()"
     },
     {
@@ -3897,7 +3897,7 @@
       "source_file": "features/sheets/presentation/controller.py",
       "source_location": "L40",
       "id": "presentation_controller_sheetscontroller_on_connect",
-      "community": 5,
+      "community": 3,
       "norm_label": "._on_connect()"
     },
     {
@@ -3906,7 +3906,7 @@
       "source_file": "features/sheets/presentation/controller.py",
       "source_location": "L54",
       "id": "presentation_controller_sheetscontroller_update_sheet_name_if_needed",
-      "community": 5,
+      "community": 3,
       "norm_label": "._update_sheet_name_if_needed()"
     },
     {
@@ -3915,7 +3915,7 @@
       "source_file": "features/sheets/presentation/controller.py",
       "source_location": "L60",
       "id": "presentation_controller_sheetscontroller_show_existing_dialog",
-      "community": 5,
+      "community": 3,
       "norm_label": "._show_existing_dialog()"
     },
     {
@@ -3924,7 +3924,7 @@
       "source_file": "features/sheets/presentation/controller.py",
       "source_location": "L81",
       "id": "presentation_controller_sheetscontroller_on_remove_requested",
-      "community": 10,
+      "community": 9,
       "norm_label": "._on_remove_requested()"
     },
     {
@@ -3933,7 +3933,7 @@
       "source_file": "features/sheets/presentation/controller.py",
       "source_location": "L92",
       "id": "presentation_controller_sheetscontroller_on_init_finished",
-      "community": 5,
+      "community": 3,
       "norm_label": "._on_init_finished()"
     },
     {
@@ -3942,7 +3942,7 @@
       "source_file": "features/sheets/presentation/controller.py",
       "source_location": "L96",
       "id": "presentation_controller_sheetscontroller_on_select",
-      "community": 10,
+      "community": 9,
       "norm_label": "._on_select()"
     },
     {
@@ -3951,7 +3951,7 @@
       "source_file": "features/sheets/presentation/controller.py",
       "source_location": "L99",
       "id": "presentation_controller_sheetscontroller_on_renamed",
-      "community": 5,
+      "community": 3,
       "norm_label": "._on_renamed()"
     },
     {
@@ -3960,7 +3960,7 @@
       "source_file": "features/sheets/presentation/controller.py",
       "source_location": "L103",
       "id": "presentation_controller_sheetscontroller_on_removed",
-      "community": 10,
+      "community": 9,
       "norm_label": "._on_removed()"
     },
     {
@@ -3969,7 +3969,7 @@
       "source_file": "features/sheets/presentation/controller.py",
       "source_location": "L107",
       "id": "presentation_controller_sheetscontroller_on_connected",
-      "community": 5,
+      "community": 3,
       "norm_label": "._on_connected()"
     },
     {
@@ -3978,7 +3978,7 @@
       "source_file": "features/sheets/presentation/controller.py",
       "source_location": "L112",
       "id": "presentation_controller_sheetscontroller_on_selected",
-      "community": 5,
+      "community": 3,
       "norm_label": "._on_selected()"
     },
     {
@@ -3987,7 +3987,7 @@
       "source_file": "features/sheets/presentation/controller.py",
       "source_location": "L116",
       "id": "presentation_controller_sheetscontroller_on_error",
-      "community": 4,
+      "community": 5,
       "norm_label": "._on_error()"
     },
     {
@@ -3996,7 +3996,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/presentation/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_sheets_presentation_init_py",
-      "community": 36,
+      "community": 38,
       "norm_label": "__init__.py"
     },
     {
@@ -4005,7 +4005,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/presentation/viewmodel.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_sheets_presentation_viewmodel_py",
-      "community": 9,
+      "community": 3,
       "norm_label": "viewmodel.py"
     },
     {
@@ -4014,7 +4014,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/presentation/viewmodel.py",
       "source_location": "L11",
       "id": "presentation_viewmodel_sheetsviewmodel",
-      "community": 9,
+      "community": 3,
       "norm_label": "sheetsviewmodel"
     },
     {
@@ -4023,7 +4023,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/presentation/viewmodel.py",
       "source_location": "L12",
       "id": "presentation_viewmodel_sheetsviewmodel_init",
-      "community": 9,
+      "community": 3,
       "norm_label": ".__init__()"
     },
     {
@@ -4032,7 +4032,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/presentation/viewmodel.py",
       "source_location": "L18",
       "id": "presentation_viewmodel_sheetsviewmodel_load_all",
-      "community": 5,
+      "community": 3,
       "norm_label": ".load_all()"
     },
     {
@@ -4041,7 +4041,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/presentation/viewmodel.py",
       "source_location": "L21",
       "id": "presentation_viewmodel_sheetsviewmodel_find_by_link",
-      "community": 9,
+      "community": 3,
       "norm_label": ".find_by_link()"
     },
     {
@@ -4050,7 +4050,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/presentation/viewmodel.py",
       "source_location": "L26",
       "id": "presentation_viewmodel_sheetsviewmodel_update_name",
-      "community": 9,
+      "community": 3,
       "norm_label": ".update_name()"
     },
     {
@@ -4059,7 +4059,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/presentation/viewmodel.py",
       "source_location": "L38",
       "id": "presentation_viewmodel_sheetsviewmodel_connect",
-      "community": 9,
+      "community": 3,
       "norm_label": ".connect()"
     },
     {
@@ -4068,7 +4068,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/presentation/viewmodel.py",
       "source_location": "L49",
       "id": "presentation_viewmodel_sheetsviewmodel_select",
-      "community": 9,
+      "community": 3,
       "norm_label": ".select()"
     },
     {
@@ -4077,7 +4077,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/presentation/viewmodel.py",
       "source_location": "L59",
       "id": "presentation_viewmodel_sheetsviewmodel_remove",
-      "community": 9,
+      "community": 3,
       "norm_label": ".remove()"
     },
     {
@@ -4086,7 +4086,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/presentation/view/sheet_create_view.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_sheets_presentation_view_sheet_create_view_py",
-      "community": 5,
+      "community": 15,
       "norm_label": "sheet_create_view.py"
     },
     {
@@ -4095,7 +4095,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/presentation/view/sheet_create_view.py",
       "source_location": "L8",
       "id": "view_sheet_create_view_sheetcreateview",
-      "community": 5,
+      "community": 15,
       "norm_label": "sheetcreateview"
     },
     {
@@ -4104,7 +4104,7 @@
       "source_file": "",
       "source_location": "",
       "id": "qdialog",
-      "community": 5,
+      "community": 15,
       "norm_label": "qdialog"
     },
     {
@@ -4113,7 +4113,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/presentation/view/sheet_create_view.py",
       "source_location": "L9",
       "id": "view_sheet_create_view_sheetcreateview_init",
-      "community": 5,
+      "community": 15,
       "norm_label": ".__init__()"
     },
     {
@@ -4122,7 +4122,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/presentation/view/sheet_create_view.py",
       "source_location": "L14",
       "id": "view_sheet_create_view_link",
-      "community": 5,
+      "community": 15,
       "norm_label": "link()"
     },
     {
@@ -4131,7 +4131,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/presentation/view/sheet_create_view.py",
       "source_location": "L18",
       "id": "view_sheet_create_view_name",
-      "community": 5,
+      "community": 15,
       "norm_label": "name()"
     },
     {
@@ -4140,7 +4140,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/presentation/view/sheet_create_view.py",
       "source_location": "L21",
       "id": "view_sheet_create_view_sheetcreateview_setup_ui",
-      "community": 5,
+      "community": 15,
       "norm_label": "._setup_ui()"
     },
     {
@@ -4149,7 +4149,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/presentation/view/sheet_create_view.py",
       "source_location": "L25",
       "id": "view_sheet_create_view_sheetcreateview_setup_components",
-      "community": 5,
+      "community": 15,
       "norm_label": "._setup_components()"
     },
     {
@@ -4158,7 +4158,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/presentation/view/sheet_create_view.py",
       "source_location": "L41",
       "id": "view_sheet_create_view_sheetcreateview_setup_layout",
-      "community": 5,
+      "community": 15,
       "norm_label": "._setup_layout()"
     },
     {
@@ -4167,7 +4167,7 @@
       "source_file": "features/sheets/presentation/view/sheets_menu_view.py",
       "source_location": "L1",
       "id": "features_sheets_presentation_view_sheets_menu_view_py",
-      "community": 5,
+      "community": 3,
       "norm_label": "sheets_menu_view.py"
     },
     {
@@ -4176,7 +4176,7 @@
       "source_file": "features/sheets/presentation/view/sheets_menu_view.py",
       "source_location": "L8",
       "id": "view_sheets_menu_view_sheetsmenuview",
-      "community": 5,
+      "community": 3,
       "norm_label": "sheetsmenuview"
     },
     {
@@ -4185,7 +4185,7 @@
       "source_file": "",
       "source_location": "",
       "id": "qmenu",
-      "community": 5,
+      "community": 3,
       "norm_label": "qmenu"
     },
     {
@@ -4194,7 +4194,7 @@
       "source_file": "features/sheets/presentation/view/sheets_menu_view.py",
       "source_location": "L14",
       "id": "view_sheets_menu_view_sheetsmenuview_init",
-      "community": 5,
+      "community": 3,
       "norm_label": ".__init__()"
     },
     {
@@ -4203,7 +4203,7 @@
       "source_file": "features/sheets/presentation/view/sheets_menu_view.py",
       "source_location": "L19",
       "id": "view_sheets_menu_view_view_title",
-      "community": 5,
+      "community": 3,
       "norm_label": "view_title()"
     },
     {
@@ -4212,7 +4212,7 @@
       "source_file": "features/sheets/presentation/view/sheets_menu_view.py",
       "source_location": "L22",
       "id": "view_sheets_menu_view_sheetsmenuview_setup_ui",
-      "community": 5,
+      "community": 3,
       "norm_label": "._setup_ui()"
     },
     {
@@ -4221,7 +4221,7 @@
       "source_file": "features/sheets/presentation/view/sheets_menu_view.py",
       "source_location": "L26",
       "id": "view_sheets_menu_view_sheetsmenuview_setup_components",
-      "community": 5,
+      "community": 3,
       "norm_label": "._setup_components()"
     },
     {
@@ -4230,7 +4230,7 @@
       "source_file": "features/sheets/presentation/view/sheets_menu_view.py",
       "source_location": "L37",
       "id": "view_sheets_menu_view_sheetsmenuview_setup_layout",
-      "community": 5,
+      "community": 3,
       "norm_label": "._setup_layout()"
     },
     {
@@ -4239,7 +4239,7 @@
       "source_file": "features/sheets/presentation/view/sheets_menu_view.py",
       "source_location": "L41",
       "id": "view_sheets_menu_view_sheetsmenuview_add_or_update_sheet",
-      "community": 5,
+      "community": 3,
       "norm_label": ".add_or_update_sheet()"
     },
     {
@@ -4248,7 +4248,7 @@
       "source_file": "features/sheets/presentation/view/sheets_menu_view.py",
       "source_location": "L69",
       "id": "view_sheets_menu_view_sheetsmenuview_set_active",
-      "community": 5,
+      "community": 3,
       "norm_label": ".set_active()"
     },
     {
@@ -4257,7 +4257,7 @@
       "source_file": "features/sheets/presentation/view/sheets_menu_view.py",
       "source_location": "L76",
       "id": "view_sheets_menu_view_sheetsmenuview_remove_sheet",
-      "community": 5,
+      "community": 3,
       "norm_label": ".remove_sheet()"
     },
     {
@@ -4266,7 +4266,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/sheets/presentation/view/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_sheets_presentation_view_init_py",
-      "community": 5,
+      "community": 15,
       "norm_label": "__init__.py"
     },
     {
@@ -4275,7 +4275,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_auth_init_py",
-      "community": 37,
+      "community": 39,
       "norm_label": "__init__.py"
     },
     {
@@ -4437,7 +4437,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/domain/use_case.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_auth_domain_use_case_py",
-      "community": 0,
+      "community": 1,
       "norm_label": "use_case.py"
     },
     {
@@ -4446,7 +4446,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/domain/use_case.py",
       "source_location": "L8",
       "id": "domain_use_case_authusecase",
-      "community": 17,
+      "community": 1,
       "norm_label": "authusecase"
     },
     {
@@ -4455,7 +4455,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/domain/use_case.py",
       "source_location": "L9",
       "id": "domain_use_case_authusecase_init",
-      "community": 17,
+      "community": 1,
       "norm_label": ".__init__()"
     },
     {
@@ -4464,7 +4464,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/domain/use_case.py",
       "source_location": "L12",
       "id": "domain_use_case_authusecase_configure",
-      "community": 17,
+      "community": 1,
       "norm_label": ".configure()"
     },
     {
@@ -4473,7 +4473,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/domain/use_case.py",
       "source_location": "L17",
       "id": "domain_use_case_authusecase_clear",
-      "community": 17,
+      "community": 1,
       "norm_label": ".clear()"
     },
     {
@@ -4481,7 +4481,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/domain/use_case.py",
       "source_location": "L13",
-      "community": 17,
+      "community": 1,
       "norm_label": "le o arquivo json, salva em storage seguro e autentica o backend.",
       "id": "domain_use_case_rationale_13"
     },
@@ -4490,7 +4490,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/domain/use_case.py",
       "source_location": "L18",
-      "community": 17,
+      "community": 1,
       "norm_label": "remove credenciais do storage e desautentica o backend.",
       "id": "domain_use_case_rationale_18"
     },
@@ -4500,7 +4500,7 @@
       "source_file": "features/auth/domain/signals.py",
       "source_location": "L1",
       "id": "features_auth_domain_signals_py",
-      "community": 0,
+      "community": 7,
       "norm_label": "signals.py"
     },
     {
@@ -4509,7 +4509,7 @@
       "source_file": "features/auth/domain/signals.py",
       "source_location": "L8",
       "id": "domain_signals_authsignals",
-      "community": 0,
+      "community": 7,
       "norm_label": "authsignals"
     },
     {
@@ -4527,7 +4527,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/domain/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_auth_domain_init_py",
-      "community": 38,
+      "community": 40,
       "norm_label": "__init__.py"
     },
     {
@@ -4554,7 +4554,7 @@
       "source_file": "",
       "source_location": "",
       "id": "errormodel",
-      "community": 0,
+      "community": 1,
       "norm_label": "errormodel"
     },
     {
@@ -4608,7 +4608,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/presentation/controller.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_auth_presentation_controller_py",
-      "community": 0,
+      "community": 1,
       "norm_label": "controller.py"
     },
     {
@@ -4617,7 +4617,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/presentation/controller.py",
       "source_location": "L17",
       "id": "presentation_controller_authcontroller",
-      "community": 4,
+      "community": 3,
       "norm_label": "authcontroller"
     },
     {
@@ -4626,7 +4626,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/presentation/controller.py",
       "source_location": "L18",
       "id": "presentation_controller_authcontroller_init",
-      "community": 4,
+      "community": 3,
       "norm_label": ".__init__()"
     },
     {
@@ -4635,7 +4635,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/presentation/controller.py",
       "source_location": "L24",
       "id": "presentation_controller_authcontroller_setup_actions",
-      "community": 4,
+      "community": 3,
       "norm_label": "._setup_actions()"
     },
     {
@@ -4644,7 +4644,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/presentation/controller.py",
       "source_location": "L32",
       "id": "presentation_controller_authcontroller_on_configure",
-      "community": 4,
+      "community": 3,
       "norm_label": "._on_configure()"
     },
     {
@@ -4653,7 +4653,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/presentation/controller.py",
       "source_location": "L39",
       "id": "presentation_controller_authcontroller_on_clear",
-      "community": 4,
+      "community": 3,
       "norm_label": "._on_clear()"
     },
     {
@@ -4662,7 +4662,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/presentation/controller.py",
       "source_location": "L49",
       "id": "presentation_controller_authcontroller_on_configured",
-      "community": 4,
+      "community": 3,
       "norm_label": "._on_configured()"
     },
     {
@@ -4671,7 +4671,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/presentation/controller.py",
       "source_location": "L52",
       "id": "presentation_controller_authcontroller_on_cleared",
-      "community": 4,
+      "community": 3,
       "norm_label": "._on_cleared()"
     },
     {
@@ -4680,7 +4680,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/presentation/controller.py",
       "source_location": "L55",
       "id": "presentation_controller_authcontroller_on_error",
-      "community": 4,
+      "community": 5,
       "norm_label": "._on_error()"
     },
     {
@@ -4689,7 +4689,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/presentation/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_auth_presentation_init_py",
-      "community": 0,
+      "community": 1,
       "norm_label": "__init__.py"
     },
     {
@@ -4698,7 +4698,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/presentation/viewmodel.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_auth_presentation_viewmodel_py",
-      "community": 0,
+      "community": 1,
       "norm_label": "viewmodel.py"
     },
     {
@@ -4707,7 +4707,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/presentation/viewmodel.py",
       "source_location": "L12",
       "id": "presentation_viewmodel_authviewmodel",
-      "community": 4,
+      "community": 3,
       "norm_label": "authviewmodel"
     },
     {
@@ -4716,7 +4716,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/presentation/viewmodel.py",
       "source_location": "L13",
       "id": "presentation_viewmodel_authviewmodel_init",
-      "community": 17,
+      "community": 3,
       "norm_label": ".__init__()"
     },
     {
@@ -4725,7 +4725,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/presentation/viewmodel.py",
       "source_location": "L18",
       "id": "presentation_viewmodel_authviewmodel_configure",
-      "community": 4,
+      "community": 3,
       "norm_label": ".configure()"
     },
     {
@@ -4734,7 +4734,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/presentation/viewmodel.py",
       "source_location": "L29",
       "id": "presentation_viewmodel_authviewmodel_clear",
-      "community": 4,
+      "community": 3,
       "norm_label": ".clear()"
     },
     {
@@ -4743,7 +4743,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/presentation/view.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_auth_presentation_view_py",
-      "community": 0,
+      "community": 1,
       "norm_label": "view.py"
     },
     {
@@ -4752,7 +4752,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/presentation/view.py",
       "source_location": "L10",
       "id": "presentation_view_authview",
-      "community": 5,
+      "community": 3,
       "norm_label": "authview"
     },
     {
@@ -4761,7 +4761,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/presentation/view.py",
       "source_location": "L14",
       "id": "presentation_view_authview_init",
-      "community": 5,
+      "community": 3,
       "norm_label": ".__init__()"
     },
     {
@@ -4770,7 +4770,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/auth/presentation/view.py",
       "source_location": "L22",
       "id": "presentation_view_authview_setup_actions",
-      "community": 5,
+      "community": 3,
       "norm_label": "._setup_actions()"
     },
     {
@@ -4779,7 +4779,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_cpf_validation_init_py",
-      "community": 39,
+      "community": 41,
       "norm_label": "__init__.py"
     },
     {
@@ -4788,7 +4788,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/domain/use_case.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_cpf_validation_domain_use_case_py",
-      "community": 0,
+      "community": 7,
       "norm_label": "use_case.py"
     },
     {
@@ -4797,7 +4797,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/domain/use_case.py",
       "source_location": "L6",
       "id": "domain_use_case_is_valid_cpf",
-      "community": 0,
+      "community": 7,
       "norm_label": "_is_valid_cpf()"
     },
     {
@@ -4806,7 +4806,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/domain/use_case.py",
       "source_location": "L29",
       "id": "domain_use_case_cpfvalidationusecase",
-      "community": 0,
+      "community": 7,
       "norm_label": "cpfvalidationusecase"
     },
     {
@@ -4815,7 +4815,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/domain/use_case.py",
       "source_location": "L30",
       "id": "domain_use_case_cpfvalidationusecase_validate",
-      "community": 0,
+      "community": 7,
       "norm_label": ".validate()"
     },
     {
@@ -4823,7 +4823,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/domain/use_case.py",
       "source_location": "L7",
-      "community": 0,
+      "community": 7,
       "norm_label": "valida um cpf pela regra dos dois digitos verificadores (algoritmo da receita fe",
       "id": "domain_use_case_rationale_7"
     },
@@ -4833,7 +4833,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/domain/signals.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_cpf_validation_domain_signals_py",
-      "community": 0,
+      "community": 7,
       "norm_label": "signals.py"
     },
     {
@@ -4842,7 +4842,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/domain/signals.py",
       "source_location": "L8",
       "id": "domain_signals_cpfvalidationsignals",
-      "community": 0,
+      "community": 7,
       "norm_label": "cpfvalidationsignals"
     },
     {
@@ -4851,7 +4851,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/domain/models.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_cpf_validation_domain_models_py",
-      "community": 0,
+      "community": 7,
       "norm_label": "models.py"
     },
     {
@@ -4860,7 +4860,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/domain/models.py",
       "source_location": "L7",
       "id": "domain_models_cpfvalidationresult",
-      "community": 0,
+      "community": 7,
       "norm_label": "cpfvalidationresult"
     },
     {
@@ -4878,7 +4878,7 @@
       "source_file": "features/cpf_validation/domain/__init__.py",
       "source_location": "L1",
       "id": "features_cpf_validation_domain_init_py",
-      "community": 40,
+      "community": 42,
       "norm_label": "__init__.py"
     },
     {
@@ -4887,7 +4887,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/presentation/controller.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_cpf_validation_presentation_controller_py",
-      "community": 0,
+      "community": 7,
       "norm_label": "controller.py"
     },
     {
@@ -4896,7 +4896,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/presentation/controller.py",
       "source_location": "L12",
       "id": "presentation_controller_cpfvalidationcontroller",
-      "community": 5,
+      "community": 7,
       "norm_label": "cpfvalidationcontroller"
     },
     {
@@ -4905,7 +4905,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/presentation/controller.py",
       "source_location": "L13",
       "id": "presentation_controller_cpfvalidationcontroller_init",
-      "community": 5,
+      "community": 7,
       "norm_label": ".__init__()"
     },
     {
@@ -4914,7 +4914,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/presentation/controller.py",
       "source_location": "L18",
       "id": "presentation_controller_cpfvalidationcontroller_setup_actions",
-      "community": 5,
+      "community": 7,
       "norm_label": "._setup_actions()"
     },
     {
@@ -4923,7 +4923,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/presentation/controller.py",
       "source_location": "L22",
       "id": "presentation_controller_cpfvalidationcontroller_on_validate",
-      "community": 5,
+      "community": 7,
       "norm_label": ".on_validate()"
     },
     {
@@ -4932,7 +4932,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/presentation/controller.py",
       "source_location": "L29",
       "id": "presentation_controller_cpfvalidationcontroller_handle_result",
-      "community": 5,
+      "community": 7,
       "norm_label": ".handle_result()"
     },
     {
@@ -4941,7 +4941,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/presentation/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_cpf_validation_presentation_init_py",
-      "community": 0,
+      "community": 7,
       "norm_label": "__init__.py"
     },
     {
@@ -4950,7 +4950,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/presentation/viewmodel.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_cpf_validation_presentation_viewmodel_py",
-      "community": 0,
+      "community": 7,
       "norm_label": "viewmodel.py"
     },
     {
@@ -4959,7 +4959,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/presentation/viewmodel.py",
       "source_location": "L7",
       "id": "presentation_viewmodel_cpfvalidationviewmodel",
-      "community": 0,
+      "community": 7,
       "norm_label": "cpfvalidationviewmodel"
     },
     {
@@ -4968,7 +4968,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/presentation/viewmodel.py",
       "source_location": "L8",
       "id": "presentation_viewmodel_cpfvalidationviewmodel_init",
-      "community": 0,
+      "community": 7,
       "norm_label": ".__init__()"
     },
     {
@@ -4977,7 +4977,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/presentation/viewmodel.py",
       "source_location": "L11",
       "id": "presentation_viewmodel_cpfvalidationviewmodel_on_validate",
-      "community": 0,
+      "community": 7,
       "norm_label": ".on_validate()"
     },
     {
@@ -4986,7 +4986,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/presentation/view.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_cpf_validation_presentation_view_py",
-      "community": 0,
+      "community": 7,
       "norm_label": "view.py"
     },
     {
@@ -4995,7 +4995,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/presentation/view.py",
       "source_location": "L14",
       "id": "presentation_view_cpfvalidationview",
-      "community": 5,
+      "community": 7,
       "norm_label": "cpfvalidationview"
     },
     {
@@ -5004,7 +5004,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/presentation/view.py",
       "source_location": "L20",
       "id": "presentation_view_cpfvalidationview_init",
-      "community": 5,
+      "community": 7,
       "norm_label": ".__init__()"
     },
     {
@@ -5013,7 +5013,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/presentation/view.py",
       "source_location": "L25",
       "id": "presentation_view_menu_title",
-      "community": 0,
+      "community": 7,
       "norm_label": "menu_title()"
     },
     {
@@ -5022,7 +5022,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/presentation/view.py",
       "source_location": "L28",
       "id": "presentation_view_cpfvalidationview_setup_ui",
-      "community": 5,
+      "community": 7,
       "norm_label": "._setup_ui()"
     },
     {
@@ -5031,7 +5031,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/presentation/view.py",
       "source_location": "L32",
       "id": "presentation_view_cpfvalidationview_setup_components",
-      "community": 5,
+      "community": 7,
       "norm_label": "._setup_components()"
     },
     {
@@ -5040,7 +5040,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/presentation/view.py",
       "source_location": "L46",
       "id": "presentation_view_cpfvalidationview_setup_layout",
-      "community": 5,
+      "community": 7,
       "norm_label": "._setup_layout()"
     },
     {
@@ -5049,7 +5049,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/presentation/view.py",
       "source_location": "L63",
       "id": "presentation_view_cpfvalidationview_get_cpf",
-      "community": 5,
+      "community": 7,
       "norm_label": ".get_cpf()"
     },
     {
@@ -5058,7 +5058,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/cpf_validation/presentation/view.py",
       "source_location": "L66",
       "id": "presentation_view_cpfvalidationview_update_result",
-      "community": 5,
+      "community": 7,
       "norm_label": ".update_result()"
     },
     {
@@ -5067,7 +5067,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/status_bar/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_status_bar_init_py",
-      "community": 41,
+      "community": 43,
       "norm_label": "__init__.py"
     },
     {
@@ -5301,7 +5301,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_init_py",
-      "community": 42,
+      "community": 44,
       "norm_label": "__init__.py"
     },
     {
@@ -5310,7 +5310,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/_server.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_server_py",
-      "community": 15,
+      "community": 6,
       "norm_label": "_server.py"
     },
     {
@@ -5319,7 +5319,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/_server.py",
       "source_location": "L15",
       "id": "backend_server_handle_data_source_error",
-      "community": 15,
+      "community": 6,
       "norm_label": "handle_data_source_error()"
     },
     {
@@ -5328,7 +5328,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/_server.py",
       "source_location": "L21",
       "id": "backend_server_handle_backend_error",
-      "community": 15,
+      "community": 6,
       "norm_label": "handle_backend_error()"
     },
     {
@@ -5337,7 +5337,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/_server.py",
       "source_location": "L26",
       "id": "backend_server_handle_unexpected_error",
-      "community": 15,
+      "community": 6,
       "norm_label": "handle_unexpected_error()"
     },
     {
@@ -5346,7 +5346,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/_server.py",
       "source_location": "L34",
       "id": "backend_server_backendserver",
-      "community": 15,
+      "community": 6,
       "norm_label": "backendserver"
     },
     {
@@ -5355,7 +5355,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/_server.py",
       "source_location": "L35",
       "id": "backend_server_backendserver_execute",
-      "community": 15,
+      "community": 6,
       "norm_label": ".execute()"
     },
     {
@@ -5364,7 +5364,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_google_sheets.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_data_source_google_sheets_py",
-      "community": 1,
+      "community": 0,
       "norm_label": "_google_sheets.py"
     },
     {
@@ -5373,7 +5373,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_google_sheets.py",
       "source_location": "L15",
       "id": "data_source_google_sheets_googlesheetsdatasource",
-      "community": 1,
+      "community": 0,
       "norm_label": "googlesheetsdatasource"
     },
     {
@@ -5382,7 +5382,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_google_sheets.py",
       "source_location": "L18",
       "id": "data_source_google_sheets_googlesheetsdatasource_init",
-      "community": 1,
+      "community": 0,
       "norm_label": ".__init__()"
     },
     {
@@ -5391,7 +5391,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_google_sheets.py",
       "source_location": "L26",
       "id": "data_source_google_sheets_googlesheetsdatasource_is_ready",
-      "community": 1,
+      "community": 0,
       "norm_label": ".is_ready()"
     },
     {
@@ -5400,7 +5400,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_google_sheets.py",
       "source_location": "L29",
       "id": "data_source_google_sheets_googlesheetsdatasource_set_credentials",
-      "community": 1,
+      "community": 0,
       "norm_label": ".set_credentials()"
     },
     {
@@ -5409,7 +5409,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_google_sheets.py",
       "source_location": "L37",
       "id": "data_source_google_sheets_googlesheetsdatasource_clear_credentials",
-      "community": 1,
+      "community": 0,
       "norm_label": ".clear_credentials()"
     },
     {
@@ -5418,7 +5418,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_google_sheets.py",
       "source_location": "L41",
       "id": "data_source_google_sheets_googlesheetsdatasource_clear_sheet",
-      "community": 1,
+      "community": 0,
       "norm_label": ".clear_sheet()"
     },
     {
@@ -5427,7 +5427,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_google_sheets.py",
       "source_location": "L45",
       "id": "data_source_google_sheets_googlesheetsdatasource_set_sheet",
-      "community": 1,
+      "community": 0,
       "norm_label": ".set_sheet()"
     },
     {
@@ -5436,7 +5436,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_google_sheets.py",
       "source_location": "L51",
       "id": "data_source_google_sheets_googlesheetsdatasource_fetch_orders_by_date",
-      "community": 1,
+      "community": 0,
       "norm_label": ".fetch_orders_by_date()"
     },
     {
@@ -5445,7 +5445,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_google_sheets.py",
       "source_location": "L57",
       "id": "data_source_google_sheets_googlesheetsdatasource_fetch_orders_by_period",
-      "community": 1,
+      "community": 0,
       "norm_label": ".fetch_orders_by_period()"
     },
     {
@@ -5454,7 +5454,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_google_sheets.py",
       "source_location": "L67",
       "id": "data_source_google_sheets_googlesheetsdatasource_setup_vm",
-      "community": 1,
+      "community": 0,
       "norm_label": "._setup_vm()"
     },
     {
@@ -5462,7 +5462,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_google_sheets.py",
       "source_location": "L16",
-      "community": 1,
+      "community": 0,
       "norm_label": "implementacao de datasourceprotocol para google sheets via gspread.",
       "id": "data_source_google_sheets_rationale_16"
     },
@@ -5472,7 +5472,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_data_source_init_py",
-      "community": 1,
+      "community": 0,
       "norm_label": "__init__.py"
     },
     {
@@ -5481,7 +5481,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_protocol.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_data_source_protocol_py",
-      "community": 10,
+      "community": 9,
       "norm_label": "_protocol.py"
     },
     {
@@ -5490,7 +5490,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_protocol.py",
       "source_location": "L5",
       "id": "data_source_protocol_datasourceprotocol",
-      "community": 10,
+      "community": 9,
       "norm_label": "datasourceprotocol"
     },
     {
@@ -5499,7 +5499,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_protocol.py",
       "source_location": "L8",
       "id": "data_source_protocol_datasourceprotocol_is_ready",
-      "community": 10,
+      "community": 9,
       "norm_label": ".is_ready()"
     },
     {
@@ -5508,7 +5508,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_protocol.py",
       "source_location": "L12",
       "id": "data_source_protocol_datasourceprotocol_set_credentials",
-      "community": 10,
+      "community": 9,
       "norm_label": ".set_credentials()"
     },
     {
@@ -5517,7 +5517,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_protocol.py",
       "source_location": "L16",
       "id": "data_source_protocol_datasourceprotocol_clear_credentials",
-      "community": 10,
+      "community": 9,
       "norm_label": ".clear_credentials()"
     },
     {
@@ -5526,7 +5526,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_protocol.py",
       "source_location": "L20",
       "id": "data_source_protocol_datasourceprotocol_clear_sheet",
-      "community": 10,
+      "community": 9,
       "norm_label": ".clear_sheet()"
     },
     {
@@ -5535,7 +5535,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_protocol.py",
       "source_location": "L24",
       "id": "data_source_protocol_datasourceprotocol_set_sheet",
-      "community": 10,
+      "community": 9,
       "norm_label": ".set_sheet()"
     },
     {
@@ -5544,7 +5544,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_protocol.py",
       "source_location": "L28",
       "id": "data_source_protocol_datasourceprotocol_fetch_orders_by_date",
-      "community": 6,
+      "community": 9,
       "norm_label": ".fetch_orders_by_date()"
     },
     {
@@ -5553,7 +5553,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_protocol.py",
       "source_location": "L32",
       "id": "data_source_protocol_datasourceprotocol_fetch_orders_by_period",
-      "community": 7,
+      "community": 14,
       "norm_label": ".fetch_orders_by_period()"
     },
     {
@@ -5561,7 +5561,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_protocol.py",
       "source_location": "L6",
-      "community": 10,
+      "community": 9,
       "norm_label": "contrato agnostico de fonte de dados para pedidos.",
       "id": "data_source_protocol_rationale_6"
     },
@@ -5570,7 +5570,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_protocol.py",
       "source_location": "L9",
-      "community": 10,
+      "community": 9,
       "norm_label": "retorna true se credentials e sheet estao configurados em memoria.",
       "id": "data_source_protocol_rationale_9"
     },
@@ -5579,7 +5579,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_protocol.py",
       "source_location": "L13",
-      "community": 10,
+      "community": 9,
       "norm_label": "autentica com o dict da service account e guarda o client em memoria.",
       "id": "data_source_protocol_rationale_13"
     },
@@ -5588,7 +5588,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_protocol.py",
       "source_location": "L17",
-      "community": 10,
+      "community": 9,
       "norm_label": "remove o client autenticado da memoria. mantem o sheet_id.",
       "id": "data_source_protocol_rationale_17"
     },
@@ -5597,7 +5597,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_protocol.py",
       "source_location": "L21",
-      "community": 10,
+      "community": 9,
       "norm_label": "remove a planilha ativa da memoria. mantem as credenciais.",
       "id": "data_source_protocol_rationale_21"
     },
@@ -5606,7 +5606,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_protocol.py",
       "source_location": "L25",
-      "community": 10,
+      "community": 9,
       "norm_label": "define a planilha ativa e dispara prewarm em background.",
       "id": "data_source_protocol_rationale_25"
     },
@@ -5615,7 +5615,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_protocol.py",
       "source_location": "L29",
-      "community": 6,
+      "community": 9,
       "norm_label": "retorna pedidos da data informada (dd/mm/yyyy).",
       "id": "data_source_protocol_rationale_29"
     },
@@ -5624,7 +5624,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_protocol.py",
       "source_location": "L33",
-      "community": 7,
+      "community": 14,
       "norm_label": "retorna pedidos no intervalo de datas informado (dd/mm/yyyy).",
       "id": "data_source_protocol_rationale_33"
     },
@@ -5634,7 +5634,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/sheet_mapper.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_data_source_sheet_mapper_py",
-      "community": 1,
+      "community": 0,
       "norm_label": "sheet_mapper.py"
     },
     {
@@ -5643,7 +5643,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/sheet_mapper.py",
       "source_location": "L9",
       "id": "data_source_sheet_mapper_sheettabs",
-      "community": 3,
+      "community": 0,
       "norm_label": "sheettabs"
     },
     {
@@ -5652,7 +5652,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/sheet_mapper.py",
       "source_location": "L14",
       "id": "data_source_sheet_mapper_sheetcols",
-      "community": 3,
+      "community": 0,
       "norm_label": "sheetcols"
     },
     {
@@ -5661,7 +5661,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/sheet_mapper.py",
       "source_location": "L62",
       "id": "data_source_sheet_mapper_productcols",
-      "community": 3,
+      "community": 0,
       "norm_label": "productcols"
     },
     {
@@ -5670,7 +5670,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/sheet_mapper.py",
       "source_location": "L70",
       "id": "data_source_sheet_mapper_productcols_slot",
-      "community": 3,
+      "community": 0,
       "norm_label": ".slot()"
     },
     {
@@ -5679,7 +5679,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/sheet_mapper.py",
       "source_location": "L74",
       "id": "data_source_sheet_mapper_paymentcols",
-      "community": 7,
+      "community": 0,
       "norm_label": "paymentcols"
     },
     {
@@ -5688,7 +5688,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/sheet_mapper.py",
       "source_location": "L82",
       "id": "data_source_sheet_mapper_paymentcols_slot",
-      "community": 7,
+      "community": 10,
       "norm_label": ".slot()"
     },
     {
@@ -5696,7 +5696,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/sheet_mapper.py",
       "source_location": "L1",
-      "community": 1,
+      "community": 0,
       "norm_label": "mapeamento de colunas e tabs da planilha.",
       "id": "data_source_sheet_mapper_rationale_1"
     },
@@ -5705,7 +5705,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/sheet_mapper.py",
       "source_location": "L15",
-      "community": 3,
+      "community": 0,
       "norm_label": "colunas fixas da aba cadastro, agrupadas por dominio.",
       "id": "data_source_sheet_mapper_rationale_15"
     },
@@ -5714,7 +5714,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/sheet_mapper.py",
       "source_location": "L63",
-      "community": 3,
+      "community": 0,
       "norm_label": "colunas dos slots de produto (1\u20137). usar com .slot(n).",
       "id": "data_source_sheet_mapper_rationale_63"
     },
@@ -5723,7 +5723,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/sheet_mapper.py",
       "source_location": "L75",
-      "community": 7,
+      "community": 0,
       "norm_label": "colunas das parcelas de pagamento (1\u20136). usar com .slot(n).",
       "id": "data_source_sheet_mapper_rationale_75"
     },
@@ -5733,7 +5733,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_normalizer.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_data_source_normalizer_py",
-      "community": 1,
+      "community": 0,
       "norm_label": "_normalizer.py"
     },
     {
@@ -5742,7 +5742,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_normalizer.py",
       "source_location": "L6",
       "id": "data_source_normalizer_sheetnormalizer",
-      "community": 1,
+      "community": 0,
       "norm_label": "sheetnormalizer"
     },
     {
@@ -5751,7 +5751,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_normalizer.py",
       "source_location": "L20",
       "id": "data_source_normalizer_normalize",
-      "community": 1,
+      "community": 0,
       "norm_label": "normalize()"
     },
     {
@@ -5760,7 +5760,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_normalizer.py",
       "source_location": "L28",
       "id": "data_source_normalizer_rename_keys",
-      "community": 1,
+      "community": 0,
       "norm_label": "_rename_keys()"
     },
     {
@@ -5769,7 +5769,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_normalizer.py",
       "source_location": "L32",
       "id": "data_source_normalizer_fix_prod4",
-      "community": 1,
+      "community": 0,
       "norm_label": "_fix_prod4()"
     },
     {
@@ -5778,7 +5778,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_normalizer.py",
       "source_location": "L52",
       "id": "data_source_normalizer_rename_at",
-      "community": 1,
+      "community": 0,
       "norm_label": "_rename_at()"
     },
     {
@@ -5786,7 +5786,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_normalizer.py",
       "source_location": "L1",
-      "community": 1,
+      "community": 0,
       "norm_label": "normaliza headers inconsistentes da planilha para os valores canonicos dos enums",
       "id": "data_source_normalizer_rationale_1"
     },
@@ -5795,7 +5795,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_normalizer.py",
       "source_location": "L7",
-      "community": 1,
+      "community": 0,
       "norm_label": "traduz headers reais da planilha para os nomes canonicos definidos nos enums.",
       "id": "data_source_normalizer_rationale_7"
     },
@@ -5804,7 +5804,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_normalizer.py",
       "source_location": "L33",
-      "community": 43,
+      "community": 45,
       "norm_label": "renomeia a coluna que segue prod3 para prod4, independente do header atual.",
       "id": "data_source_normalizer_rationale_33"
     },
@@ -5814,7 +5814,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_viewmodel.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_data_source_viewmodel_py",
-      "community": 1,
+      "community": 0,
       "norm_label": "_viewmodel.py"
     },
     {
@@ -5823,7 +5823,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_viewmodel.py",
       "source_location": "L9",
       "id": "data_source_viewmodel_sheetsviewmodel",
-      "community": 1,
+      "community": 0,
       "norm_label": "_sheetsviewmodel"
     },
     {
@@ -5832,7 +5832,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_viewmodel.py",
       "source_location": "L12",
       "id": "data_source_viewmodel_sheetsviewmodel_init",
-      "community": 1,
+      "community": 0,
       "norm_label": ".__init__()"
     },
     {
@@ -5841,7 +5841,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_viewmodel.py",
       "source_location": "L19",
       "id": "data_source_viewmodel_database",
-      "community": 1,
+      "community": 0,
       "norm_label": "database()"
     },
     {
@@ -5850,7 +5850,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_viewmodel.py",
       "source_location": "L22",
       "id": "data_source_viewmodel_sheetsviewmodel_prewarm",
-      "community": 1,
+      "community": 0,
       "norm_label": ".prewarm()"
     },
     {
@@ -5859,7 +5859,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_viewmodel.py",
       "source_location": "L28",
       "id": "data_source_viewmodel_sheetsviewmodel_load_schema",
-      "community": 1,
+      "community": 0,
       "norm_label": "._load_schema()"
     },
     {
@@ -5868,7 +5868,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_viewmodel.py",
       "source_location": "L42",
       "id": "data_source_viewmodel_fetch",
-      "community": 1,
+      "community": 0,
       "norm_label": "fetch()"
     },
     {
@@ -5876,7 +5876,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_viewmodel.py",
       "source_location": "L10",
-      "community": 1,
+      "community": 0,
       "norm_label": "encapsula o acesso a planilha: schema cacheado, prewarm e fetch.",
       "id": "data_source_viewmodel_rationale_10"
     },
@@ -5885,7 +5885,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_viewmodel.py",
       "source_location": "L29",
-      "community": 1,
+      "community": 0,
       "norm_label": "carrega cabecalho e indice da coluna data na primeira chamada; no-op nas seguint",
       "id": "data_source_viewmodel_rationale_29"
     },
@@ -5894,206 +5894,224 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_viewmodel.py",
       "source_location": "L43",
-      "community": 44,
+      "community": 46,
       "norm_label": "busca pedidos por datas usando dois passes para minimizar chamadas a api.",
       "id": "data_source_viewmodel_rationale_43"
     },
     {
       "label": "_utils.py",
       "file_type": "code",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_utils.py",
+      "source_file": "backend/data_source/_utils.py",
       "source_location": "L1",
-      "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_data_source_utils_py",
-      "community": 1,
+      "id": "backend_data_source_utils_py",
+      "community": 0,
       "norm_label": "_utils.py"
+    },
+    {
+      "label": "DateFormat",
+      "file_type": "code",
+      "source_file": "backend/data_source/_utils.py",
+      "source_location": "L6",
+      "id": "data_source_utils_dateformat",
+      "community": 0,
+      "norm_label": "dateformat"
+    },
+    {
+      "label": "str",
+      "file_type": "code",
+      "source_file": "",
+      "source_location": "",
+      "id": "str",
+      "community": 10,
+      "norm_label": "str"
+    },
+    {
+      "label": "to_datetime()",
+      "file_type": "code",
+      "source_file": "backend/data_source/_utils.py",
+      "source_location": "L11",
+      "id": "data_source_utils_to_datetime",
+      "community": 0,
+      "norm_label": "to_datetime()"
     },
     {
       "label": "normalize_date()",
       "file_type": "code",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_utils.py",
-      "source_location": "L5",
+      "source_file": "backend/data_source/_utils.py",
+      "source_location": "L20",
       "id": "data_source_utils_normalize_date",
-      "community": 1,
+      "community": 0,
       "norm_label": "normalize_date()"
     },
     {
       "label": "to_dicts()",
       "file_type": "code",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_utils.py",
-      "source_location": "L15",
+      "source_file": "backend/data_source/_utils.py",
+      "source_location": "L30",
       "id": "data_source_utils_to_dicts",
-      "community": 1,
+      "community": 0,
       "norm_label": "to_dicts()"
     },
     {
       "label": "to_ranges()",
       "file_type": "code",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_utils.py",
-      "source_location": "L21",
+      "source_file": "backend/data_source/_utils.py",
+      "source_location": "L36",
       "id": "data_source_utils_to_ranges",
-      "community": 1,
+      "community": 0,
       "norm_label": "to_ranges()"
     },
     {
       "label": "date_range()",
       "file_type": "code",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_utils.py",
-      "source_location": "L34",
+      "source_file": "backend/data_source/_utils.py",
+      "source_location": "L49",
       "id": "data_source_utils_date_range",
-      "community": 1,
+      "community": 0,
       "norm_label": "date_range()"
     },
     {
       "label": "Normaliza uma data para DD/MM/YYYY aceitando os formatos DD/MM/YY e DD/MM/YYYY.",
       "file_type": "rationale",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_utils.py",
-      "source_location": "L6",
-      "community": 1,
-      "norm_label": "normaliza uma data para dd/mm/yyyy aceitando os formatos dd/mm/yy e dd/mm/yyyy.",
-      "id": "data_source_utils_rationale_6"
+      "source_file": "backend/data_source/_utils.py",
+      "source_location": "L21",
+      "id": "data_source_utils_rationale_21",
+      "community": 0,
+      "norm_label": "normaliza uma data para dd/mm/yyyy aceitando os formatos dd/mm/yy e dd/mm/yyyy."
     },
     {
       "label": "Converte linhas da planilha em lista de dicts usando o cabe\u00e7alho como chaves (lo",
       "file_type": "rationale",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_utils.py",
-      "source_location": "L16",
-      "community": 1,
-      "norm_label": "converte linhas da planilha em lista de dicts usando o cabecalho como chaves (lo",
-      "id": "data_source_utils_rationale_16"
+      "source_file": "backend/data_source/_utils.py",
+      "source_location": "L31",
+      "id": "data_source_utils_rationale_31",
+      "community": 0,
+      "norm_label": "converte linhas da planilha em lista de dicts usando o cabecalho como chaves (lo"
     },
     {
       "label": "Agrupa n\u00fameros de linha consecutivos em ranges A1 notation e divide em batches d",
       "file_type": "rationale",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_utils.py",
-      "source_location": "L22",
-      "community": 1,
-      "norm_label": "agrupa numeros de linha consecutivos em ranges a1 notation e divide em batches d",
-      "id": "data_source_utils_rationale_22"
+      "source_file": "backend/data_source/_utils.py",
+      "source_location": "L37",
+      "id": "data_source_utils_rationale_37",
+      "community": 0,
+      "norm_label": "agrupa numeros de linha consecutivos em ranges a1 notation e divide em batches d"
     },
     {
       "label": "Retorna o conjunto de todas as datas (DD/MM/YYYY) entre start e end, inclusive.",
       "file_type": "rationale",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_utils.py",
-      "source_location": "L35",
-      "community": 1,
-      "norm_label": "retorna o conjunto de todas as datas (dd/mm/yyyy) entre start e end, inclusive.",
-      "id": "data_source_utils_rationale_35"
+      "source_file": "backend/data_source/_utils.py",
+      "source_location": "L50",
+      "id": "data_source_utils_rationale_50",
+      "community": 0,
+      "norm_label": "retorna o conjunto de todas as datas (dd/mm/yyyy) entre start e end, inclusive."
     },
     {
       "label": "_handler.py",
       "file_type": "code",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_handler.py",
+      "source_file": "backend/data_source/errors/_handler.py",
       "source_location": "L1",
-      "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_data_source_errors_handler_py",
-      "community": 1,
+      "id": "backend_data_source_errors_handler_py",
+      "community": 0,
       "norm_label": "_handler.py"
     },
     {
       "label": "_is_valid_date()",
       "file_type": "code",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_handler.py",
-      "source_location": "L14",
+      "source_file": "backend/data_source/errors/_handler.py",
+      "source_location": "L13",
       "id": "errors_handler_is_valid_date",
-      "community": 1,
+      "community": 0,
       "norm_label": "_is_valid_date()"
-    },
-    {
-      "label": "_parse_date()",
-      "file_type": "code",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_handler.py",
-      "source_location": "L18",
-      "id": "errors_handler_parse_date",
-      "community": 1,
-      "norm_label": "_parse_date()"
     },
     {
       "label": "_SheetsGuard",
       "file_type": "code",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_handler.py",
-      "source_location": "L22",
+      "source_file": "backend/data_source/errors/_handler.py",
+      "source_location": "L17",
       "id": "errors_handler_sheetsguard",
-      "community": 1,
+      "community": 0,
       "norm_label": "_sheetsguard"
     },
     {
       "label": "credentials_file()",
       "file_type": "code",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_handler.py",
-      "source_location": "L27",
+      "source_file": "backend/data_source/errors/_handler.py",
+      "source_location": "L22",
       "id": "errors_handler_credentials_file",
-      "community": 1,
+      "community": 0,
       "norm_label": "credentials_file()"
     },
     {
       "label": "local_storage()",
       "file_type": "code",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_handler.py",
-      "source_location": "L34",
+      "source_file": "backend/data_source/errors/_handler.py",
+      "source_location": "L29",
       "id": "errors_handler_local_storage",
-      "community": 1,
+      "community": 0,
       "norm_label": "local_storage()"
     },
     {
       "label": "authentication()",
       "file_type": "code",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_handler.py",
-      "source_location": "L41",
+      "source_file": "backend/data_source/errors/_handler.py",
+      "source_location": "L36",
       "id": "errors_handler_authentication",
-      "community": 1,
+      "community": 0,
       "norm_label": "authentication()"
     },
     {
       "label": ".validate_credentials()",
       "file_type": "code",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_handler.py",
-      "source_location": "L55",
+      "source_file": "backend/data_source/errors/_handler.py",
+      "source_location": "L50",
       "id": "errors_handler_sheetsguard_validate_credentials",
-      "community": 1,
+      "community": 0,
       "norm_label": ".validate_credentials()"
     },
     {
       "label": ".validate_sheet_id()",
       "file_type": "code",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_handler.py",
-      "source_location": "L59",
+      "source_file": "backend/data_source/errors/_handler.py",
+      "source_location": "L54",
       "id": "errors_handler_sheetsguard_validate_sheet_id",
-      "community": 1,
+      "community": 0,
       "norm_label": ".validate_sheet_id()"
     },
     {
       "label": ".validate_date()",
       "file_type": "code",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_handler.py",
-      "source_location": "L63",
+      "source_file": "backend/data_source/errors/_handler.py",
+      "source_location": "L58",
       "id": "errors_handler_sheetsguard_validate_date",
-      "community": 1,
+      "community": 0,
       "norm_label": ".validate_date()"
     },
     {
       "label": ".validate_date_range()",
       "file_type": "code",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_handler.py",
-      "source_location": "L67",
+      "source_file": "backend/data_source/errors/_handler.py",
+      "source_location": "L62",
       "id": "errors_handler_sheetsguard_validate_date_range",
-      "community": 1,
+      "community": 0,
       "norm_label": ".validate_date_range()"
     },
     {
       "label": "handle_api()",
       "file_type": "code",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_handler.py",
-      "source_location": "L77",
+      "source_file": "backend/data_source/errors/_handler.py",
+      "source_location": "L72",
       "id": "errors_handler_handle_api",
-      "community": 1,
+      "community": 0,
       "norm_label": "handle_api()"
     },
     {
       "label": "handle_sheet_setup()",
       "file_type": "code",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_handler.py",
-      "source_location": "L95",
+      "source_file": "backend/data_source/errors/_handler.py",
+      "source_location": "L90",
       "id": "errors_handler_handle_sheet_setup",
-      "community": 1,
+      "community": 0,
       "norm_label": "handle_sheet_setup()"
     },
     {
@@ -6102,7 +6120,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_data_source_errors_errors_py",
-      "community": 1,
+      "community": 0,
       "norm_label": "_errors.py"
     },
     {
@@ -6111,7 +6129,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L1",
       "id": "errors_errors_datasourceerror",
-      "community": 1,
+      "community": 0,
       "norm_label": "datasourceerror"
     },
     {
@@ -6120,7 +6138,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L7",
       "id": "errors_errors_credentialsfilenotfounderror",
-      "community": 1,
+      "community": 0,
       "norm_label": "credentialsfilenotfounderror"
     },
     {
@@ -6129,7 +6147,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L12",
       "id": "errors_errors_credentialsfilenotfounderror_init",
-      "community": 1,
+      "community": 0,
       "norm_label": ".__init__()"
     },
     {
@@ -6138,7 +6156,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L17",
       "id": "errors_errors_credentialssaveerror",
-      "community": 1,
+      "community": 0,
       "norm_label": "credentialssaveerror"
     },
     {
@@ -6147,7 +6165,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L22",
       "id": "errors_errors_credentialssaveerror_init",
-      "community": 1,
+      "community": 0,
       "norm_label": ".__init__()"
     },
     {
@@ -6156,7 +6174,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L26",
       "id": "errors_errors_credentialsfilecorruptederror",
-      "community": 1,
+      "community": 0,
       "norm_label": "credentialsfilecorruptederror"
     },
     {
@@ -6165,7 +6183,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L31",
       "id": "errors_errors_credentialsfilecorruptederror_init",
-      "community": 1,
+      "community": 0,
       "norm_label": ".__init__()"
     },
     {
@@ -6174,7 +6192,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L35",
       "id": "errors_errors_credentialsformaterror",
-      "community": 1,
+      "community": 0,
       "norm_label": "credentialsformaterror"
     },
     {
@@ -6183,7 +6201,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L40",
       "id": "errors_errors_credentialsformaterror_init",
-      "community": 1,
+      "community": 0,
       "norm_label": ".__init__()"
     },
     {
@@ -6192,7 +6210,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L44",
       "id": "errors_errors_invalidcredentialserror",
-      "community": 1,
+      "community": 0,
       "norm_label": "invalidcredentialserror"
     },
     {
@@ -6201,7 +6219,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L49",
       "id": "errors_errors_invalidcredentialserror_init",
-      "community": 1,
+      "community": 0,
       "norm_label": ".__init__()"
     },
     {
@@ -6210,7 +6228,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L53",
       "id": "errors_errors_networkunavailableerror",
-      "community": 1,
+      "community": 0,
       "norm_label": "networkunavailableerror"
     },
     {
@@ -6219,7 +6237,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L58",
       "id": "errors_errors_networkunavailableerror_init",
-      "community": 1,
+      "community": 0,
       "norm_label": ".__init__()"
     },
     {
@@ -6228,7 +6246,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L62",
       "id": "errors_errors_networktimeouterror",
-      "community": 1,
+      "community": 0,
       "norm_label": "networktimeouterror"
     },
     {
@@ -6237,7 +6255,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L67",
       "id": "errors_errors_networktimeouterror_init",
-      "community": 1,
+      "community": 0,
       "norm_label": ".__init__()"
     },
     {
@@ -6246,7 +6264,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L71",
       "id": "errors_errors_tokenexpirederror",
-      "community": 1,
+      "community": 0,
       "norm_label": "tokenexpirederror"
     },
     {
@@ -6255,7 +6273,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L76",
       "id": "errors_errors_tokenexpirederror_init",
-      "community": 1,
+      "community": 0,
       "norm_label": ".__init__()"
     },
     {
@@ -6264,7 +6282,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L80",
       "id": "errors_errors_sheetidinvaliderror",
-      "community": 1,
+      "community": 0,
       "norm_label": "sheetidinvaliderror"
     },
     {
@@ -6273,7 +6291,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L85",
       "id": "errors_errors_sheetidinvaliderror_init",
-      "community": 1,
+      "community": 0,
       "norm_label": ".__init__()"
     },
     {
@@ -6282,7 +6300,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L90",
       "id": "errors_errors_sheetnotfounderror",
-      "community": 1,
+      "community": 0,
       "norm_label": "sheetnotfounderror"
     },
     {
@@ -6291,7 +6309,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L95",
       "id": "errors_errors_sheetnotfounderror_init",
-      "community": 1,
+      "community": 0,
       "norm_label": ".__init__()"
     },
     {
@@ -6300,7 +6318,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L99",
       "id": "errors_errors_sheetaccessdeniederror",
-      "community": 1,
+      "community": 0,
       "norm_label": "sheetaccessdeniederror"
     },
     {
@@ -6309,7 +6327,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L104",
       "id": "errors_errors_sheetaccessdeniederror_init",
-      "community": 1,
+      "community": 0,
       "norm_label": ".__init__()"
     },
     {
@@ -6318,7 +6336,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L108",
       "id": "errors_errors_invaliddateformaterror",
-      "community": 1,
+      "community": 0,
       "norm_label": "invaliddateformaterror"
     },
     {
@@ -6327,7 +6345,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L113",
       "id": "errors_errors_invaliddateformaterror_init",
-      "community": 1,
+      "community": 0,
       "norm_label": ".__init__()"
     },
     {
@@ -6336,7 +6354,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L118",
       "id": "errors_errors_invaliddaterangeerror",
-      "community": 1,
+      "community": 0,
       "norm_label": "invaliddaterangeerror"
     },
     {
@@ -6345,7 +6363,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L123",
       "id": "errors_errors_invaliddaterangeerror_init",
-      "community": 1,
+      "community": 0,
       "norm_label": ".__init__()"
     },
     {
@@ -6354,7 +6372,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L129",
       "id": "errors_errors_apiquotaexceedederror",
-      "community": 1,
+      "community": 0,
       "norm_label": "apiquotaexceedederror"
     },
     {
@@ -6363,7 +6381,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L134",
       "id": "errors_errors_apiquotaexceedederror_init",
-      "community": 1,
+      "community": 0,
       "norm_label": ".__init__()"
     },
     {
@@ -6372,7 +6390,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L138",
       "id": "errors_errors_apiunexpectedresponseerror",
-      "community": 1,
+      "community": 0,
       "norm_label": "apiunexpectedresponseerror"
     },
     {
@@ -6381,7 +6399,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L143",
       "id": "errors_errors_apiunexpectedresponseerror_init",
-      "community": 1,
+      "community": 0,
       "norm_label": ".__init__()"
     },
     {
@@ -6390,7 +6408,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L148",
       "id": "errors_errors_unexpectedsheetstructureerror",
-      "community": 1,
+      "community": 0,
       "norm_label": "unexpectedsheetstructureerror"
     },
     {
@@ -6399,7 +6417,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L153",
       "id": "errors_errors_unexpectedsheetstructureerror_init",
-      "community": 1,
+      "community": 0,
       "norm_label": ".__init__()"
     },
     {
@@ -6408,7 +6426,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L159",
       "id": "errors_errors_prewarmfailederror",
-      "community": 1,
+      "community": 0,
       "norm_label": "prewarmfailederror"
     },
     {
@@ -6417,7 +6435,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L164",
       "id": "errors_errors_prewarmfailederror_init",
-      "community": 1,
+      "community": 0,
       "norm_label": ".__init__()"
     },
     {
@@ -6426,7 +6444,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L169",
       "id": "errors_errors_datasourcenotreadyerror",
-      "community": 1,
+      "community": 0,
       "norm_label": "datasourcenotreadyerror"
     },
     {
@@ -6435,7 +6453,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_errors.py",
       "source_location": "L174",
       "id": "errors_errors_datasourcenotreadyerror_init",
-      "community": 1,
+      "community": 0,
       "norm_label": ".__init__()"
     },
     {
@@ -6444,7 +6462,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_features_init_py",
-      "community": 45,
+      "community": 47,
       "norm_label": "__init__.py"
     },
     {
@@ -6453,7 +6471,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/auth/service.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_features_auth_service_py",
-      "community": 10,
+      "community": 9,
       "norm_label": "service.py"
     },
     {
@@ -6462,7 +6480,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/auth/service.py",
       "source_location": "L6",
       "id": "auth_service_authservice",
-      "community": 10,
+      "community": 9,
       "norm_label": "authservice"
     },
     {
@@ -6471,7 +6489,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/auth/service.py",
       "source_location": "L7",
       "id": "auth_service_authservice_connect",
-      "community": 10,
+      "community": 9,
       "norm_label": ".connect()"
     },
     {
@@ -6480,7 +6498,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/auth/service.py",
       "source_location": "L12",
       "id": "auth_service_authservice_disconnect",
-      "community": 10,
+      "community": 9,
       "norm_label": ".disconnect()"
     },
     {
@@ -6488,7 +6506,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/auth/service.py",
       "source_location": "L1",
-      "community": 10,
+      "community": 9,
       "norm_label": "service de autenticacao \u2014 gerencia o estado de conexao do datasource.",
       "id": "auth_service_rationale_1"
     },
@@ -6498,7 +6516,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/auth/route.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_features_auth_route_py",
-      "community": 10,
+      "community": 9,
       "norm_label": "route.py"
     },
     {
@@ -6507,7 +6525,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/auth/route.py",
       "source_location": "L12",
       "id": "auth_route_connect",
-      "community": 5,
+      "community": 3,
       "norm_label": "connect()"
     },
     {
@@ -6516,7 +6534,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/auth/route.py",
       "source_location": "L19",
       "id": "auth_route_disconnect",
-      "community": 10,
+      "community": 9,
       "norm_label": "disconnect()"
     },
     {
@@ -6524,7 +6542,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/auth/route.py",
       "source_location": "L1",
-      "community": 10,
+      "community": 9,
       "norm_label": "rotas de autenticacao",
       "id": "auth_route_rationale_1"
     },
@@ -6534,7 +6552,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/auth/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_features_auth_init_py",
-      "community": 10,
+      "community": 9,
       "norm_label": "__init__.py"
     },
     {
@@ -6543,7 +6561,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_features_orders_init_py",
-      "community": 1,
+      "community": 0,
       "norm_label": "__init__.py"
     },
     {
@@ -6552,7 +6570,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/__init__.py",
       "source_location": "L14",
       "id": "orders_init_check_connection",
-      "community": 1,
+      "community": 0,
       "norm_label": "check_connection()"
     },
     {
@@ -6561,7 +6579,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/shared/models.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_features_orders_shared_models_py",
-      "community": 7,
+      "community": 10,
       "norm_label": "models.py"
     },
     {
@@ -6570,7 +6588,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/shared/models.py",
       "source_location": "L5",
       "id": "shared_models_address",
-      "community": 7,
+      "community": 10,
       "norm_label": "address"
     },
     {
@@ -6579,7 +6597,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/shared/models.py",
       "source_location": "L18",
       "id": "shared_models_event",
-      "community": 7,
+      "community": 10,
       "norm_label": "event"
     },
     {
@@ -6588,7 +6606,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/shared/models.py",
       "source_location": "L24",
       "id": "shared_models_customer",
-      "community": 7,
+      "community": 10,
       "norm_label": "customer"
     },
     {
@@ -6597,7 +6615,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/shared/models.py",
       "source_location": "L33",
       "id": "shared_models_receiver",
-      "community": 7,
+      "community": 10,
       "norm_label": "receiver"
     },
     {
@@ -6606,7 +6624,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/shared/models.py",
       "source_location": "L40",
       "id": "shared_models_customization",
-      "community": 7,
+      "community": 10,
       "norm_label": "customization"
     },
     {
@@ -6615,7 +6633,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/shared/models.py",
       "source_location": "L48",
       "id": "shared_models_productitem",
-      "community": 7,
+      "community": 10,
       "norm_label": "productitem"
     },
     {
@@ -6624,7 +6642,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/shared/models.py",
       "source_location": "L56",
       "id": "shared_models_paymentitem",
-      "community": 7,
+      "community": 10,
       "norm_label": "paymentitem"
     },
     {
@@ -6633,7 +6651,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/shared/models.py",
       "source_location": "L65",
       "id": "shared_models_financial",
-      "community": 7,
+      "community": 10,
       "norm_label": "financial"
     },
     {
@@ -6642,7 +6660,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/shared/models.py",
       "source_location": "L76",
       "id": "shared_models_delivery",
-      "community": 7,
+      "community": 10,
       "norm_label": "delivery"
     },
     {
@@ -6651,7 +6669,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/shared/models.py",
       "source_location": "L86",
       "id": "shared_models_order",
-      "community": 7,
+      "community": 10,
       "norm_label": "order"
     },
     {
@@ -6660,7 +6678,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/shared/mapper.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_features_orders_shared_mapper_py",
-      "community": 7,
+      "community": 10,
       "norm_label": "mapper.py"
     },
     {
@@ -6669,7 +6687,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/shared/mapper.py",
       "source_location": "L11",
       "id": "shared_mapper_ordermapper",
-      "community": 7,
+      "community": 10,
       "norm_label": "ordermapper"
     },
     {
@@ -6678,7 +6696,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/shared/mapper.py",
       "source_location": "L15",
       "id": "shared_mapper_to_model",
-      "community": 7,
+      "community": 10,
       "norm_label": "to_model()"
     },
     {
@@ -6687,7 +6705,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/shared/mapper.py",
       "source_location": "L32",
       "id": "shared_mapper_customer",
-      "community": 7,
+      "community": 10,
       "norm_label": "_customer()"
     },
     {
@@ -6696,7 +6714,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/shared/mapper.py",
       "source_location": "L42",
       "id": "shared_mapper_receiver",
-      "community": 7,
+      "community": 10,
       "norm_label": "_receiver()"
     },
     {
@@ -6705,7 +6723,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/shared/mapper.py",
       "source_location": "L53",
       "id": "shared_mapper_customization",
-      "community": 7,
+      "community": 10,
       "norm_label": "_customization()"
     },
     {
@@ -6714,7 +6732,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/shared/mapper.py",
       "source_location": "L62",
       "id": "shared_mapper_products",
-      "community": 7,
+      "community": 10,
       "norm_label": "_products()"
     },
     {
@@ -6723,7 +6741,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/shared/mapper.py",
       "source_location": "L77",
       "id": "shared_mapper_payments",
-      "community": 7,
+      "community": 10,
       "norm_label": "_payments()"
     },
     {
@@ -6732,7 +6750,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/shared/mapper.py",
       "source_location": "L94",
       "id": "shared_mapper_financial",
-      "community": 7,
+      "community": 10,
       "norm_label": "_financial()"
     },
     {
@@ -6741,7 +6759,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/shared/mapper.py",
       "source_location": "L106",
       "id": "shared_mapper_delivery",
-      "community": 7,
+      "community": 10,
       "norm_label": "_delivery()"
     },
     {
@@ -6749,7 +6767,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/shared/mapper.py",
       "source_location": "L1",
-      "community": 7,
+      "community": 10,
       "norm_label": "mapeamento de uma linha do dataframe para o model order.",
       "id": "shared_mapper_rationale_1"
     },
@@ -6758,7 +6776,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/shared/mapper.py",
       "source_location": "L12",
-      "community": 7,
+      "community": 10,
       "norm_label": "converte uma linha do dataframe (vinda do sheetsrepository) em um order.",
       "id": "shared_mapper_rationale_12"
     },
@@ -6767,7 +6785,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/shared/mapper.py",
       "source_location": "L16",
-      "community": 46,
+      "community": 48,
       "norm_label": "monta um order completo a partir de uma linha do dataframe.",
       "id": "shared_mapper_rationale_16"
     },
@@ -6777,7 +6795,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/shared/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_features_orders_shared_init_py",
-      "community": 7,
+      "community": 10,
       "norm_label": "__init__.py"
     },
     {
@@ -6795,7 +6813,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/payments/service.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_features_orders_subfeatures_payments_service_py",
-      "community": 6,
+      "community": 18,
       "norm_label": "service.py"
     },
     {
@@ -6804,7 +6822,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/payments/service.py",
       "source_location": "L10",
       "id": "payments_service_paymentsmapper",
-      "community": 6,
+      "community": 18,
       "norm_label": "paymentsmapper"
     },
     {
@@ -6813,7 +6831,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/payments/service.py",
       "source_location": "L14",
       "id": "payments_service_to_response",
-      "community": 6,
+      "community": 18,
       "norm_label": "to_response()"
     },
     {
@@ -6822,7 +6840,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/payments/service.py",
       "source_location": "L21",
       "id": "payments_service_paymentsservice",
-      "community": 6,
+      "community": 18,
       "norm_label": "paymentsservice"
     },
     {
@@ -6831,7 +6849,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/payments/service.py",
       "source_location": "L24",
       "id": "payments_service_paymentsservice_init",
-      "community": 6,
+      "community": 18,
       "norm_label": ".__init__()"
     },
     {
@@ -6848,7 +6866,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/payments/service.py",
       "source_location": "L1",
-      "community": 6,
+      "community": 18,
       "norm_label": "service e mapper de pagamentos pendentes.",
       "id": "payments_service_rationale_1"
     },
@@ -6857,7 +6875,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/payments/service.py",
       "source_location": "L11",
-      "community": 6,
+      "community": 18,
       "norm_label": "serializa o resultado do paymentsservice para dict json-ready.",
       "id": "payments_service_rationale_11"
     },
@@ -6866,7 +6884,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/payments/service.py",
       "source_location": "L22",
-      "community": 6,
+      "community": 18,
       "norm_label": "filtra pedidos com pagamento pendente e monta os objetos de dominio.",
       "id": "payments_service_rationale_22"
     },
@@ -6912,7 +6930,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/payments/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_features_orders_subfeatures_payments_init_py",
-      "community": 47,
+      "community": 49,
       "norm_label": "__init__.py"
     },
     {
@@ -6921,7 +6939,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/payments/repository.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_features_orders_subfeatures_payments_repository_py",
-      "community": 6,
+      "community": 18,
       "norm_label": "repository.py"
     },
     {
@@ -6930,7 +6948,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/payments/repository.py",
       "source_location": "L11",
       "id": "payments_repository_paymentsrepository",
-      "community": 6,
+      "community": 18,
       "norm_label": "paymentsrepository"
     },
     {
@@ -6939,7 +6957,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/payments/repository.py",
       "source_location": "L17",
       "id": "payments_repository_paymentsrepository_get_by_date",
-      "community": 6,
+      "community": 18,
       "norm_label": ".get_by_date()"
     },
     {
@@ -6948,7 +6966,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/payments/repository.py",
       "source_location": "L25",
       "id": "payments_repository_to_dataframe",
-      "community": 6,
+      "community": 18,
       "norm_label": "_to_dataframe()"
     },
     {
@@ -6957,7 +6975,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/payments/repository.py",
       "source_location": "L51",
       "id": "payments_repository_cast_numeric",
-      "community": 6,
+      "community": 18,
       "norm_label": "_cast_numeric()"
     },
     {
@@ -6965,7 +6983,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/payments/repository.py",
       "source_location": "L1",
-      "community": 6,
+      "community": 18,
       "norm_label": "repositorio de pagamentos \u2014 busca e prepara dados da planilha para o paymentsser",
       "id": "payments_repository_rationale_1"
     },
@@ -6974,7 +6992,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/payments/repository.py",
       "source_location": "L12",
-      "community": 6,
+      "community": 18,
       "norm_label": "acessa o data source e entrega um dataframe tipado para o paymentsservice.",
       "id": "payments_repository_rationale_12"
     },
@@ -6983,7 +7001,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/payments/repository.py",
       "source_location": "L18",
-      "community": 6,
+      "community": 18,
       "norm_label": "retorna todos os pedidos de uma data com colunas numericas convertidas para floa",
       "id": "payments_repository_rationale_18"
     },
@@ -6992,7 +7010,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/payments/repository.py",
       "source_location": "L26",
-      "community": 48,
+      "community": 50,
       "norm_label": "converte list[dict] em dataframe com cast numerico de todas as colunas de valor.",
       "id": "payments_repository_rationale_26"
     },
@@ -7001,62 +7019,62 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/payments/repository.py",
       "source_location": "L52",
-      "community": 49,
+      "community": 51,
       "norm_label": "faz cast numerico de uma coluna se ela existir no dataframe.",
       "id": "payments_repository_rationale_52"
     },
     {
       "label": "service.py",
       "file_type": "code",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/summary/service.py",
+      "source_file": "backend/features/orders/subfeatures/summary/service.py",
       "source_location": "L1",
-      "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_features_orders_subfeatures_summary_service_py",
-      "community": 7,
+      "id": "backend_features_orders_subfeatures_summary_service_py",
+      "community": 14,
       "norm_label": "service.py"
     },
     {
       "label": "OrdersMapper",
       "file_type": "code",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/summary/service.py",
-      "source_location": "L9",
+      "source_file": "backend/features/orders/subfeatures/summary/service.py",
+      "source_location": "L10",
       "id": "summary_service_ordersmapper",
-      "community": 7,
+      "community": 14,
       "norm_label": "ordersmapper"
     },
     {
       "label": "to_response()",
       "file_type": "code",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/summary/service.py",
-      "source_location": "L13",
+      "source_file": "backend/features/orders/subfeatures/summary/service.py",
+      "source_location": "L14",
       "id": "summary_service_to_response",
-      "community": 7,
+      "community": 14,
       "norm_label": "to_response()"
     },
     {
       "label": "OrdersService",
       "file_type": "code",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/summary/service.py",
-      "source_location": "L20",
+      "source_file": "backend/features/orders/subfeatures/summary/service.py",
+      "source_location": "L21",
       "id": "summary_service_ordersservice",
-      "community": 7,
+      "community": 14,
       "norm_label": "ordersservice"
     },
     {
       "label": ".__init__()",
       "file_type": "code",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/summary/service.py",
-      "source_location": "L23",
+      "source_file": "backend/features/orders/subfeatures/summary/service.py",
+      "source_location": "L24",
       "id": "summary_service_ordersservice_init",
-      "community": 7,
+      "community": 14,
       "norm_label": ".__init__()"
     },
     {
       "label": ".get_by_period()",
       "file_type": "code",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/summary/service.py",
-      "source_location": "L26",
+      "source_file": "backend/features/orders/subfeatures/summary/service.py",
+      "source_location": "L27",
       "id": "summary_service_ordersservice_get_by_period",
-      "community": 7,
+      "community": 14,
       "norm_label": ".get_by_period()"
     },
     {
@@ -7064,36 +7082,36 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/summary/service.py",
       "source_location": "L1",
-      "community": 7,
+      "community": 14,
       "norm_label": "service e mapper de resumo de pedidos por periodo.",
       "id": "summary_service_rationale_1"
     },
     {
       "label": "Serializa o resultado do OrdersService para dict JSON-ready.",
       "file_type": "rationale",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/summary/service.py",
-      "source_location": "L10",
-      "community": 7,
-      "norm_label": "serializa o resultado do ordersservice para dict json-ready.",
-      "id": "summary_service_rationale_10"
+      "source_file": "backend/features/orders/subfeatures/summary/service.py",
+      "source_location": "L11",
+      "id": "summary_service_rationale_11",
+      "community": 14,
+      "norm_label": "serializa o resultado do ordersservice para dict json-ready."
     },
     {
       "label": "Busca e monta os pedidos de um per\u00edodo.",
       "file_type": "rationale",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/summary/service.py",
-      "source_location": "L21",
-      "community": 7,
-      "norm_label": "busca e monta os pedidos de um periodo.",
-      "id": "summary_service_rationale_21"
+      "source_file": "backend/features/orders/subfeatures/summary/service.py",
+      "source_location": "L22",
+      "id": "summary_service_rationale_22",
+      "community": 14,
+      "norm_label": "busca e monta os pedidos de um periodo."
     },
     {
       "label": "Retorna todos os pedidos do per\u00edodo informado.",
       "file_type": "rationale",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/summary/service.py",
-      "source_location": "L27",
-      "community": 7,
-      "norm_label": "retorna todos os pedidos do periodo informado.",
-      "id": "summary_service_rationale_27"
+      "source_file": "backend/features/orders/subfeatures/summary/service.py",
+      "source_location": "L28",
+      "id": "summary_service_rationale_28",
+      "community": 14,
+      "norm_label": "retorna todos os pedidos do periodo informado."
     },
     {
       "label": "route.py",
@@ -7128,7 +7146,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/summary/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_features_orders_subfeatures_summary_init_py",
-      "community": 50,
+      "community": 52,
       "norm_label": "__init__.py"
     },
     {
@@ -7137,7 +7155,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/summary/repository.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_features_orders_subfeatures_summary_repository_py",
-      "community": 7,
+      "community": 14,
       "norm_label": "repository.py"
     },
     {
@@ -7146,7 +7164,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/summary/repository.py",
       "source_location": "L11",
       "id": "summary_repository_orderssummaryrepository",
-      "community": 7,
+      "community": 14,
       "norm_label": "orderssummaryrepository"
     },
     {
@@ -7155,7 +7173,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/summary/repository.py",
       "source_location": "L17",
       "id": "summary_repository_orderssummaryrepository_get_by_period",
-      "community": 7,
+      "community": 14,
       "norm_label": ".get_by_period()"
     },
     {
@@ -7164,7 +7182,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/summary/repository.py",
       "source_location": "L25",
       "id": "summary_repository_to_dataframe",
-      "community": 7,
+      "community": 14,
       "norm_label": "_to_dataframe()"
     },
     {
@@ -7173,7 +7191,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/summary/repository.py",
       "source_location": "L50",
       "id": "summary_repository_cast_numeric",
-      "community": 7,
+      "community": 14,
       "norm_label": "_cast_numeric()"
     },
     {
@@ -7181,7 +7199,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/summary/repository.py",
       "source_location": "L1",
-      "community": 7,
+      "community": 14,
       "norm_label": "repositorio de pedidos por periodo \u2014 busca e prepara dados da planilha para o or",
       "id": "summary_repository_rationale_1"
     },
@@ -7190,7 +7208,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/summary/repository.py",
       "source_location": "L12",
-      "community": 7,
+      "community": 14,
       "norm_label": "acessa o data source e entrega um dataframe tipado para o ordersservice.      un",
       "id": "summary_repository_rationale_12"
     },
@@ -7199,7 +7217,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/summary/repository.py",
       "source_location": "L18",
-      "community": 7,
+      "community": 14,
       "norm_label": "retorna todos os pedidos de um periodo com colunas numericas convertidas para fl",
       "id": "summary_repository_rationale_18"
     },
@@ -7208,7 +7226,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/summary/repository.py",
       "source_location": "L26",
-      "community": 51,
+      "community": 53,
       "norm_label": "converte list[dict] em dataframe com cast numerico de todas as colunas de valor.",
       "id": "summary_repository_rationale_26"
     },
@@ -7217,7 +7235,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/summary/repository.py",
       "source_location": "L51",
-      "community": 52,
+      "community": 54,
       "norm_label": "faz cast numerico de uma coluna se ela existir no dataframe.",
       "id": "summary_repository_rationale_51"
     },
@@ -7380,7 +7398,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/deliveries/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_features_orders_subfeatures_deliveries_init_py",
-      "community": 53,
+      "community": 55,
       "norm_label": "__init__.py"
     },
     {
@@ -7443,7 +7461,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/sheet/service.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_features_sheet_service_py",
-      "community": 10,
+      "community": 9,
       "norm_label": "service.py"
     },
     {
@@ -7452,7 +7470,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/sheet/service.py",
       "source_location": "L6",
       "id": "sheet_service_sheetservice",
-      "community": 10,
+      "community": 9,
       "norm_label": "sheetservice"
     },
     {
@@ -7461,7 +7479,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/sheet/service.py",
       "source_location": "L7",
       "id": "sheet_service_sheetservice_select",
-      "community": 10,
+      "community": 9,
       "norm_label": ".select()"
     },
     {
@@ -7470,7 +7488,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/sheet/service.py",
       "source_location": "L10",
       "id": "sheet_service_sheetservice_remove",
-      "community": 10,
+      "community": 9,
       "norm_label": ".remove()"
     },
     {
@@ -7478,7 +7496,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/sheet/service.py",
       "source_location": "L1",
-      "community": 10,
+      "community": 9,
       "norm_label": "service de planilha \u2014 gerencia a planilha ativa no datasource.",
       "id": "sheet_service_rationale_1"
     },
@@ -7488,7 +7506,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/sheet/route.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_features_sheet_route_py",
-      "community": 10,
+      "community": 9,
       "norm_label": "route.py"
     },
     {
@@ -7497,7 +7515,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/sheet/route.py",
       "source_location": "L12",
       "id": "sheet_route_select_sheet",
-      "community": 10,
+      "community": 9,
       "norm_label": "select_sheet()"
     },
     {
@@ -7506,7 +7524,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/sheet/route.py",
       "source_location": "L18",
       "id": "sheet_route_remove_sheet",
-      "community": 10,
+      "community": 9,
       "norm_label": "remove_sheet()"
     },
     {
@@ -7515,16 +7533,16 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/sheet/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_features_sheet_init_py",
-      "community": 10,
+      "community": 9,
       "norm_label": "__init__.py"
     },
     {
       "label": "__init__.py",
       "file_type": "code",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/utils/__init__.py",
+      "source_file": "backend/utils/__init__.py",
       "source_location": "L1",
-      "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_utils_init_py",
-      "community": 18,
+      "id": "backend_utils_init_py",
+      "community": 13,
       "norm_label": "__init__.py"
     },
     {
@@ -7533,7 +7551,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/utils/numbers.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_utils_numbers_py",
-      "community": 18,
+      "community": 21,
       "norm_label": "numbers.py"
     },
     {
@@ -7542,7 +7560,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/utils/numbers.py",
       "source_location": "L4",
       "id": "utils_numbers_normalize_decimal",
-      "community": 18,
+      "community": 21,
       "norm_label": "normalize_decimal()"
     },
     {
@@ -7550,7 +7568,7 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/utils/numbers.py",
       "source_location": "L1",
-      "community": 18,
+      "community": 21,
       "norm_label": "utilitarios de formatacao numerica.",
       "id": "utils_numbers_rationale_1"
     },
@@ -7559,9 +7577,36 @@
       "file_type": "rationale",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/utils/numbers.py",
       "source_location": "L5",
-      "community": 18,
+      "community": 21,
       "norm_label": "converte numero no formato brasileiro para o formato ingles.      remove o separ",
       "id": "utils_numbers_rationale_5"
+    },
+    {
+      "label": "dates.py",
+      "file_type": "code",
+      "source_file": "backend/utils/dates.py",
+      "source_location": "L1",
+      "id": "backend_utils_dates_py",
+      "community": 13,
+      "norm_label": "dates.py"
+    },
+    {
+      "label": "DateFormat",
+      "file_type": "code",
+      "source_file": "backend/utils/dates.py",
+      "source_location": "L5",
+      "id": "utils_dates_dateformat",
+      "community": 13,
+      "norm_label": "dateformat"
+    },
+    {
+      "label": "to_datetime()",
+      "file_type": "code",
+      "source_file": "backend/utils/dates.py",
+      "source_location": "L10",
+      "id": "utils_dates_to_datetime",
+      "community": 0,
+      "norm_label": "to_datetime()"
     },
     {
       "label": "_errors.py",
@@ -7569,7 +7614,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/errors/_errors.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_errors_errors_py",
-      "community": 15,
+      "community": 6,
       "norm_label": "_errors.py"
     },
     {
@@ -7578,7 +7623,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/errors/_errors.py",
       "source_location": "L1",
       "id": "errors_errors_backenderror",
-      "community": 15,
+      "community": 6,
       "norm_label": "backenderror"
     },
     {
@@ -7587,7 +7632,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/errors/_errors.py",
       "source_location": "L7",
       "id": "errors_errors_backenderror_to_dict",
-      "community": 15,
+      "community": 6,
       "norm_label": ".to_dict()"
     },
     {
@@ -7596,7 +7641,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/errors/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_errors_init_py",
-      "community": 15,
+      "community": 6,
       "norm_label": "__init__.py"
     },
     {
@@ -7605,7 +7650,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/errors/_mapper.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_errors_mapper_py",
-      "community": 15,
+      "community": 6,
       "norm_label": "_mapper.py"
     },
     {
@@ -7614,7 +7659,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/errors/_mapper.py",
       "source_location": "L26",
       "id": "errors_mapper_translate",
-      "community": 15,
+      "community": 6,
       "norm_label": "translate()"
     },
     {
@@ -7623,7 +7668,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/errors/_mapper.py",
       "source_location": "L35",
       "id": "errors_mapper_generic_mapper",
-      "community": 15,
+      "community": 6,
       "norm_label": "generic_mapper()"
     },
     {
@@ -7632,7 +7677,7 @@
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/assets/__init__.py",
       "source_location": "L1",
       "id": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_assets_init_py",
-      "community": 54,
+      "community": 56,
       "norm_label": "__init__.py"
     },
     {
@@ -7641,15 +7686,78 @@
       "source_file": "assets/strings.py",
       "source_location": "L1",
       "id": "assets_strings_py",
-      "community": 55,
+      "community": 57,
       "norm_label": "strings.py"
+    },
+    {
+      "label": "Normaliza uma data para DD/MM/YYYY aceitando os formatos DD/MM/YY e DD/MM/YYYY.",
+      "file_type": "rationale",
+      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_utils.py",
+      "source_location": "L6",
+      "community": 58,
+      "norm_label": "normaliza uma data para dd/mm/yyyy aceitando os formatos dd/mm/yy e dd/mm/yyyy.",
+      "id": "data_source_utils_rationale_6"
+    },
+    {
+      "label": "Converte linhas da planilha em lista de dicts usando o cabe\u00e7alho como chaves (lo",
+      "file_type": "rationale",
+      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_utils.py",
+      "source_location": "L16",
+      "community": 59,
+      "norm_label": "converte linhas da planilha em lista de dicts usando o cabecalho como chaves (lo",
+      "id": "data_source_utils_rationale_16"
+    },
+    {
+      "label": "Agrupa n\u00fameros de linha consecutivos em ranges A1 notation e divide em batches d",
+      "file_type": "rationale",
+      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_utils.py",
+      "source_location": "L22",
+      "community": 60,
+      "norm_label": "agrupa numeros de linha consecutivos em ranges a1 notation e divide em batches d",
+      "id": "data_source_utils_rationale_22"
+    },
+    {
+      "label": "Retorna o conjunto de todas as datas (DD/MM/YYYY) entre start e end, inclusive.",
+      "file_type": "rationale",
+      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_utils.py",
+      "source_location": "L35",
+      "community": 61,
+      "norm_label": "retorna o conjunto de todas as datas (dd/mm/yyyy) entre start e end, inclusive.",
+      "id": "data_source_utils_rationale_35"
+    },
+    {
+      "label": "Serializa o resultado do OrdersService para dict JSON-ready.",
+      "file_type": "rationale",
+      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/summary/service.py",
+      "source_location": "L10",
+      "community": 62,
+      "norm_label": "serializa o resultado do ordersservice para dict json-ready.",
+      "id": "summary_service_rationale_10"
+    },
+    {
+      "label": "Busca e monta os pedidos de um per\u00edodo.",
+      "file_type": "rationale",
+      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/summary/service.py",
+      "source_location": "L21",
+      "community": 63,
+      "norm_label": "busca e monta os pedidos de um periodo.",
+      "id": "summary_service_rationale_21"
+    },
+    {
+      "label": "Retorna todos os pedidos do per\u00edodo informado.",
+      "file_type": "rationale",
+      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/summary/service.py",
+      "source_location": "L27",
+      "community": 64,
+      "norm_label": "retorna todos os pedidos do periodo informado.",
+      "id": "summary_service_rationale_27"
     },
     {
       "label": "Contrato que qualquer client precisa cumprir.",
       "file_type": "rationale",
       "source_file": "core/network/_client.py",
       "source_location": "L14",
-      "community": 3,
+      "community": 4,
       "norm_label": "contrato que qualquer client precisa cumprir.",
       "id": "network_client_rationale_14"
     },
@@ -7658,7 +7766,7 @@
       "file_type": "rationale",
       "source_file": "core/network/_client.py",
       "source_location": "L21",
-      "community": 3,
+      "community": 4,
       "norm_label": "roteia requests para o backend local (in-process).     nenhuma rede envolvida \u2014",
       "id": "network_client_rationale_21"
     }
@@ -7667,31 +7775,31 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/__init__.py",
+      "source_file": "__init__.py",
       "source_location": "L17",
       "weight": 1.0,
-      "_src": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_init_py",
+      "_src": "init_py",
       "_tgt": "maria_cacau_init_asset",
-      "source": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_init_py",
+      "source": "init_py",
       "target": "maria_cacau_init_asset",
       "confidence_score": 1.0
     },
     {
       "relation": "rationale_for",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/__init__.py",
+      "source_file": "__init__.py",
       "source_location": "L1",
       "weight": 1.0,
       "_src": "maria_cacau_init_rationale_1",
-      "_tgt": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_init_py",
-      "source": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_init_py",
+      "_tgt": "init_py",
+      "source": "init_py",
       "target": "maria_cacau_init_rationale_1",
       "confidence_score": 1.0
     },
     {
       "relation": "rationale_for",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/__init__.py",
+      "source_file": "__init__.py",
       "source_location": "L18",
       "weight": 1.0,
       "_src": "maria_cacau_init_rationale_18",
@@ -7699,6 +7807,18 @@
       "source": "maria_cacau_init_asset",
       "target": "maria_cacau_init_rationale_18",
       "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "__init__.py",
+      "source_location": "L19",
+      "weight": 1.0,
+      "_src": "maria_cacau_init_asset",
+      "_tgt": "str",
+      "source": "maria_cacau_init_asset",
+      "target": "str"
     },
     {
       "relation": "calls",
@@ -8046,6 +8166,54 @@
       "_tgt": "enum",
       "source": "enum",
       "target": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_data_source_sheet_mapper_py",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/data_source/_utils.py",
+      "source_location": "L3",
+      "weight": 1.0,
+      "_src": "backend_data_source_utils_py",
+      "_tgt": "enum",
+      "source": "enum",
+      "target": "backend_data_source_utils_py",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "inherits",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/data_source/_utils.py",
+      "source_location": "L6",
+      "weight": 1.0,
+      "_src": "data_source_utils_dateformat",
+      "_tgt": "enum",
+      "source": "enum",
+      "target": "data_source_utils_dateformat",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/utils/dates.py",
+      "source_location": "L2",
+      "weight": 1.0,
+      "_src": "backend_utils_dates_py",
+      "_tgt": "enum",
+      "source": "enum",
+      "target": "backend_utils_dates_py",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "inherits",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/utils/dates.py",
+      "source_location": "L5",
+      "weight": 1.0,
+      "_src": "utils_dates_dateformat",
+      "_tgt": "enum",
+      "source": "enum",
+      "target": "utils_dates_dateformat",
       "confidence_score": 1.0
     },
     {
@@ -9098,11 +9266,11 @@
       "source_file": "core/network/_client.py",
       "source_location": "L7",
       "weight": 0.8,
-      "_src": "network_client_rationale_13",
-      "_tgt": "network_response_httpresponse",
+      "_src": "network_response_httpresponse",
+      "_tgt": "network_client_rationale_13",
+      "confidence_score": 0.5,
       "source": "network_response_httpresponse",
-      "target": "network_client_rationale_13",
-      "confidence_score": 0.5
+      "target": "network_client_rationale_13"
     },
     {
       "relation": "uses",
@@ -9110,11 +9278,11 @@
       "source_file": "core/network/_client.py",
       "source_location": "L7",
       "weight": 0.8,
-      "_src": "network_client_rationale_20",
-      "_tgt": "network_response_httpresponse",
+      "_src": "network_response_httpresponse",
+      "_tgt": "network_client_rationale_20",
+      "confidence_score": 0.5,
       "source": "network_response_httpresponse",
-      "target": "network_client_rationale_20",
-      "confidence_score": 0.5
+      "target": "network_client_rationale_20"
     },
     {
       "relation": "calls",
@@ -9314,11 +9482,11 @@
       "source_file": "core/network/_client.py",
       "source_location": "L6",
       "weight": 0.8,
-      "_src": "network_client_rationale_13",
-      "_tgt": "network_request_httprequest",
+      "_src": "network_request_httprequest",
+      "_tgt": "network_client_rationale_13",
+      "confidence_score": 0.5,
       "source": "network_request_httprequest",
-      "target": "network_client_rationale_13",
-      "confidence_score": 0.5
+      "target": "network_client_rationale_13"
     },
     {
       "relation": "uses",
@@ -9326,11 +9494,11 @@
       "source_file": "core/network/_client.py",
       "source_location": "L6",
       "weight": 0.8,
-      "_src": "network_client_rationale_20",
-      "_tgt": "network_request_httprequest",
+      "_src": "network_request_httprequest",
+      "_tgt": "network_client_rationale_20",
+      "confidence_score": 0.5,
       "source": "network_request_httprequest",
-      "target": "network_client_rationale_20",
-      "confidence_score": 0.5
+      "target": "network_client_rationale_20"
     },
     {
       "relation": "calls",
@@ -12130,6 +12298,18 @@
     },
     {
       "relation": "calls",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/chart/chart_widget.py",
+      "source_location": "L147",
+      "weight": 1.0,
+      "_src": "chart_chart_widget_dschart_render_bar",
+      "_tgt": "str",
+      "source": "chart_chart_widget_dschart_render_bar",
+      "target": "str"
+    },
+    {
+      "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/design_system/components/chart/chart_widget.py",
       "source_location": "L159",
@@ -13309,6 +13489,18 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/data/mapper.py",
+      "source_location": "L20",
+      "weight": 1.0,
+      "_src": "data_mapper_from_response",
+      "_tgt": "str",
+      "source": "data_mapper_from_response",
+      "target": "str"
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/delivery/data/mapper.py",
       "source_location": "L28",
       "weight": 1.0,
       "_src": "data_mapper_from_response",
@@ -13907,13 +14099,13 @@
     {
       "relation": "rationale_for",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/domain/use_case.py",
+      "source_file": "features/home/sub_features/summary/domain/use_case.py",
       "source_location": "L1",
       "weight": 1.0,
       "_src": "domain_use_case_rationale_1",
-      "_tgt": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_sub_features_summary_domain_use_case_py",
+      "_tgt": "features_home_sub_features_summary_domain_use_case_py",
       "source": "domain_use_case_rationale_1",
-      "target": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_sub_features_summary_domain_use_case_py",
+      "target": "features_home_sub_features_summary_domain_use_case_py",
       "confidence_score": 1.0
     },
     {
@@ -13939,6 +14131,66 @@
       "source": "domain_use_case_rationale_1",
       "target": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_cpf_validation_domain_use_case_py",
       "confidence_score": 1.0
+    },
+    {
+      "relation": "uses",
+      "confidence": "INFERRED",
+      "source_file": "features/home/sub_features/summary/domain/use_case.py",
+      "source_location": "L5",
+      "weight": 0.8,
+      "_src": "domain_use_case_rationale_1",
+      "_tgt": "data_repository_summaryrepository",
+      "source": "domain_use_case_rationale_1",
+      "target": "data_repository_summaryrepository",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "uses",
+      "confidence": "INFERRED",
+      "source_file": "features/home/sub_features/summary/domain/use_case.py",
+      "source_location": "L6",
+      "weight": 0.8,
+      "_src": "domain_use_case_rationale_1",
+      "_tgt": "domain_models_daysummary",
+      "source": "domain_use_case_rationale_1",
+      "target": "domain_models_daysummary",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "uses",
+      "confidence": "INFERRED",
+      "source_file": "features/home/sub_features/summary/domain/use_case.py",
+      "source_location": "L6",
+      "weight": 0.8,
+      "_src": "domain_use_case_rationale_1",
+      "_tgt": "domain_models_orderdetail",
+      "source": "domain_use_case_rationale_1",
+      "target": "domain_models_orderdetail",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "uses",
+      "confidence": "INFERRED",
+      "source_file": "features/home/sub_features/summary/domain/use_case.py",
+      "source_location": "L6",
+      "weight": 0.8,
+      "_src": "domain_use_case_rationale_1",
+      "_tgt": "domain_models_productcount",
+      "source": "domain_use_case_rationale_1",
+      "target": "domain_models_productcount",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "uses",
+      "confidence": "INFERRED",
+      "source_file": "features/home/sub_features/summary/domain/use_case.py",
+      "source_location": "L6",
+      "weight": 0.8,
+      "_src": "domain_use_case_rationale_1",
+      "_tgt": "domain_models_productssummary",
+      "source": "domain_use_case_rationale_1",
+      "target": "domain_models_productssummary",
+      "confidence_score": 0.5
     },
     {
       "relation": "contains",
@@ -15285,18 +15537,6 @@
       "confidence_score": 1.0
     },
     {
-      "relation": "imports_from",
-      "confidence": "EXTRACTED",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/domain/use_case.py",
-      "source_location": "L5",
-      "weight": 1.0,
-      "_src": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_sub_features_summary_domain_use_case_py",
-      "_tgt": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_sub_features_summary_data_repository_py",
-      "source": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_sub_features_summary_data_repository_py",
-      "target": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_sub_features_summary_domain_use_case_py",
-      "confidence_score": 1.0
-    },
-    {
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/data/repository.py",
@@ -15307,6 +15547,18 @@
       "source": "data_repository_summaryrepository",
       "target": "data_repository_summaryrepository_get_by_period",
       "confidence_score": 1.0
+    },
+    {
+      "relation": "uses",
+      "confidence": "INFERRED",
+      "source_file": "features/home/sub_features/summary/domain/use_case.py",
+      "source_location": "L5",
+      "weight": 0.8,
+      "_src": "domain_use_case_summaryusecase",
+      "_tgt": "data_repository_summaryrepository",
+      "source": "data_repository_summaryrepository",
+      "target": "domain_use_case_summaryusecase",
+      "confidence_score": 0.5
     },
     {
       "relation": "calls",
@@ -15321,57 +15573,33 @@
       "target": "domain_use_case_summaryusecase_init"
     },
     {
-      "relation": "imports_from",
-      "confidence": "EXTRACTED",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/domain/use_case.py",
-      "source_location": "L6",
-      "weight": 1.0,
-      "_src": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_sub_features_summary_domain_use_case_py",
-      "_tgt": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_sub_features_summary_domain_models_py",
-      "source": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_sub_features_summary_domain_use_case_py",
-      "target": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_sub_features_summary_domain_models_py",
-      "confidence_score": 1.0
-    },
-    {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/domain/use_case.py",
+      "source_file": "features/home/sub_features/summary/domain/use_case.py",
       "source_location": "L9",
       "weight": 1.0,
-      "_src": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_sub_features_summary_domain_use_case_py",
+      "_src": "features_home_sub_features_summary_domain_use_case_py",
       "_tgt": "domain_use_case_summaryusecase",
-      "source": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_sub_features_summary_domain_use_case_py",
+      "source": "features_home_sub_features_summary_domain_use_case_py",
       "target": "domain_use_case_summaryusecase",
       "confidence_score": 1.0
     },
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/domain/use_case.py",
+      "source_file": "features/home/sub_features/summary/domain/use_case.py",
       "source_location": "L51",
       "weight": 1.0,
-      "_src": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_sub_features_summary_domain_use_case_py",
+      "_src": "features_home_sub_features_summary_domain_use_case_py",
       "_tgt": "domain_use_case_to_sorted_counts",
-      "source": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_sub_features_summary_domain_use_case_py",
+      "source": "features_home_sub_features_summary_domain_use_case_py",
       "target": "domain_use_case_to_sorted_counts",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "imports_from",
-      "confidence": "EXTRACTED",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/presentation/viewmodel.py",
-      "source_location": "L9",
-      "weight": 1.0,
-      "_src": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_sub_features_summary_presentation_viewmodel_py",
-      "_tgt": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_sub_features_summary_domain_use_case_py",
-      "source": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_sub_features_summary_domain_use_case_py",
-      "target": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_features_home_sub_features_summary_presentation_viewmodel_py",
       "confidence_score": 1.0
     },
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/domain/use_case.py",
+      "source_file": "features/home/sub_features/summary/domain/use_case.py",
       "source_location": "L10",
       "weight": 1.0,
       "_src": "domain_use_case_summaryusecase",
@@ -15383,7 +15611,7 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/domain/use_case.py",
+      "source_file": "features/home/sub_features/summary/domain/use_case.py",
       "source_location": "L13",
       "weight": 1.0,
       "_src": "domain_use_case_summaryusecase",
@@ -15395,7 +15623,7 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/domain/use_case.py",
+      "source_file": "features/home/sub_features/summary/domain/use_case.py",
       "source_location": "L17",
       "weight": 1.0,
       "_src": "domain_use_case_summaryusecase",
@@ -15403,6 +15631,54 @@
       "source": "domain_use_case_summaryusecase",
       "target": "domain_use_case_summaryusecase_build_summary",
       "confidence_score": 1.0
+    },
+    {
+      "relation": "uses",
+      "confidence": "INFERRED",
+      "source_file": "features/home/sub_features/summary/domain/use_case.py",
+      "source_location": "L6",
+      "weight": 0.8,
+      "_src": "domain_use_case_summaryusecase",
+      "_tgt": "domain_models_daysummary",
+      "source": "domain_use_case_summaryusecase",
+      "target": "domain_models_daysummary",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "uses",
+      "confidence": "INFERRED",
+      "source_file": "features/home/sub_features/summary/domain/use_case.py",
+      "source_location": "L6",
+      "weight": 0.8,
+      "_src": "domain_use_case_summaryusecase",
+      "_tgt": "domain_models_orderdetail",
+      "source": "domain_use_case_summaryusecase",
+      "target": "domain_models_orderdetail",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "uses",
+      "confidence": "INFERRED",
+      "source_file": "features/home/sub_features/summary/domain/use_case.py",
+      "source_location": "L6",
+      "weight": 0.8,
+      "_src": "domain_use_case_summaryusecase",
+      "_tgt": "domain_models_productcount",
+      "source": "domain_use_case_summaryusecase",
+      "target": "domain_models_productcount",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "uses",
+      "confidence": "INFERRED",
+      "source_file": "features/home/sub_features/summary/domain/use_case.py",
+      "source_location": "L6",
+      "weight": 0.8,
+      "_src": "domain_use_case_summaryusecase",
+      "_tgt": "domain_models_productssummary",
+      "source": "domain_use_case_summaryusecase",
+      "target": "domain_models_productssummary",
+      "confidence_score": 0.5
     },
     {
       "relation": "calls",
@@ -15419,7 +15695,7 @@
     {
       "relation": "calls",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/domain/use_case.py",
+      "source_file": "features/home/sub_features/summary/domain/use_case.py",
       "source_location": "L15",
       "weight": 1.0,
       "_src": "domain_use_case_summaryusecase_get_summary",
@@ -15455,7 +15731,7 @@
     {
       "relation": "calls",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/features/home/sub_features/summary/domain/use_case.py",
+      "source_file": "features/home/sub_features/summary/domain/use_case.py",
       "source_location": "L39",
       "weight": 1.0,
       "_src": "domain_use_case_summaryusecase_build_summary",
@@ -19953,18 +20229,6 @@
       "confidence_score": 1.0
     },
     {
-      "relation": "imports_from",
-      "confidence": "EXTRACTED",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_google_sheets.py",
-      "source_location": "L10",
-      "weight": 1.0,
-      "_src": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_data_source_google_sheets_py",
-      "_tgt": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_data_source_errors_handler_py",
-      "source": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_data_source_google_sheets_py",
-      "target": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_data_source_errors_handler_py",
-      "confidence_score": 1.0
-    },
-    {
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_google_sheets.py",
@@ -20949,18 +21213,6 @@
       "confidence_score": 1.0
     },
     {
-      "relation": "imports_from",
-      "confidence": "EXTRACTED",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_viewmodel.py",
-      "source_location": "L5",
-      "weight": 1.0,
-      "_src": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_data_source_viewmodel_py",
-      "_tgt": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_data_source_errors_handler_py",
-      "source": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_data_source_viewmodel_py",
-      "target": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_data_source_errors_handler_py",
-      "confidence_score": 1.0
-    },
-    {
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_viewmodel.py",
@@ -21131,73 +21383,253 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_utils.py",
-      "source_location": "L5",
+      "source_file": "backend/data_source/_utils.py",
+      "source_location": "L6",
       "weight": 1.0,
-      "_src": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_data_source_utils_py",
+      "_src": "backend_data_source_utils_py",
+      "_tgt": "data_source_utils_dateformat",
+      "source": "backend_data_source_utils_py",
+      "target": "data_source_utils_dateformat",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/data_source/_utils.py",
+      "source_location": "L11",
+      "weight": 1.0,
+      "_src": "backend_data_source_utils_py",
+      "_tgt": "data_source_utils_to_datetime",
+      "source": "backend_data_source_utils_py",
+      "target": "data_source_utils_to_datetime",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/data_source/_utils.py",
+      "source_location": "L20",
+      "weight": 1.0,
+      "_src": "backend_data_source_utils_py",
       "_tgt": "data_source_utils_normalize_date",
-      "source": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_data_source_utils_py",
+      "source": "backend_data_source_utils_py",
       "target": "data_source_utils_normalize_date",
       "confidence_score": 1.0
     },
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_utils.py",
-      "source_location": "L15",
+      "source_file": "backend/data_source/_utils.py",
+      "source_location": "L30",
       "weight": 1.0,
-      "_src": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_data_source_utils_py",
+      "_src": "backend_data_source_utils_py",
       "_tgt": "data_source_utils_to_dicts",
-      "source": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_data_source_utils_py",
+      "source": "backend_data_source_utils_py",
       "target": "data_source_utils_to_dicts",
       "confidence_score": 1.0
     },
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_utils.py",
-      "source_location": "L21",
+      "source_file": "backend/data_source/_utils.py",
+      "source_location": "L36",
       "weight": 1.0,
-      "_src": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_data_source_utils_py",
+      "_src": "backend_data_source_utils_py",
       "_tgt": "data_source_utils_to_ranges",
-      "source": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_data_source_utils_py",
+      "source": "backend_data_source_utils_py",
       "target": "data_source_utils_to_ranges",
       "confidence_score": 1.0
     },
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_utils.py",
-      "source_location": "L34",
+      "source_file": "backend/data_source/_utils.py",
+      "source_location": "L49",
       "weight": 1.0,
-      "_src": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_data_source_utils_py",
+      "_src": "backend_data_source_utils_py",
       "_tgt": "data_source_utils_date_range",
-      "source": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_data_source_utils_py",
+      "source": "backend_data_source_utils_py",
       "target": "data_source_utils_date_range",
       "confidence_score": 1.0
     },
     {
       "relation": "imports_from",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_handler.py",
-      "source_location": "L10",
+      "source_file": "backend/data_source/errors/_handler.py",
+      "source_location": "L9",
       "weight": 1.0,
-      "_src": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_data_source_errors_handler_py",
-      "_tgt": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_data_source_utils_py",
-      "source": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_data_source_utils_py",
-      "target": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_data_source_errors_handler_py",
+      "_src": "backend_data_source_errors_handler_py",
+      "_tgt": "backend_data_source_utils_py",
+      "source": "backend_data_source_utils_py",
+      "target": "backend_data_source_errors_handler_py",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "inherits",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/data_source/_utils.py",
+      "source_location": "L6",
+      "weight": 1.0,
+      "_src": "data_source_utils_dateformat",
+      "_tgt": "str",
+      "source": "data_source_utils_dateformat",
+      "target": "str",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "inherits",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/utils/dates.py",
+      "source_location": "L5",
+      "weight": 1.0,
+      "_src": "utils_dates_dateformat",
+      "_tgt": "str",
+      "source": "str",
+      "target": "utils_dates_dateformat",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/shared/mapper.py",
+      "source_location": "L19",
+      "weight": 1.0,
+      "_src": "shared_mapper_to_model",
+      "_tgt": "str",
+      "source": "str",
+      "target": "shared_mapper_to_model"
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/shared/mapper.py",
+      "source_location": "L34",
+      "weight": 1.0,
+      "_src": "shared_mapper_customer",
+      "_tgt": "str",
+      "source": "str",
+      "target": "shared_mapper_customer"
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/shared/mapper.py",
+      "source_location": "L43",
+      "weight": 1.0,
+      "_src": "shared_mapper_receiver",
+      "_tgt": "str",
+      "source": "str",
+      "target": "shared_mapper_receiver"
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/shared/mapper.py",
+      "source_location": "L55",
+      "weight": 1.0,
+      "_src": "shared_mapper_customization",
+      "_tgt": "str",
+      "source": "str",
+      "target": "shared_mapper_customization"
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/shared/mapper.py",
+      "source_location": "L65",
+      "weight": 1.0,
+      "_src": "shared_mapper_products",
+      "_tgt": "str",
+      "source": "str",
+      "target": "shared_mapper_products"
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/shared/mapper.py",
+      "source_location": "L83",
+      "weight": 1.0,
+      "_src": "shared_mapper_payments",
+      "_tgt": "str",
+      "source": "str",
+      "target": "shared_mapper_payments"
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/shared/mapper.py",
+      "source_location": "L107",
+      "weight": 1.0,
+      "_src": "shared_mapper_delivery",
+      "_tgt": "str",
+      "source": "str",
+      "target": "shared_mapper_delivery"
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/deliveries/service.py",
+      "source_location": "L32",
+      "weight": 1.0,
+      "_src": "deliveries_service_deliveriesservice_get_by_date",
+      "_tgt": "str",
+      "source": "str",
+      "target": "deliveries_service_deliveriesservice_get_by_date"
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/errors/_mapper.py",
+      "source_location": "L27",
+      "weight": 1.0,
+      "_src": "errors_mapper_translate",
+      "_tgt": "str",
+      "source": "str",
+      "target": "errors_mapper_translate"
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/errors/_mapper.py",
+      "source_location": "L36",
+      "weight": 1.0,
+      "_src": "errors_mapper_generic_mapper",
+      "_tgt": "str",
+      "source": "str",
+      "target": "errors_mapper_generic_mapper"
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/data_source/_utils.py",
+      "source_location": "L51",
+      "weight": 1.0,
+      "_src": "data_source_utils_date_range",
+      "_tgt": "data_source_utils_to_datetime",
+      "source": "data_source_utils_to_datetime",
+      "target": "data_source_utils_date_range",
       "confidence_score": 1.0
     },
     {
       "relation": "rationale_for",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_utils.py",
-      "source_location": "L6",
+      "source_file": "backend/data_source/_utils.py",
+      "source_location": "L21",
       "weight": 1.0,
-      "_src": "data_source_utils_rationale_6",
+      "_src": "data_source_utils_rationale_21",
       "_tgt": "data_source_utils_normalize_date",
       "source": "data_source_utils_normalize_date",
-      "target": "data_source_utils_rationale_6",
+      "target": "data_source_utils_rationale_21",
       "confidence_score": 1.0
     },
     {
@@ -21216,163 +21648,139 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "confidence_score": 0.8,
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_handler.py",
-      "source_location": "L19",
+      "source_file": "backend/data_source/errors/_handler.py",
+      "source_location": "L63",
       "weight": 1.0,
-      "_src": "data_source_utils_normalize_date",
-      "_tgt": "errors_handler_parse_date",
+      "_src": "errors_handler_sheetsguard_validate_date_range",
+      "_tgt": "data_source_utils_normalize_date",
       "source": "data_source_utils_normalize_date",
-      "target": "errors_handler_parse_date"
+      "target": "errors_handler_sheetsguard_validate_date_range"
     },
     {
       "relation": "rationale_for",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_utils.py",
-      "source_location": "L16",
+      "source_file": "backend/data_source/_utils.py",
+      "source_location": "L31",
       "weight": 1.0,
-      "_src": "data_source_utils_rationale_16",
+      "_src": "data_source_utils_rationale_31",
       "_tgt": "data_source_utils_to_dicts",
       "source": "data_source_utils_to_dicts",
-      "target": "data_source_utils_rationale_16",
+      "target": "data_source_utils_rationale_31",
       "confidence_score": 1.0
     },
     {
       "relation": "rationale_for",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_utils.py",
-      "source_location": "L22",
+      "source_file": "backend/data_source/_utils.py",
+      "source_location": "L37",
       "weight": 1.0,
-      "_src": "data_source_utils_rationale_22",
+      "_src": "data_source_utils_rationale_37",
       "_tgt": "data_source_utils_to_ranges",
       "source": "data_source_utils_to_ranges",
-      "target": "data_source_utils_rationale_22",
+      "target": "data_source_utils_rationale_37",
       "confidence_score": 1.0
     },
     {
       "relation": "rationale_for",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/_utils.py",
-      "source_location": "L35",
+      "source_file": "backend/data_source/_utils.py",
+      "source_location": "L50",
       "weight": 1.0,
-      "_src": "data_source_utils_rationale_35",
+      "_src": "data_source_utils_rationale_50",
       "_tgt": "data_source_utils_date_range",
       "source": "data_source_utils_date_range",
-      "target": "data_source_utils_rationale_35",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "imports_from",
-      "confidence": "EXTRACTED",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_handler.py",
-      "source_location": "L11",
-      "weight": 1.0,
-      "_src": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_data_source_errors_handler_py",
-      "_tgt": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_data_source_errors_errors_py",
-      "source": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_data_source_errors_handler_py",
-      "target": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_data_source_errors_errors_py",
+      "target": "data_source_utils_rationale_50",
       "confidence_score": 1.0
     },
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_handler.py",
-      "source_location": "L14",
+      "source_file": "backend/data_source/errors/_handler.py",
+      "source_location": "L13",
       "weight": 1.0,
-      "_src": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_data_source_errors_handler_py",
+      "_src": "backend_data_source_errors_handler_py",
       "_tgt": "errors_handler_is_valid_date",
-      "source": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_data_source_errors_handler_py",
+      "source": "backend_data_source_errors_handler_py",
       "target": "errors_handler_is_valid_date",
       "confidence_score": 1.0
     },
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_handler.py",
-      "source_location": "L18",
+      "source_file": "backend/data_source/errors/_handler.py",
+      "source_location": "L17",
       "weight": 1.0,
-      "_src": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_data_source_errors_handler_py",
-      "_tgt": "errors_handler_parse_date",
-      "source": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_data_source_errors_handler_py",
-      "target": "errors_handler_parse_date",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_handler.py",
-      "source_location": "L22",
-      "weight": 1.0,
-      "_src": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_data_source_errors_handler_py",
+      "_src": "backend_data_source_errors_handler_py",
       "_tgt": "errors_handler_sheetsguard",
-      "source": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_data_source_errors_handler_py",
+      "source": "backend_data_source_errors_handler_py",
       "target": "errors_handler_sheetsguard",
       "confidence_score": 1.0
     },
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_handler.py",
-      "source_location": "L27",
+      "source_file": "backend/data_source/errors/_handler.py",
+      "source_location": "L22",
       "weight": 1.0,
-      "_src": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_data_source_errors_handler_py",
+      "_src": "backend_data_source_errors_handler_py",
       "_tgt": "errors_handler_credentials_file",
-      "source": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_data_source_errors_handler_py",
+      "source": "backend_data_source_errors_handler_py",
       "target": "errors_handler_credentials_file",
       "confidence_score": 1.0
     },
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_handler.py",
-      "source_location": "L34",
+      "source_file": "backend/data_source/errors/_handler.py",
+      "source_location": "L29",
       "weight": 1.0,
-      "_src": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_data_source_errors_handler_py",
+      "_src": "backend_data_source_errors_handler_py",
       "_tgt": "errors_handler_local_storage",
-      "source": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_data_source_errors_handler_py",
+      "source": "backend_data_source_errors_handler_py",
       "target": "errors_handler_local_storage",
       "confidence_score": 1.0
     },
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_handler.py",
-      "source_location": "L41",
+      "source_file": "backend/data_source/errors/_handler.py",
+      "source_location": "L36",
       "weight": 1.0,
-      "_src": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_data_source_errors_handler_py",
+      "_src": "backend_data_source_errors_handler_py",
       "_tgt": "errors_handler_authentication",
-      "source": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_data_source_errors_handler_py",
+      "source": "backend_data_source_errors_handler_py",
       "target": "errors_handler_authentication",
       "confidence_score": 1.0
     },
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_handler.py",
-      "source_location": "L77",
+      "source_file": "backend/data_source/errors/_handler.py",
+      "source_location": "L72",
       "weight": 1.0,
-      "_src": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_data_source_errors_handler_py",
+      "_src": "backend_data_source_errors_handler_py",
       "_tgt": "errors_handler_handle_api",
-      "source": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_data_source_errors_handler_py",
+      "source": "backend_data_source_errors_handler_py",
       "target": "errors_handler_handle_api",
       "confidence_score": 1.0
     },
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_handler.py",
-      "source_location": "L95",
+      "source_file": "backend/data_source/errors/_handler.py",
+      "source_location": "L90",
       "weight": 1.0,
-      "_src": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_data_source_errors_handler_py",
+      "_src": "backend_data_source_errors_handler_py",
       "_tgt": "errors_handler_handle_sheet_setup",
-      "source": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_data_source_errors_handler_py",
+      "source": "backend_data_source_errors_handler_py",
       "target": "errors_handler_handle_sheet_setup",
       "confidence_score": 1.0
     },
     {
       "relation": "calls",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_handler.py",
-      "source_location": "L64",
+      "source_file": "backend/data_source/errors/_handler.py",
+      "source_location": "L59",
       "weight": 1.0,
       "_src": "errors_handler_sheetsguard_validate_date",
       "_tgt": "errors_handler_is_valid_date",
@@ -21381,22 +21789,10 @@
       "confidence_score": 1.0
     },
     {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_handler.py",
-      "source_location": "L68",
-      "weight": 1.0,
-      "_src": "errors_handler_sheetsguard_validate_date_range",
-      "_tgt": "errors_handler_parse_date",
-      "source": "errors_handler_parse_date",
-      "target": "errors_handler_sheetsguard_validate_date_range",
-      "confidence_score": 1.0
-    },
-    {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_handler.py",
-      "source_location": "L55",
+      "source_file": "backend/data_source/errors/_handler.py",
+      "source_location": "L50",
       "weight": 1.0,
       "_src": "errors_handler_sheetsguard",
       "_tgt": "errors_handler_sheetsguard_validate_credentials",
@@ -21407,8 +21803,8 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_handler.py",
-      "source_location": "L59",
+      "source_file": "backend/data_source/errors/_handler.py",
+      "source_location": "L54",
       "weight": 1.0,
       "_src": "errors_handler_sheetsguard",
       "_tgt": "errors_handler_sheetsguard_validate_sheet_id",
@@ -21419,8 +21815,8 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_handler.py",
-      "source_location": "L63",
+      "source_file": "backend/data_source/errors/_handler.py",
+      "source_location": "L58",
       "weight": 1.0,
       "_src": "errors_handler_sheetsguard",
       "_tgt": "errors_handler_sheetsguard_validate_date",
@@ -21431,8 +21827,8 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/data_source/errors/_handler.py",
-      "source_location": "L67",
+      "source_file": "backend/data_source/errors/_handler.py",
+      "source_location": "L62",
       "weight": 1.0,
       "_src": "errors_handler_sheetsguard",
       "_tgt": "errors_handler_sheetsguard_validate_date_range",
@@ -21547,6 +21943,18 @@
       "_tgt": "errors_errors_invaliddateformaterror",
       "source": "errors_handler_sheetsguard_validate_date",
       "target": "errors_errors_invaliddateformaterror"
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/data_source/errors/_handler.py",
+      "source_location": "L63",
+      "weight": 1.0,
+      "_src": "errors_handler_sheetsguard_validate_date_range",
+      "_tgt": "utils_dates_to_datetime",
+      "source": "errors_handler_sheetsguard_validate_date_range",
+      "target": "utils_dates_to_datetime"
     },
     {
       "relation": "calls",
@@ -23445,94 +23853,82 @@
       "confidence_score": 1.0
     },
     {
-      "relation": "imports_from",
-      "confidence": "EXTRACTED",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/summary/service.py",
-      "source_location": "L6",
-      "weight": 1.0,
-      "_src": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_features_orders_subfeatures_summary_service_py",
-      "_tgt": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_features_orders_subfeatures_summary_repository_py",
-      "source": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_features_orders_subfeatures_summary_service_py",
-      "target": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_features_orders_subfeatures_summary_repository_py",
-      "confidence_score": 1.0
-    },
-    {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/summary/service.py",
-      "source_location": "L9",
+      "source_file": "backend/features/orders/subfeatures/summary/service.py",
+      "source_location": "L10",
       "weight": 1.0,
-      "_src": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_features_orders_subfeatures_summary_service_py",
+      "_src": "backend_features_orders_subfeatures_summary_service_py",
       "_tgt": "summary_service_ordersmapper",
-      "source": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_features_orders_subfeatures_summary_service_py",
+      "source": "backend_features_orders_subfeatures_summary_service_py",
       "target": "summary_service_ordersmapper",
       "confidence_score": 1.0
     },
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/summary/service.py",
-      "source_location": "L13",
+      "source_file": "backend/features/orders/subfeatures/summary/service.py",
+      "source_location": "L14",
       "weight": 1.0,
-      "_src": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_features_orders_subfeatures_summary_service_py",
+      "_src": "backend_features_orders_subfeatures_summary_service_py",
       "_tgt": "summary_service_to_response",
-      "source": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_features_orders_subfeatures_summary_service_py",
+      "source": "backend_features_orders_subfeatures_summary_service_py",
       "target": "summary_service_to_response",
       "confidence_score": 1.0
     },
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/summary/service.py",
-      "source_location": "L20",
+      "source_file": "backend/features/orders/subfeatures/summary/service.py",
+      "source_location": "L21",
       "weight": 1.0,
-      "_src": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_features_orders_subfeatures_summary_service_py",
+      "_src": "backend_features_orders_subfeatures_summary_service_py",
       "_tgt": "summary_service_ordersservice",
-      "source": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_features_orders_subfeatures_summary_service_py",
+      "source": "backend_features_orders_subfeatures_summary_service_py",
       "target": "summary_service_ordersservice",
       "confidence_score": 1.0
     },
     {
       "relation": "rationale_for",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/summary/service.py",
+      "source_file": "backend/features/orders/subfeatures/summary/service.py",
       "source_location": "L1",
       "weight": 1.0,
       "_src": "summary_service_rationale_1",
-      "_tgt": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_features_orders_subfeatures_summary_service_py",
-      "source": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_features_orders_subfeatures_summary_service_py",
+      "_tgt": "backend_features_orders_subfeatures_summary_service_py",
+      "source": "backend_features_orders_subfeatures_summary_service_py",
       "target": "summary_service_rationale_1",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "imports_from",
-      "confidence": "EXTRACTED",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/summary/route.py",
-      "source_location": "L5",
-      "weight": 1.0,
-      "_src": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_features_orders_subfeatures_summary_route_py",
-      "_tgt": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_features_orders_subfeatures_summary_service_py",
-      "source": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_features_orders_subfeatures_summary_service_py",
-      "target": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_features_orders_subfeatures_summary_route_py",
       "confidence_score": 1.0
     },
     {
       "relation": "rationale_for",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/summary/service.py",
-      "source_location": "L10",
+      "source_file": "backend/features/orders/subfeatures/summary/service.py",
+      "source_location": "L11",
       "weight": 1.0,
-      "_src": "summary_service_rationale_10",
+      "_src": "summary_service_rationale_11",
       "_tgt": "summary_service_ordersmapper",
       "source": "summary_service_ordersmapper",
-      "target": "summary_service_rationale_10",
+      "target": "summary_service_rationale_11",
       "confidence_score": 1.0
+    },
+    {
+      "relation": "uses",
+      "confidence": "INFERRED",
+      "source_file": "backend/features/orders/subfeatures/summary/service.py",
+      "source_location": "L7",
+      "weight": 0.8,
+      "_src": "summary_service_ordersmapper",
+      "_tgt": "summary_repository_orderssummaryrepository",
+      "source": "summary_service_ordersmapper",
+      "target": "summary_repository_orderssummaryrepository",
+      "confidence_score": 0.5
     },
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/summary/service.py",
-      "source_location": "L23",
+      "source_file": "backend/features/orders/subfeatures/summary/service.py",
+      "source_location": "L24",
       "weight": 1.0,
       "_src": "summary_service_ordersservice",
       "_tgt": "summary_service_ordersservice_init",
@@ -23543,8 +23939,8 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/summary/service.py",
-      "source_location": "L26",
+      "source_file": "backend/features/orders/subfeatures/summary/service.py",
+      "source_location": "L27",
       "weight": 1.0,
       "_src": "summary_service_ordersservice",
       "_tgt": "summary_service_ordersservice_get_by_period",
@@ -23555,14 +23951,26 @@
     {
       "relation": "rationale_for",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/summary/service.py",
-      "source_location": "L21",
+      "source_file": "backend/features/orders/subfeatures/summary/service.py",
+      "source_location": "L22",
       "weight": 1.0,
-      "_src": "summary_service_rationale_21",
+      "_src": "summary_service_rationale_22",
       "_tgt": "summary_service_ordersservice",
       "source": "summary_service_ordersservice",
-      "target": "summary_service_rationale_21",
+      "target": "summary_service_rationale_22",
       "confidence_score": 1.0
+    },
+    {
+      "relation": "uses",
+      "confidence": "INFERRED",
+      "source_file": "backend/features/orders/subfeatures/summary/service.py",
+      "source_location": "L7",
+      "weight": 0.8,
+      "_src": "summary_service_ordersservice",
+      "_tgt": "summary_repository_orderssummaryrepository",
+      "source": "summary_service_ordersservice",
+      "target": "summary_repository_orderssummaryrepository",
+      "confidence_score": 0.5
     },
     {
       "relation": "calls",
@@ -23579,14 +23987,74 @@
     {
       "relation": "rationale_for",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/features/orders/subfeatures/summary/service.py",
-      "source_location": "L27",
+      "source_file": "backend/features/orders/subfeatures/summary/service.py",
+      "source_location": "L28",
       "weight": 1.0,
-      "_src": "summary_service_rationale_27",
+      "_src": "summary_service_rationale_28",
       "_tgt": "summary_service_ordersservice_get_by_period",
       "source": "summary_service_ordersservice_get_by_period",
-      "target": "summary_service_rationale_27",
+      "target": "summary_service_rationale_28",
       "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/features/orders/subfeatures/summary/service.py",
+      "source_location": "L33",
+      "weight": 1.0,
+      "_src": "summary_service_ordersservice_get_by_period",
+      "_tgt": "utils_dates_to_datetime",
+      "source": "summary_service_ordersservice_get_by_period",
+      "target": "utils_dates_to_datetime"
+    },
+    {
+      "relation": "uses",
+      "confidence": "INFERRED",
+      "source_file": "backend/features/orders/subfeatures/summary/service.py",
+      "source_location": "L7",
+      "weight": 0.8,
+      "_src": "summary_service_rationale_1",
+      "_tgt": "summary_repository_orderssummaryrepository",
+      "source": "summary_service_rationale_1",
+      "target": "summary_repository_orderssummaryrepository",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "uses",
+      "confidence": "INFERRED",
+      "source_file": "backend/features/orders/subfeatures/summary/service.py",
+      "source_location": "L7",
+      "weight": 0.8,
+      "_src": "summary_service_rationale_11",
+      "_tgt": "summary_repository_orderssummaryrepository",
+      "source": "summary_service_rationale_11",
+      "target": "summary_repository_orderssummaryrepository",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "uses",
+      "confidence": "INFERRED",
+      "source_file": "backend/features/orders/subfeatures/summary/service.py",
+      "source_location": "L7",
+      "weight": 0.8,
+      "_src": "summary_service_rationale_22",
+      "_tgt": "summary_repository_orderssummaryrepository",
+      "source": "summary_service_rationale_22",
+      "target": "summary_repository_orderssummaryrepository",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "uses",
+      "confidence": "INFERRED",
+      "source_file": "backend/features/orders/subfeatures/summary/service.py",
+      "source_location": "L7",
+      "weight": 0.8,
+      "_src": "summary_service_rationale_28",
+      "_tgt": "summary_repository_orderssummaryrepository",
+      "source": "summary_service_rationale_28",
+      "target": "summary_repository_orderssummaryrepository",
+      "confidence_score": 0.5
     },
     {
       "relation": "contains",
@@ -24191,13 +24659,13 @@
     {
       "relation": "imports_from",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/kings/Documents/GitHub/Maria-Cacau-Contagem/maria_cacau/backend/utils/__init__.py",
+      "source_file": "backend/utils/__init__.py",
       "source_location": "L1",
       "weight": 1.0,
-      "_src": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_utils_init_py",
-      "_tgt": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_utils_numbers_py",
-      "source": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_utils_init_py",
-      "target": "users_kings_documents_github_maria_cacau_contagem_maria_cacau_backend_utils_numbers_py",
+      "_src": "backend_utils_init_py",
+      "_tgt": "backend_utils_dates_py",
+      "source": "backend_utils_init_py",
+      "target": "backend_utils_dates_py",
       "confidence_score": 1.0
     },
     {
@@ -24234,6 +24702,30 @@
       "_tgt": "utils_numbers_normalize_decimal",
       "source": "utils_numbers_normalize_decimal",
       "target": "utils_numbers_rationale_5",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/utils/dates.py",
+      "source_location": "L5",
+      "weight": 1.0,
+      "_src": "backend_utils_dates_py",
+      "_tgt": "utils_dates_dateformat",
+      "source": "backend_utils_dates_py",
+      "target": "utils_dates_dateformat",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/utils/dates.py",
+      "source_location": "L10",
+      "weight": 1.0,
+      "_src": "backend_utils_dates_py",
+      "_tgt": "utils_dates_to_datetime",
+      "source": "backend_utils_dates_py",
+      "target": "utils_dates_to_datetime",
       "confidence_score": 1.0
     },
     {

--- a/maria_cacau/backend/data_source/_utils.py
+++ b/maria_cacau/backend/data_source/_utils.py
@@ -1,12 +1,27 @@
 import re
 from datetime import datetime, timedelta
+from enum import Enum
+
+
+class DateFormat(str, Enum):
+    BR_SHORT = "%d/%m/%y"
+    BR_FULL  = "%d/%m/%Y"
+
+
+def to_datetime(value: str) -> datetime:
+    for fmt in (DateFormat.BR_FULL, DateFormat.BR_SHORT):
+        try:
+            return datetime.strptime(value, fmt)
+        except ValueError:
+            continue
+    raise ValueError(f"time data '{value}' does not match any known date format")
 
 
 def normalize_date(val: str) -> str | None:
     """Normaliza uma data para DD/MM/YYYY aceitando os formatos DD/MM/YY e DD/MM/YYYY. Retorna None se inválida."""
-    for fmt in ("%d/%m/%y", "%d/%m/%Y"):
+    for fmt in (DateFormat.BR_SHORT, DateFormat.BR_FULL):
         try:
-            return datetime.strptime(val.strip(), fmt).strftime("%d/%m/%Y")
+            return datetime.strptime(val.strip(), fmt).strftime(DateFormat.BR_FULL)
         except ValueError:
             continue
     return None
@@ -33,10 +48,10 @@ def to_ranges(row_numbers: list[int]) -> list[list[str]]:
 
 def date_range(start: str, end: str) -> set[str]:
     """Retorna o conjunto de todas as datas (DD/MM/YYYY) entre start e end, inclusive."""
-    d_start = datetime.strptime(start, "%d/%m/%Y")
-    d_end   = datetime.strptime(end,   "%d/%m/%Y")
+    d_start = to_datetime(start)
+    d_end   = to_datetime(end)
     dates, current = set(), d_start
     while current <= d_end:
-        dates.add(current.strftime("%d/%m/%Y"))
+        dates.add(current.strftime(DateFormat.BR_FULL))
         current += timedelta(days=1)
     return dates

--- a/maria_cacau/backend/data_source/errors/_handler.py
+++ b/maria_cacau/backend/data_source/errors/_handler.py
@@ -1,22 +1,17 @@
 import functools
 import json
 from contextlib import contextmanager
-from datetime import datetime
 
 import google.auth.exceptions
 import gspread
 import requests
 
-from .._utils import normalize_date
+from .._utils import normalize_date, to_datetime
 from ._errors import *
 
 
 def _is_valid_date(value: str) -> bool:
     return normalize_date(value) is not None
-
-
-def _parse_date(value: str) -> datetime:
-    return datetime.strptime(normalize_date(value), "%d/%m/%Y")
 
 
 class _SheetsGuard:
@@ -65,7 +60,7 @@ class _SheetsGuard:
             raise InvalidDateFormatError(value=value)
 
     def validate_date_range(self, start: str, end: str) -> None:
-        if _parse_date(end) < _parse_date(start):
+        if to_datetime(normalize_date(end)) < to_datetime(normalize_date(start)):
             raise InvalidDateRangeError(start=start, end=end)
 
 

--- a/maria_cacau/backend/features/orders/subfeatures/summary/service.py
+++ b/maria_cacau/backend/features/orders/subfeatures/summary/service.py
@@ -2,6 +2,7 @@
 
 import dataclasses
 
+from .....utils import to_datetime
 from ...shared import Order, OrderMapper
 from .repository import OrdersSummaryRepository
 
@@ -28,4 +29,6 @@ class OrdersService:
         df = self._repo.get_by_period(start, end)
         if df.empty:
             return []
-        return [OrderMapper.to_model(row) for _, row in df.iterrows()]
+        orders = [OrderMapper.to_model(row) for _, row in df.iterrows()]
+        orders.sort(key=lambda o: to_datetime(o.delivery.date))
+        return orders

--- a/maria_cacau/backend/utils/__init__.py
+++ b/maria_cacau/backend/utils/__init__.py
@@ -1,3 +1,4 @@
+from .dates import DateFormat, to_datetime
 from .numbers import normalize_decimal
 
-__all__ = ["normalize_decimal"]
+__all__ = ["DateFormat", "normalize_decimal", "to_datetime"]

--- a/maria_cacau/backend/utils/dates.py
+++ b/maria_cacau/backend/utils/dates.py
@@ -1,0 +1,16 @@
+from datetime import datetime
+from enum import Enum
+
+
+class DateFormat(str, Enum):
+    BR_SHORT = "%d/%m/%y"
+    BR_FULL  = "%d/%m/%Y"
+
+
+def to_datetime(value: str) -> datetime:
+    for fmt in (DateFormat.BR_FULL, DateFormat.BR_SHORT):
+        try:
+            return datetime.strptime(value, fmt)
+        except ValueError:
+            continue
+    raise ValueError(f"time data '{value}' does not match any known date format")

--- a/maria_cacau/features/home/sub_features/summary/domain/use_case.py
+++ b/maria_cacau/features/home/sub_features/summary/domain/use_case.py
@@ -24,7 +24,7 @@ class SummaryUseCase:
         global_totals: dict[str, int] = defaultdict(int)
         days: list[DaySummary] = []
 
-        for date in sorted(by_day):
+        for date in by_day:
             day_orders = by_day[date]
             day_totals: dict[str, int] = defaultdict(int)
 


### PR DESCRIPTION
## Overview

Dois problemas foram identificados e resolvidos no fluxo de resumo de pedidos. 
- Duplicação da lógica de parsing de datas espalhada em vários pontos do backend — cada módulo manipulava formato de data de forma independente, o que tornava a manutenção frágil. 
- https://github.com/Maria-Cacau/.github/issues/1: Bug visual onde a ordenação dos pedidos por data de entrega estava sendo feita no front, mas de forma incorreta, fazendo os pedidos aparecerem fora de ordem.

A lógica de datas foi centralizada em um único utilitário compartilhado por todo o backend, e a ordenação passou a ser responsabilidade exclusiva da camada de serviço — garantindo que os pedidos cheguem sempre ordenados independentemente de como a view os consome.

## Ajustes feitos
- Criado utilitário centralizado de datas com suporte aos dois formatos brasileiros (curto e completo), eliminando lógica duplicada entre módulos
- Ordenação dos pedidos por data de entrega movida para o serviço de backend, removendo a dependência da view para manter a ordem correta
- Parsing de datas no guard de validação de intervalo atualizado para usar o utilitário compartilhado
- Remoção de função privada de parsing que duplicava comportamento já existente
